### PR TITLE
Fix .Q.fu issue when used within scaleSampling

### DIFF
--- a/code/common/memusage.q
+++ b/code/common/memusage.q
@@ -53,7 +53,7 @@ objsize:{
 	  0h in t:sampling[type each;x];calcsize[count x;8;0]+"j"$scaleSampling[{[f;x]sum f each x}[.z.s];x];
 	// complex = if only 1 type and simple list, pointers + sum count each*first type
 	// assume count>1000 has no attrbutes (i.e. table unlikely to have 1000 columns, list of strings unlikely to have attr for some objects only
-	  (d[0] within 1 76h)&1=count d:distinct t;calcsize[count x;8;0]+"j"$scaleSampling[{sum .Q.fu[{calcsize[x;typesize x 0;$[1000<count x;0;attrsize each x]]}]count each x};x];
+	  (d[0] within 1 76h)&1=count d:distinct t;calcsize[count x;8;0]+"j"$scaleSampling[{sum calcsize[count each x;typesize x 0;$[1000<count x;0;attrsize each x]]};x];
 	// other complex, pointers + size of each objects
 	  calcsize[count x;8;0]+"j"$scaleSampling[{[f;x]sum f each x}[.z.s];x]]
 	};


### PR DESCRIPTION
.Q.fu is coded wrongly to take `count each x` into the function `{calcsize[x;typesize x 0;$[1000<count x;0;attrsize each x]]}`, causing the typesize to be long type and return incorrect result.
.Q.fu is removed since scaleSampling already does the optimization. Doesn't make sense to have it in there.