### PR TITLE
Improved debugging features 

### DIFF
--- a/torq.q
+++ b/torq.q
@@ -411,7 +411,11 @@ if[not any `debug`noredirect in key params; rolllogauto[]];
 // this should then be enough to bootstrap
 loadf:{
 	.lg.o[`fileload;"loading ",x];
-	@[{system"l ",x; .lg.o[`fileload;"successfully loaded ",x]};x;{.lg.e[`fileload;"failed to load ",x," : ",y]}[x]]}
+	
+	debug:`debug in key .proc.params;
+	if[debug;system"l ",x];
+	if[not debug;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
+	.lg.o[`fileload;"successfully loaded ",x]}
 
 loaddir:{
 	.lg.o[`fileload;"loading q and k files from directory ",x];

--- a/torq.q
+++ b/torq.q
@@ -413,8 +413,7 @@ loadf:{
 	.lg.o[`fileload;"loading ",x];
 	
 	debug:`debug in key .proc.params;
-	if[debug;system"l ",x];
-	if[not debug;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
+	$[debug;system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
 	.lg.o[`fileload;"successfully loaded ",x]}
 
 loaddir:{

--- a/torq.q
+++ b/torq.q
@@ -412,8 +412,7 @@ if[not any `debug`noredirect in key params; rolllogauto[]];
 loadf:{
 	.lg.o[`fileload;"loading ",x];
 	
-	debug:`debug in key .proc.params;
-	$[debug;system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
+	$[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
 	.lg.o[`fileload;"successfully loaded ",x]}
 
 loaddir:{


### PR DESCRIPTION
Improved debugging features in the loadf function so that errors inside files are no longer masked. If an error occurs when files are loaded in, it will flag at that point in the file and enter debug mode.

I'm happy in my eyes that this change won't have any other implications and there are no other error traps that will cause issue.