### PR TITLE
Porting Torq to kdb 3.6

### DIFF
--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -173,7 +173,7 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
                 $[not 0=algo;statstab ,: (filetoCompress;algo;(-21!filetoCompress)`compressedLength;sizeuncomp);statstab ,: (filetoCompress;algo;comprL;sizeuncomp)]];
             [$[(not count (-21!compressedFile));
 		[.lg.o[`compression; "Failed to compress file ",(string filetoCompress)];hdel compressedFile];
-		.lg.o[`compression; $[algo=0;"Decompressed ";"Compressed "], "file ", (string compressedFile), " doesn't match original. Deleting new file"]; hdel compressedFile;]]]
+		.lg.o[`compression;$[algo=0;"Decompressed ";"Compressed "],"file ",string[compressedFile]," doesn't match original. Deleting new file"];hdel compressedFile;]]]
         ];
         / if already compressed/decompressed, then log that and skip.
         [((not 0 = count -21!filetoCompress) & not 0 = algo)|((0 = count -21!filetoCompress) & 0 = algo)];

--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -170,9 +170,9 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
                 / move the hash files too.
                 if[78 <= type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#"];
                 /-log to the table if the algo wasn't 0
-                $[not 0=algo;statstab ,: (filetoCompress;algo;(-21!filetoCompress)`compressedLength;sizeuncomp);statstab ,: (filetoCompress;algo;comprL;sizeuncomp)]];
+                statstab,:$[not 0=algo;(filetoCompress;algo;(-21!filetoCompress)`compressedLength;sizeuncomp);(filetoCompress;algo;comprL;sizeuncomp)]];
             [$[(not count (-21!compressedFile));
-		[.lg.o[`compression; "Failed to compress file ",(string filetoCompress)];hdel compressedFile];
+		[.lg.o[`compression; "Failed to compress file ",string[filetoCompress]];hdel compressedFile];
 		.lg.o[`compression;$[algo=0;"Decompressed ";"Compressed "],"file ",string[compressedFile]," doesn't match original. Deleting new file"];hdel compressedFile;]]]
         ];
         / if already compressed/decompressed, then log that and skip.

--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -173,8 +173,8 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
                 $[not 0=algo;statstab ,: (filetoCompress;algo;(-21!filetoCompress)`compressedLength;sizeuncomp);statstab ,: (filetoCompress;algo;comprL;sizeuncomp)]];
             [$[(not count (-21!compressedFile));
 		[.lg.o[`compression; "Failed to compress file ",(string filetoCompress)];hdel compressedFile];
-		.lg.o[`compression; $[algo=0;"Decompressed ";"Compressed "], "file ", (string compressedFile), " doesn't match original. Deleting new file"]; hdel compressedFile]]]
+		.lg.o[`compression; $[algo=0;"Decompressed ";"Compressed "], "file ", (string compressedFile), " doesn't match original. Deleting new file"]; hdel compressedFile;]]]
         ];
         / if already compressed/decompressed, then log that and skip.
         [((not 0 = count -21!filetoCompress) & not 0 = algo)|((0 = count -21!filetoCompress) & 0 = algo)];
-        .lg.o[`compression; "file ", (string filetoCompress), " is already ",$[0=algo; "decompressed";"compressed"],". Skipping this file"]]}
+        .lg.o[`compression; "file ", (string filetoCompress), " is already ",$[0=algo; "decompressed";"compressed"],". Skipping this file"];]}

--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -158,14 +158,15 @@ summarystats:{
 compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
     compressedFile: hsym `$(string filetoCompress),"_kdbtempzip";
     / compress or decompress as appropriate:
+    cmp:$[algo=0;"de";""];
     $[((0 = count -21!filetoCompress) & not 0 = algo)|((not 0 = count -21!filetoCompress) & 0 = algo);
-        [.lg.o[`compression;$[algo=0;"Decompressing ";"Compressing "],"file ", (string filetoCompress), " with algo: ", (string algo), ", blocksize: ", (string blocksize), ", and level: ", (string level), "."];
+        [.lg.o[`compression;cmp,"compressing ","file ", (string filetoCompress), " with algo: ", (string algo), ", blocksize: ", (string blocksize), ", and level: ", (string level), "."];
          / perform the compression/decompression
         if[0=algo;comprL:(-21!filetoCompress)`compressedLength];
         -19!(filetoCompress;compressedFile;blocksize;algo;level);
          / check the compressed/decomp file and move if appropriate; else delete compressed file and log error
         $[((get compressedFile)~sf:get filetoCompress) & (count -21!compressedFile) or algo=0;
-            [.lg.o[`compression;"File ", $[algo=0;"decompressed ";"compressed "],"successfully; matches orginal. Deleting original."];
+            [.lg.o[`compression;"File ",cmp,"compressed ","successfully; matches orginal. Deleting original."];
                 system "r ", (last ":" vs string compressedFile)," ", last ":" vs string filetoCompress;
                 / move the hash files too.
                 if[78 <= type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#"];
@@ -173,8 +174,8 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
                 statstab,:$[not 0=algo;(filetoCompress;algo;(-21!filetoCompress)`compressedLength;sizeuncomp);(filetoCompress;algo;comprL;sizeuncomp)]];
             [$[(not count (-21!compressedFile));
 		[.lg.o[`compression; "Failed to compress file ",string[filetoCompress]];hdel compressedFile];
-		.lg.o[`compression;$[algo=0;"Decompressed ";"Compressed "],"file ",string[compressedFile]," doesn't match original. Deleting new file"];hdel compressedFile;]]]
+		.lg.o[`compression;cmp,"compressed ","file ",string[compressedFile]," doesn't match original. Deleting new file"];hdel compressedFile;]]]
         ];
         / if already compressed/decompressed, then log that and skip.
         [((not 0 = count -21!filetoCompress) & not 0 = algo)|((0 = count -21!filetoCompress) & 0 = algo)];
-        .lg.o[`compression; "file ", (string filetoCompress), " is already ",$[0=algo; "decompressed";"compressed"],". Skipping this file"];]}
+        .lg.o[`compression; "file ", (string filetoCompress), " is already ",cmp,"compressed",". Skipping this file"];]}

--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -172,9 +172,9 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
                 if[78 <= type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#"];
                 /-log to the table if the algo wasn't 0
                 statstab,:$[not 0=algo;(filetoCompress;algo;(-21!filetoCompress)`compressedLength;sizeuncomp);(filetoCompress;algo;comprL;sizeuncomp)]];
-            [$[(not count (-21!compressedFile));
+            [$[not count -21!compressedFile;
 		[.lg.o[`compression; "Failed to compress file ",string[filetoCompress]];hdel compressedFile];
-		.lg.o[`compression;cmp,"compressed ","file ",string[compressedFile]," doesn't match original. Deleting new file"];hdel compressedFile;]]]
+		[.lg.o[`compression;cmp,"compressed ","file ",string[compressedFile]," doesn't match original. Deleting new file"];hdel compressedFile]]]]
         ];
         / if already compressed/decompressed, then log that and skip.
         .lg.o[`compression; "file ", (string filetoCompress), " is already ",cmp,"compressed",". Skipping this file"]]}

--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -177,5 +177,4 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
 		.lg.o[`compression;cmp,"compressed ","file ",string[compressedFile]," doesn't match original. Deleting new file"];hdel compressedFile;]]]
         ];
         / if already compressed/decompressed, then log that and skip.
-        [((not 0 = count -21!filetoCompress) & not 0 = algo)|((0 = count -21!filetoCompress) & 0 = algo)];
-        .lg.o[`compression; "file ", (string filetoCompress), " is already ",cmp,"compressed",". Skipping this file"];]}
+        .lg.o[`compression; "file ", (string filetoCompress), " is already ",cmp,"compressed",". Skipping this file"]]}

--- a/code/common/html.q
+++ b/code/common/html.q
@@ -67,7 +67,7 @@ jsformat:{ k:cols x; flip k !(y value t:type each x)@'value x:flip 0!x}
 // Arg: dictionary decoded front end JSON  
 // format should be `func`arg1`arg2 ... `arg8!(function;arg1;arg2;...;arg3)
 // all args except arg1 are optional
-execdict:{$[not `func in key x;'"no func in dictionary";1=count key x;(value x`func) @ 1;1<count key x;(value x`func) . value x _ `func;]}
+execdict:{$[not `func in key x;'"no func in dictionary";1=count key x;(value x`func) @ 1;1<count key x;(value x`func) . value x _ `func;()]}
 // Arg: string JSON encoded string from front end
 evaluate:{@[execdict;x;{'"failed to execute ",(-3!x)," : ",y}[x]]}
 

--- a/code/common/html.q
+++ b/code/common/html.q
@@ -67,7 +67,7 @@ jsformat:{ k:cols x; flip k !(y value t:type each x)@'value x:flip 0!x}
 // Arg: dictionary decoded front end JSON  
 // format should be `func`arg1`arg2 ... `arg8!(function;arg1;arg2;...;arg3)
 // all args except arg1 are optional
-execdict:{$[not `func in key x;'"no func in dictionary";1=count key x;(value x`func) @ 1;1<count key x;(value x`func) . value x _ `func]}
+execdict:{$[not `func in key x;'"no func in dictionary";1=count key x;(value x`func) @ 1;1<count key x;(value x`func) . value x _ `func;]}
 // Arg: string JSON encoded string from front end
 evaluate:{@[execdict;x;{'"failed to execute ",(-3!x)," : ",y}[x]]}
 

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -335,7 +335,7 @@ reloadproc:{[h;d;ptype]
 	.wdb.countreload:count[raze .servers.getservers[`proctype;;()!();1b;0b]each reloadorder];
 	$[eodwaittime>0;
 		{[x;y;ptype].[{neg[y]@x};(x;y);{[ptype;x].lg.e[`reloadproc;"failed to reload the ",string[ptype]];'x}[ptype]]}[({@[`. `reload;x;()]; (neg .z.w)(`.wdb.handler;1b); (neg .z.w)[]};d);h;ptype];
-		@[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e][ptype]}]
+		@[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e]}[ptype]]
 	];
 	.lg.o[`reload;"the ",string[ptype]," has been successfully reloaded"];
 	}

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -335,7 +335,7 @@ reloadproc:{[h;d;ptype]
 	.wdb.countreload:count[raze .servers.getservers[`proctype;;()!();1b;0b]each reloadorder];
 	$[eodwaittime>0;
 		{[x;y;ptype].[{neg[y]@x};(x;y);{[ptype;x].lg.e[`reloadproc;"failed to reload the ",string[ptype]];'x}[ptype]]}[({@[`. `reload;x;()]; (neg .z.w)(`.wdb.handler;1b); (neg .z.w)[]};d);h;ptype];
-		@[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e][ptype]}];
+		@[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e][ptype]}]
 	];
 	.lg.o[`reload;"the ",string[ptype]," has been successfully reloaded"];
 	}


### PR DESCRIPTION
Since 3.6, conditionals inside a function must have an odd number of arguments, otherwise it throws a 'cond error.