### PR TITLE
Response format

### DIFF
--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -73,7 +73,7 @@
 // addserver and asyncexec, with the (servertypes) parameter projected to a single server of (for example) `standardserver
 
 \d .gw
-
+formatresponse:@[value;`.gw.formatresponse;{[x;y]if[10h=type y;'y];y}]
 synccallsallowed:@[value;`.gw.synccallsallowed; 0b]		// whether synchronous calls are allowed
 querykeeptime:@[value;`.gw.querykeeptime; 0D00:30]		// the time to keep queries in the 
 errorprefix:@[value;`.gw.errorprefix; "error: "]		// the prefix for clients to look for in error strings
@@ -450,13 +450,13 @@ asyncexec:asyncexecjpt[;;raze;();0Wn]
 
 // execute a synchronous query
 syncexecj:{[query;servertype;joinfunction]
- if[not .gw.synccallsallowed; '`$"synchronous calls are not allowed"];
+ if[not .gw.synccallsallowed;.gw.formatresponse "Synchronous calls are not allowed"];
  // check if the gateway allows the query to be called
- if[.gw.permissioned;if[not .pm.allowed [.z.u;query];'"User is not permissioned to run this query from the gateway"]];
+ if[.gw.permissioned;if[not .pm.allowed [.z.u;query];.gw.formatresponse "User is not permissioned to run this query from the gateway"]];
  // check if we have all the servers active
  serverids:getserverids[servertype];
  // check if gateway in eod reload phase
- if[checkeod[serverids]; '"unable to query multiple servers during eod reload"];
+ if[checkeod[serverids];.gw.formatresponse"unable to query multiple servers during eod reload"];
  // get the list of handles
  tab:availableserverstable[0b];
  handles:(exec serverid!handle from tab)first each (exec serverid from tab) inter/: serverids;
@@ -471,12 +471,13 @@ syncexecj:{[query;servertype;joinfunction]
  res:handles@\:(::);
  // update the usage data
  update inuse:0b,usage:usage+(handles!res[;1] - start)[handle] from `.gw.servers where handle in handles;
+ 
  // check if there are any errors in the returned results
  $[all res[;0];
   // no errors - join the results
-  @[joinfunction;res[;2];{'`$"failed to apply supplied join function to results: ",x}];
+  .gw.formatresponse @[joinfunction;res[;2];{"failed to apply supplied join function to results: ",x}];
   [failed:where not res[;0];
-   '`$"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]] 
+   .gw.formatresponse"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]] 
  }
 
 syncexec:syncexecj[;;raze]

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -214,8 +214,8 @@ checkresults:{[queryid]
 
 // build and send a response to go to the client
 // if the postback function is defined, then wrap the result in that, and also send back the original query
-sendclientreply:{[queryid;result;status].k.p:result;
- .k.k:querydetails:queryqueue[queryid];
+sendclientreply:{[queryid;result;status]
+ querydetails:queryqueue[queryid];
  // if query has already been sent an error, don't send another one
  if[querydetails`error; :()];
  tosend:$[()~querydetails[`postback];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -73,7 +73,7 @@
 // addserver and asyncexec, with the (servertypes) parameter projected to a single server of (for example) `standardserver
 
 \d .gw
-formatresponse:@[value;`.gw.formatresponse;{{[status;s;result] :$[(not status) and (s=`sync);'result;result];}}]
+formatresponse:@[value;`.gw.formatresponse;{{[status;call;result] :$[not[status]and(call=`sync);'result;result];}}]
 synccallsallowed:@[value;`.gw.synccallsallowed; 0b]		// whether synchronous calls are allowed
 querykeeptime:@[value;`.gw.querykeeptime; 0D00:30]		// the time to keep queries in the 
 errorprefix:@[value;`.gw.errorprefix; "error: "]		// the prefix for clients to look for in error strings
@@ -439,7 +439,7 @@ asyncexecjpt:{[query;servertype;joinfunction;postback;timeout]
 	servertype:res;
  ]]];
  if[count errStr;
-  @[neg .z.w;$[()~postback;errStr;$[-11h=type postback;enlist postback;postback],(enlist query),enlist errStr];()];
+  @[neg .z.w;.gw.formatresponse[0b;`async;$[()~postback;errStr;$[-11h=type postback;enlist postback;postback],(enlist query),enlist errStr]];()];
   :()];
 
  addquerytimeout[query;servertype;queryattributes;joinfunction;postback;timeout];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -73,7 +73,7 @@
 // addserver and asyncexec, with the (servertypes) parameter projected to a single server of (for example) `standardserver
 
 \d .gw
-formatresponse:@[value;`.gw.formatresponse;{{[status;call;result] :$[not[status]and(call=`sync);'result;result];}}]
+formatresponse:@[value;`.gw.formatresponse;{{[status;call;result] :$[not[status]and call=`sync;'result;result];}}]
 synccallsallowed:@[value;`.gw.synccallsallowed; 0b]		// whether synchronous calls are allowed
 querykeeptime:@[value;`.gw.querykeeptime; 0D00:30]		// the time to keep queries in the 
 errorprefix:@[value;`.gw.errorprefix; "error: "]		// the prefix for clients to look for in error strings
@@ -221,13 +221,13 @@ sendclientreply:{[queryid;result]
  tosend:$[()~querydetails[`postback];
 	result;
 	(querydetails`postback),(enlist querydetails`query),enlist result];
- @[neg querydetails`clienth;tosend;()]}
+ @[neg querydetails`clienth;.gw.formatresponse[1b;`async;tosend];()]}
 
 // execute a query on the server.  Catch the error, propagate back
-serverexecute:{[queryid;query] 
+serverexecute:{[queryid;query]
  res:@[{(0b;value x)};query;{(1b;"failed to run query on server ",(string .z.h),":",(string system"p"),": ",x)}];
  // send back the result, in an error trap
- @[neg .z.w; $[res 0; (`.gw.addservererror;queryid;res 1); (`.gw.addserverresult;queryid;res 1)]; 
+ @[neg .z.w;$[res 0; (`.gw.addservererror;queryid;res 1); (`.gw.addserverresult;queryid;res 1)]; 
 	// if we fail to send the result back it might be something IPC related, e.g. limit error, so try just sending back an error message
 	{@[neg .z.w;(`.gw.addservererror;x;"failed to return query from server ",(string .z.h),":",(string system"p"),": ",y);()]}[queryid]];}
 // send a query to a server 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -73,6 +73,7 @@
 // addserver and asyncexec, with the (servertypes) parameter projected to a single server of (for example) `standardserver
 
 \d .gw
+
 formatresponse:@[value;`.gw.formatresponse;{{[status;sync;result] :$[not[status]and sync=`sync;'result;result];}}]
 synccallsallowed:@[value;`.gw.synccallsallowed; 0b]		// whether synchronous calls are allowed
 querykeeptime:@[value;`.gw.querykeeptime; 0D00:30]		// the time to keep queries in the 
@@ -224,10 +225,10 @@ sendclientreply:{[queryid;result;status]
  @[neg querydetails`clienth;.gw.formatresponse[status;`async;tosend];()]}
 
 // execute a query on the server.  Catch the error, propagate back
-serverexecute:{[queryid;query]
+serverexecute:{[queryid;query] 
  res:@[{(0b;value x)};query;{(1b;"failed to run query on server ",(string .z.h),":",(string system"p"),": ",x)}];
  // send back the result, in an error trap
- @[neg .z.w; $[res 0; (`.gw.addservererror;queryid;res 1); (`.gw.addserverresult;queryid;res 1)];
+ @[neg .z.w; $[res 0; (`.gw.addservererror;queryid;res 1); (`.gw.addserverresult;queryid;res 1)]; 
 	// if we fail to send the result back it might be something IPC related, e.g. limit error, so try just sending back an error message
 	{@[neg .z.w;(`.gw.addservererror;x;"failed to return query from server ",(string .z.h),":",(string system"p"),": ",y);()]}[queryid]];}
 // send a query to a server 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -472,11 +472,11 @@ syncexecj:{[query;servertype;joinfunction]
  res:handles@\:(::);
  // update the usage data
  update inuse:0b,usage:usage+(handles!res[;1] - start)[handle] from `.gw.servers where handle in handles;
-
  // check if there are any errors in the returned results
  $[all res[;0];
   // no errors - join the results
-  .gw.formatresponse[1b;`sync;]@[joinfunction;res[;2];{.gw.formatresponse[0b;`sync;"failed to apply supplied join function to results: ",x]}];
+  [s:@[{(1b;x y)}joinfunction;res[;2];{(0b;"failed to apply supplied join function to results: ",x)}];
+    .gw.formatresponse[s 0;`sync;s 1]];
   [failed:where not res[;0];
    .gw.formatresponse[0b;`sync;"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]]] 
  }


### PR DESCRIPTION
Response format for sync and async requests.

Takes 3 args - status, sync, result to allow specific functionality for each case.

Defaults to throw error for sync errors, else passes through the error string or result.

Updated 'sendclientreply' to take extra argument, status, for async calls