### PR TITLE
Response formatter

### DIFF
--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -248,7 +248,7 @@ removeserverhandle:{[serverh]
  // 1) queries sent to this server but no reply back yet
  qids:where {[res;id] any (::)~/:res[1;where id=res[1;;0];1]}[;serverid] each results;
  // propagate an error back to each client
- sendclientreply[;.gw.errorprefix,"backend ",(string servertype)," server handling query closed the connection";0b] each qids;
+ sendclientreply[;.gw.errorprefix,"backend ",string[servertype]," server handling query closed the connection";0b] each qids;
  finishquery[qids;1b;serverh]; 
 
  // 2) queries partially run + waiting for this server
@@ -259,13 +259,13 @@ removeserverhandle:{[serverh]
 	s:where (::)~/:res[1;;1]; 
 	$[11h=type s; not all s in aTypes; not all any each s in\: aIDs] 
 	}[;serverid;activeServerIDs;activeServerTypes] each results _ 0Ni;
- sendclientreply[;.gw.errorprefix,"backend ",(string servertype)," server for running query closed the connection";0b] each qids2;
+ sendclientreply[;.gw.errorprefix,"backend ",string[servertype]," server for running query closed the connection";0b] each qids2;
  finishquery[qids2;1b;serverh]; 
 
  // 3) queries not yet run + waiting for this server
  qids3:exec queryid from .gw.queryqueue where null submittime, not `boolean${$[11h=type z; all z in x; all any each z in\: y]}[activeServerTypes;activeServerIDs] each servertype; 
  // propagate an error back to each client
- sendclientreply[;.gw.errorprefix,"backend ",(string servertype)," server for queued query closed the connection";0b] each qids3;
+ sendclientreply[;.gw.errorprefix,"backend ",string[servertype]," server for queued query closed the connection";0b] each qids3;
  finishquery[qids3;1b;serverh]; 
 
  // mark the server as inactive
@@ -446,7 +446,7 @@ asyncexecjpt:{[query;servertype;joinfunction;postback;timeout]
 	servertype:res;
  ]]];
  if[count errStr;
-  @[neg .z.w;.gw.formatresponse[0b;`async;$[()~postback;errStr;$[-11h=type postback;enlist postback;postback],(enlist query),enlist errStr]];()];
+  @[neg .z.w;.gw.formatresponse[0b;`async;$[()~postback;errStr;$[-11h=type postback;enlist postback;postback],enlist[query],enlist errStr]];()];
   :()];
 
  addquerytimeout[query;servertype;queryattributes;joinfunction;postback;timeout];
@@ -568,7 +568,8 @@ reloadstart:{
  /- extract ids of queries not yet returned
  qids:exec queryid from .gw.queryqueue where 1<count each distinct each{@[(exec serverid!servertype from .gw.servers)@;x;x]}each servertype,null returntime;
  /- propagate a timeout error to each client
- if[count qids;.gw.sendclientreply[;.gw.errorprefix,"query did not return prior to eod reload";0b]each qids;.gw.finishquery[qids;1b;0Ni]];}
+ if[count qids;.gw.sendclientreply[;.gw.errorprefix,"query did not return prior to eod reload";0b]each qids;.gw.finishquery[qids;1b;0Ni]];
+ };
 
 reloadend:{
  .lg.o[`reload;"reload end called"];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -73,7 +73,7 @@
 // addserver and asyncexec, with the (servertypes) parameter projected to a single server of (for example) `standardserver
 
 \d .gw
-
+formatresponse:@[value;`.gw.formatresponse;{[x;y]if[10h=type y;'y];y}]
 synccallsallowed:@[value;`.gw.synccallsallowed; 0b]		// whether synchronous calls are allowed
 querykeeptime:@[value;`.gw.querykeeptime; 0D00:30]		// the time to keep queries in the 
 errorprefix:@[value;`.gw.errorprefix; "error: "]		// the prefix for clients to look for in error strings
@@ -450,13 +450,13 @@ asyncexec:asyncexecjpt[;;raze;();0Wn]
 
 // execute a synchronous query
 syncexecj:{[query;servertype;joinfunction]
- if[not .gw.synccallsallowed; '`$"synchronous calls are not allowed"];
+ if[not .gw.synccallsallowed;.gw.formatresponse "Synchronous calls are not allowed"];
  // check if the gateway allows the query to be called
- if[.gw.permissioned;if[not .pm.allowed [.z.u;query];'"User is not permissioned to run this query from the gateway"]];
+ if[.gw.permissioned;if[not .pm.allowed [.z.u;query];.gw.formatresponse "User is not permissioned to run this query from the gateway"]];
  // check if we have all the servers active
  serverids:getserverids[servertype];
  // check if gateway in eod reload phase
- if[checkeod[serverids]; '"unable to query multiple servers during eod reload"];
+ if[checkeod[serverids];.gw.formatresponse"unable to query multiple servers during eod reload"];
  // get the list of handles
  tab:availableserverstable[0b];
  handles:(exec serverid!handle from tab)first each (exec serverid from tab) inter/: serverids;
@@ -471,12 +471,13 @@ syncexecj:{[query;servertype;joinfunction]
  res:handles@\:(::);
  // update the usage data
  update inuse:0b,usage:usage+(handles!res[;1] - start)[handle] from `.gw.servers where handle in handles;
+ 
  // check if there are any errors in the returned results
  $[all res[;0];
   // no errors - join the results
-  @[joinfunction;res[;2];{'`$"failed to apply supplied join function to results: ",x}];
+  .gw.formatresponse @[joinfunction;res[;2];{"failed to apply supplied join function to results: ",x}];
   [failed:where not res[;0];
-   '`$"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]] 
+   .gw.formatresponse"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]] 
  }
 
 syncexec:syncexecj[;;raze]

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -424,7 +424,8 @@ asyncexecjpt:{[query;servertype;joinfunction;postback;timeout]
  if[.gw.permissioned;
   if[not .pm.allowed[.z.u; query];
    @[neg .z.w;.gw.formatresponse[0b;`async;"User is not permissioned to run this query from the gateway"];()];
-   :()];
+   :();
+   ];
   ];
  query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);value q]}; .z.u; query);
  /- if sync calls are allowed disable async calls to avoid query conflicts
@@ -484,7 +485,7 @@ syncexecj:{[query;servertype;joinfunction]
   [s:@[{(1b;x y)}joinfunction;res[;2];{(0b;"failed to apply supplied join function to results: ",x)}];
    .gw.formatresponse[s 0;`sync;s 1]];
   [failed:where not res[;0];
-   .gw.formatresponse[0b;`sync;"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]]] 
+   .gw.formatresponse[0b;`sync;"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]]];
  };
 
 syncexec:syncexecj[;;raze]

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -214,8 +214,8 @@ checkresults:{[queryid]
 
 // build and send a response to go to the client
 // if the postback function is defined, then wrap the result in that, and also send back the original query
-sendclientreply:{[queryid;result;status].k.p:result;
- .k.k:querydetails:queryqueue[queryid];
+sendclientreply:{[queryid;result;status]
+ querydetails:queryqueue[queryid];
  // if query has already been sent an error, don't send another one
  if[querydetails`error; :()];
  tosend:$[()~querydetails[`postback];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -422,7 +422,7 @@ getserveridstype:{[att;typ]
 // execute an asynchronous query
 asyncexecjpt:{[query;servertype;joinfunction;postback;timeout]
  if[.gw.permissioned;
-  if[.pm.allowed[.z.u; query];
+  if[not .pm.allowed[.z.u; query];
    @[neg .z.w;.gw.formatresponse[0b;`async;"User is not permissioned to run this query from the gateway"];()];
    :()];
   ];
@@ -482,10 +482,10 @@ syncexecj:{[query;servertype;joinfunction]
  $[all res[;0];
   // no errors - join the results
   [s:@[{(1b;x y)}joinfunction;res[;2];{(0b;"failed to apply supplied join function to results: ",x)}];
-    .gw.formatresponse[s 0;`sync;s 1]];
+   .gw.formatresponse[s 0;`sync;s 1]];
   [failed:where not res[;0];
    .gw.formatresponse[0b;`sync;"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]]] 
- }
+ };
 
 syncexec:syncexecj[;;raze]
 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -73,7 +73,7 @@
 // addserver and asyncexec, with the (servertypes) parameter projected to a single server of (for example) `standardserver
 
 \d .gw
-formatresponse:@[value;`.gw.formatresponse;{{[status;s;result] :$[(not status) and (s=`sync);'result;result];}}]
+formatresponse:@[value;`.gw.formatresponse;{{[status;call;result] :$[not[status]and(call=`sync);'result;result];}}]
 synccallsallowed:@[value;`.gw.synccallsallowed; 0b]		// whether synchronous calls are allowed
 querykeeptime:@[value;`.gw.querykeeptime; 0D00:30]		// the time to keep queries in the 
 errorprefix:@[value;`.gw.errorprefix; "error: "]		// the prefix for clients to look for in error strings
@@ -439,7 +439,7 @@ asyncexecjpt:{[query;servertype;joinfunction;postback;timeout]
 	servertype:res;
  ]]];
  if[count errStr;
-  @[neg .z.w;$[()~postback;errStr;$[-11h=type postback;enlist postback;postback],(enlist query),enlist errStr];()];
+  @[neg .z.w;.gw.formatresponse[0b;`async;$[()~postback;errStr;$[-11h=type postback;enlist postback;postback],(enlist query),enlist errStr]];()];
   :()];
 
  addquerytimeout[query;servertype;queryattributes;joinfunction;postback;timeout];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -73,7 +73,7 @@
 // addserver and asyncexec, with the (servertypes) parameter projected to a single server of (for example) `standardserver
 
 \d .gw
-formatresponse:@[value;`.gw.formatresponse;{{[status;call;result] :$[not[status]and(call=`sync);'result;result];}}]
+formatresponse:@[value;`.gw.formatresponse;{{[status;call;result] :$[not[status]and call=`sync;'result;result];}}]
 synccallsallowed:@[value;`.gw.synccallsallowed; 0b]		// whether synchronous calls are allowed
 querykeeptime:@[value;`.gw.querykeeptime; 0D00:30]		// the time to keep queries in the 
 errorprefix:@[value;`.gw.errorprefix; "error: "]		// the prefix for clients to look for in error strings
@@ -221,13 +221,13 @@ sendclientreply:{[queryid;result]
  tosend:$[()~querydetails[`postback];
 	result;
 	(querydetails`postback),(enlist querydetails`query),enlist result];
- @[neg querydetails`clienth;tosend;()]}
+ @[neg querydetails`clienth;.gw.formatresponse[1b;`async;tosend];()]}
 
 // execute a query on the server.  Catch the error, propagate back
-serverexecute:{[queryid;query] 
+serverexecute:{[queryid;query]
  res:@[{(0b;value x)};query;{(1b;"failed to run query on server ",(string .z.h),":",(string system"p"),": ",x)}];
  // send back the result, in an error trap
- @[neg .z.w; $[res 0; (`.gw.addservererror;queryid;res 1); (`.gw.addserverresult;queryid;res 1)]; 
+ @[neg .z.w;$[res 0; (`.gw.addservererror;queryid;res 1); (`.gw.addserverresult;queryid;res 1)]; 
 	// if we fail to send the result back it might be something IPC related, e.g. limit error, so try just sending back an error message
 	{@[neg .z.w;(`.gw.addservererror;x;"failed to return query from server ",(string .z.h),":",(string system"p"),": ",y);()]}[queryid]];}
 // send a query to a server 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -73,6 +73,7 @@
 // addserver and asyncexec, with the (servertypes) parameter projected to a single server of (for example) `standardserver
 
 \d .gw
+
 formatresponse:@[value;`.gw.formatresponse;{{[status;sync;result] :$[not[status]and sync=`sync;'result;result];}}]
 synccallsallowed:@[value;`.gw.synccallsallowed; 0b]		// whether synchronous calls are allowed
 querykeeptime:@[value;`.gw.querykeeptime; 0D00:30]		// the time to keep queries in the 
@@ -224,10 +225,10 @@ sendclientreply:{[queryid;result;status]
  @[neg querydetails`clienth;.gw.formatresponse[status;`async;tosend];()]}
 
 // execute a query on the server.  Catch the error, propagate back
-serverexecute:{[queryid;query]
+serverexecute:{[queryid;query] 
  res:@[{(0b;value x)};query;{(1b;"failed to run query on server ",(string .z.h),":",(string system"p"),": ",x)}];
  // send back the result, in an error trap
- @[neg .z.w; $[res 0; (`.gw.addservererror;queryid;res 1); (`.gw.addserverresult;queryid;res 1)];
+ @[neg .z.w; $[res 0; (`.gw.addservererror;queryid;res 1); (`.gw.addserverresult;queryid;res 1)]; 
 	// if we fail to send the result back it might be something IPC related, e.g. limit error, so try just sending back an error message
 	{@[neg .z.w;(`.gw.addservererror;x;"failed to return query from server ",(string .z.h),":",(string system"p"),": ",y);()]}[queryid]];}
 // send a query to a server 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -472,11 +472,11 @@ syncexecj:{[query;servertype;joinfunction]
  res:handles@\:(::);
  // update the usage data
  update inuse:0b,usage:usage+(handles!res[;1] - start)[handle] from `.gw.servers where handle in handles;
-
  // check if there are any errors in the returned results
  $[all res[;0];
   // no errors - join the results
-  .gw.formatresponse[1b;`sync;]@[joinfunction;res[;2];{.gw.formatresponse[0b;`sync;"failed to apply supplied join function to results: ",x]}];
+  [s:@[{(1b;x y)}joinfunction;res[;2];{(0b;"failed to apply supplied join function to results: ",x)}];
+    .gw.formatresponse[s 0;`sync;s 1]];
   [failed:where not res[;0];
    .gw.formatresponse[0b;`sync;"queries failed on server(s) ",(", " sv string exec servertype from servers where handle in handles failed),".  Error(s) were ","; " sv res[failed][;2]]]] 
  }


### PR DESCRIPTION
Response format for sync and async requests.

Takes 3 args - `status, sync, result` to allow specific functionality for each case.

Defaults to throw error for sync errors, else passes through the error string or result.

Updated `sendclientreply` to take extra argument, `status`, for async calls