### PR TITLE
Initial commit of service layer extension to TorQ

### DIFF
--- a/torq.q
+++ b/torq.q
@@ -95,7 +95,7 @@ envvars:@[value;`envvars;`symbol$()]
 envvars:distinct `KDBCODE`KDBCONFIG`KDBLOG`KDBHTML`KDBLIB,envvars
 // The script may have optional environment variables
 // KDBAPPCONFIG may be defined for loading app specific config
-{if[not ""~getenv[x]; envvars::distinct x,envvars]}each `KDBAPPCONFIG`KDBSERVCONFIG
+{if[not ""~getenv x; envvars::distinct x,envvars]}each `KDBAPPCONFIG`KDBSERVCONFIG
 
 // set the torq environment variables if not already set
 qhome:{q:getenv[`QHOME]; if[q~""; q:$[.z.o like "w*"; "c:/q"; getenv[`HOME],"/q"]]; q}
@@ -576,7 +576,7 @@ if[`loaddir in key .proc.params;
 	.proc.loaddir each .proc.params`loaddir]
 
 // Load message handlers after all the other library code
-.proc.loaddir each(getenv$[.proc.loadhandlers & not ""~getenv[`KDBSERVCODE];`KDBCODE`KDBSERVCODE;(),`KDBCODE]),\:"/handlers";
+.proc.loaddir each(getenv$[.proc.loadhandlers & not ""~getenv`KDBSERVCODE;`KDBCODE`KDBSERVCODE;(),`KDBCODE]),\:"/handlers";
 
 // If the timer is loaded, and logrolling is set to true, try to log the roll file on a daily basis
 if[.proc.logroll and not any `debug`noredirect in key .proc.params;

--- a/torq.q
+++ b/torq.q
@@ -156,12 +156,14 @@ getconfig:{[path;level]
         /-if level=2 then all files are returned regardless
         if[level<2;
           if[()~keyappconf;
-            appconf:()]];
+            appconf:()];
+          if[()~keyservconf;
+            servconf:()]];
 
         /-get KDBCONFIG path
         conf:`$(kc:getenv[`KDBCONFIG]),"/",path;
 
-        /-if level is non-zero return appconfig and config files
+        /-if level is non-zero return appconfig, servconfig and config files
         (),$[level;
           appconf,servconf,conf;
           first appconf,servconf,conf]}
@@ -510,30 +512,27 @@ override:{overrideconfig[.proc.params]}
 
 loadspeccode:{[ext;dir]
 	$[""~getenv dir;
-		 .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
-		 loaddir getenv[dir],ext
+	 .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
+	 loaddir getenv[dir],ext
    ];
 	};
 
 reloadcommoncode:{
-		loaddir getenv[`KDBCODE],"/common";
-		// Optionally load common code from seperate directory
-		loadspeccode["/common"]'[`KDBAPPCODE`KDBSERVCODE];
+	// Load common code from each directory if it exists
+	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
 	};
 reloadprocesscode:{
-		loaddir getenv[`KDBCODE],"/",string proctype;
-		// Optionally load proctype code from seperate directory
-  	loadspeccode["/",string proctype]'[`KDBSERVCODE`KDBAPPCODE];
+	// Load proctype code from each directory if it exists
+	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
 	};
 reloadnamecode:{
-		loaddir getenv[`KDBCODE],"/",string procname;
-		// Optionally load procname code from seperate directory
-  	loadspeccode["/",string procname]'[`KDBSERVCODE`KDBAPPCODE];
+	// Load procname code from each directory if it exists
+	loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
 	};
 
 \d . 
 // Load configuration
-// TorQ loads configuration modules in the order: TorQ Default, then Application Specific
+// TorQ loads configuration modules in the order: TorQ Default, Service Specific and then Application Specific
 // Each module loads configuration in the order: default configuration, then process type specific, then process specific
 if[not `noconfig in key .proc.params;
 	// load TorQ Default configuration module


### PR DESCRIPTION
Added configuration in torq.q for optional addition of "service" layer

- Modification of _reloadcommon/process/namecode_ functions to check and load common/process and name code for new layer.
- Logic added to allow service layer to have custom handlers
- Modified _getconfig_ function to load in service layer specific configuration
- Addition of service layer _/settings/_ override logic