### PR TITLE
Add a parentproctype flag for torq.q

### DIFF
--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -41,7 +41,7 @@ loadpassword:{
            .lg.o[`conn;"password file ",(string file)," not found"];
            [.lg.o[`conn;"password file ",(string file)," found"];
             .servers.USERPASS:first`$read0 hsym file]]};
-    files:{.proc.getconfig["passwords/",(string x),".txt";2]} each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
+	files:{.proc.getconfig["passwords/",(string x),".txt";2]} each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
 	loadpassfile each (distinct files[;1],files[;0]) except `;
 	}
 loadpassword[]

--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -41,7 +41,7 @@ loadpassword:{
            .lg.o[`conn;"password file ",(string file)," not found"];
            [.lg.o[`conn;"password file ",(string file)," found"];
             .servers.USERPASS:first`$read0 hsym file]]};
-	files:{.proc.getconfig["passwords/",(string x),".txt";2]} each `default,.proc.proctype,.proc.procname;
+	files:{.proc.getconfig["passwords/",(string x),".txt";2]} each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
 	loadpassfile each (distinct files[;1],files[;0]) except `;
 	}
 loadpassword[]

--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -41,7 +41,7 @@ loadpassword:{
            .lg.o[`conn;"password file ",(string file)," not found"];
            [.lg.o[`conn;"password file ",(string file)," found"];
             .servers.USERPASS:first`$read0 hsym file]]};
-	files:{.proc.getconfig["passwords/",(string x),".txt";2]} each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
+    files:{.proc.getconfig["passwords/",(string x),".txt";2]} each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
 	loadpassfile each (distinct files[;1],files[;0]) except `;
 	}
 loadpassword[]

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -40,12 +40,13 @@ AquaQ TorQ can be extended or modified as required. We have chosen some
 default behaviour, but it can all be overridden. The features of AquaQ
 TorQ are:
 
--   Process Management: Each process is given a type and name. By
-    default these are used to determine the code base it loads, the
-    configuration loaded, log file naming and how it reports itself to
-    discovery services. Whenever possible we have tried to ensure that
-    all default behaviour can be overridden at the process type level,
-    and further at the process name level.
+-   Process Management: Each process is given a type and name, and can
+    optionally be given a parent type. By default these are used to
+    determine the code base it loads, the configuration loaded, log 
+    file naming and how it reports itself to discovery services.
+    Whenever possible we have tried to ensure that all default
+    behaviour can be overridden at the process type level, and further
+    at the process name level.
 
 -   Code Management: Processes can optionally load common or process
     type/name specific code bases. All code loading is error trapped.
@@ -53,9 +54,9 @@ TorQ are:
 -   Configuration Management: Configuration scripts can be loaded as
     standard and with specific process type/name configuration
     overriding default values. Configuration scripts are loaded in a
-    specific order; default, then process type specific, then process
-    name specific. Values loaded last will override values loaded
-    previously.
+    specific order; default, then parent process type specific
+    (optional), process type specific, then process name specific.
+    Values loaded last will override values loaded previously.
 
 -   Usage Logging: All process usage is logged to a single text log file
     and periodically rolled. Logging includes opening/closing of
@@ -70,7 +71,8 @@ TorQ are:
     through query counts and total data size counts. Connections are
     stored and retrieved and can be set to automatically be re-opened as
     required. The password used for outgoing connections can be
-    overridden at default, process type and process name level.
+    overridden at default, parent process type (optional), process type
+    and process name level.
 
 -   Access Controls: Basic access controls are provided, and could be
     extended. These apply restrictions on the IP addresses of remote

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -54,6 +54,10 @@ parameters. An example is below.
     $ . setenv.sh
     $ q torq.q -debug -proctype testproc -procname test1 
 
+To specify the parent process type, do:
+
+    $ q torq.q -debug -parentproctype -testparentproc -proctype testproc -procname test1
+
 To load a file, do:
 
     $ q torq.q -load myfile.q -debug -proctype testproc -procname test1
@@ -70,6 +74,7 @@ The available command line parameters are:
   |Cmd Line Param|            Description|
   |-------------------------| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
   |-procname x -proctype y   |The process name and process type|
+  |-parentproctype x         |The parent process type|
   |-procfile x               |The name of the file to get the process information from|
   |-load x \[y..z\]          |The files or database directory to load|
   |-loaddir x \[y..z\]       |Load all .q, .k files in specified directories|
@@ -128,19 +133,24 @@ Process Identification
 ----------------------
 
 At the crux of AquaQ TorQ is how processes identify themselves. This is
-defined by two variables - .proc.proctype and .proc.procname which are
-the type and name of the process respectively. These two values
-determine the code base and configuration loaded, and how they are
-connected to by other processes. If both of these are not defined, the
-TorQ will attempt to use the port number a process was started on to
-determine the code base and configuration loaded.
+defined by two required variables - .proc.proctype and .proc.procname
+which are the type and name of the process respectively and an optional
+variable parentproctype which is the type of the parent process. These
+three values determine the code base and configuration loaded, and how
+they are connected to by other processes. If both of the required
+variables are not defined, the TorQ will attempt to use the port number
+a process was started on to determine the code base and configuration
+loaded.
 
 The most important of these is the proctype. It is up to the user to
 define at what level to specify a process type. For example, in a
 production environment it would be valid to specify processes of type
 “hdb” (historic database) and “rdb” (real time database). It would also
 be valid to segregate a little more granularly based on approximate
-functionality, for example “hdbEMEA” and “hdbAmericas”. The actual
+functionality, for example “hdbEMEA” and “hdbAmericas”. In this example
+it may be sensible to set the parentproctype as "hdb" and putting all
+shared code in the "hdb" configuration to be loaded first with the
+region-specific configuration being loaded after. The actual
 functionality of a process can be defined more specifically, but this
 will be discussed later. The procname value is used solely for
 identification purposes. A process can determine its type and name in a
@@ -310,9 +320,12 @@ files in the below order:-
 
 -   default.q: default configuration loaded by all processes. In a
     standard installation this should contain the superset of
-    customisable configuration, including comments;
+    customisable configuration, including comments.
 
--   [proctype].q: configuration for a specific process type;
+-   [parentproctype].q: configuration for a specific parent process
+    type (only if parentproctype specified).
+
+-   [proctype].q: configuration for a specific process type.
 
 -   [procname].q: configuration for a specific named process.
 
@@ -331,6 +344,9 @@ configuration in the following order:-
 
 -   default.q: Application default configuration loaded by all
     processes.
+
+-   [\[parentproctype\]]{}.q : Application specific configuration for a
+    specific parent process type (only if parentproctype specified).
 
 -   [\[proctype\]]{}.q: Application specific configuration for a
     specific process type.
@@ -378,6 +394,9 @@ order:
 
 -   $KDBCODE/common: shared codebase loaded by all processes;
 
+-   $KDBCODE/\[parentproctype\]: code for a specific parent process type
+    (only if parentproctype specified).
+
 -   $KDBCODE/\[proctype\]: code for a specific process type;
 
 -   $KDBCODE/\[procname\]: code for a specific process name;
@@ -396,6 +415,12 @@ If this environment variable is set, TorQ will load codebase in the following or
 -   $KDBCODE/common: shared codebase loaded by all processes;
 
 -   $KDBAPPCODE/common: application specific code shared by all processes;
+
+-   $KDBCODE/\[parentproctype\]: code for a specific parent process type (only if
+    parentproctype specified);
+
+-   $KDBAPPCODE/\[parentproctype\[: application specific code for a specific parent
+    process type (only if parentproctype specified);
 
 -   $KDBCODE/\[proctype\]: code for a specific process type;
 

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -395,7 +395,7 @@ order:
 -   $KDBCODE/common: shared codebase loaded by all processes;
 
 -   $KDBCODE/\[parentproctype\]: code for a specific parent process type
-    (only if parentproctype specified).
+    (only if parentproctype specified);
 
 -   $KDBCODE/\[proctype\]: code for a specific process type;
 
@@ -419,7 +419,7 @@ If this environment variable is set, TorQ will load codebase in the following or
 -   $KDBCODE/\[parentproctype\]: code for a specific parent process type (only if
     parentproctype specified);
 
--   $KDBAPPCODE/\[parentproctype\[: application specific code for a specific parent
+-   $KDBAPPCODE/\[parentproctype\]: application specific code for a specific parent
     process type (only if parentproctype specified);
 
 -   $KDBCODE/\[proctype\]: code for a specific process type;

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -56,7 +56,7 @@ parameters. An example is below.
 
 To specify the parent process type, do:
 
-    $ q torq.q -debug -parentproctype -testparentproc -proctype testproc -procname test1
+    $ q torq.q -debug -parentproctype testparentproc -proctype testproc -procname test1
 
 To load a file, do:
 

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -134,13 +134,13 @@ Process Identification
 
 At the crux of AquaQ TorQ is how processes identify themselves. This is
 defined by two required variables - .proc.proctype and .proc.procname
-which are the type and name of the process respectively and an optional
-variable parentproctype which is the type of the parent process. These
-three values determine the code base and configuration loaded, and how
-they are connected to by other processes. If both of the required
-variables are not defined, the TorQ will attempt to use the port number
-a process was started on to determine the code base and configuration
-loaded.
+which are the type and name of the process respectively. An optional
+variable parentproctype allows an inital codebase and configuration to
+be loaded. The two required  values determine the code base and
+configuration loaded, and how they are connected to by other processes.
+If both of the required variables are not defined, TorQ will attempt
+to use the port number a process was started on to determine the code
+base and configuration loaded.
 
 The most important of these is the proctype. It is up to the user to
 define at what level to specify a process type. For example, in a

--- a/torq.q
+++ b/torq.q
@@ -345,9 +345,10 @@ $[count[req] = count req inter key params;
   ()];		 
 
 // If parentproctype has been supplied then set it
-parentproctype:$[`parentproctype in key params;
-  first `$params `parentproctype;
-  ()];
+parentproctype:();
+if[`parentproctype in key params;
+    parentproctype:first `$params `parentproctype;
+    .lg.o[`init;"read in process parameter of parentproctype=",string parentproctype]];
 
 checkdependency[getconfig["dependency.csv";1]]
 

--- a/torq.q
+++ b/torq.q
@@ -82,9 +82,9 @@ configusage:@[value;`configusage;"Config management:
 helpusage:@[value;`helpusage;"Help: 
  if help.q from code.kx is loaded, use help` for more information.
  if api.q is loaded, you should be able to access api information from the commandline.  Use 
-  .api.f[symbol or string pattern] e.g. .api.f[`proc] to find a function/variable
-  .api.p[symbol or string pattern] e.g. .api.p[`timer] to find a publically marked function/variable
-  .api.u[symbol or string pattern] e.g. .api.u[`] to find a publically marked, user defined function (i.e. don't show .q functions)"] 
+	.api.f[symbol or string pattern] e.g. .api.f[`proc] to find a function/variable
+	.api.p[symbol or string pattern] e.g. .api.p[`timer] to find a publically marked function/variable
+	.api.u[symbol or string pattern] e.g. .api.u[`] to find a publically marked, user defined function (i.e. don't show .q functions)"] 
 
 // If the usage value has been overridden, use that.  Else concat the req environment, with the stdoptions, with the extra usage info
 getusage:{@[value;`.proc.usage;generalusage,"\n\n",envusage,"\n\n",envoptusage,"\n\n",stdoptionusage,"\n\n",extrausage,"\n\n",configusage,"\n\n",helpusage,"\n\n"]}
@@ -101,7 +101,7 @@ envvars:distinct `KDBCODE`KDBCONFIG`KDBLOG`KDBHTML`KDBLIB,envvars
 qhome:{q:getenv[`QHOME]; if[q~""; q:$[.z.o like "w*"; "c:/q"; getenv[`HOME],"/q"]]; q}
 settorqenv:{[envvar; default] 
  if[""~getenv[envvar]; 
-  .lg.o[`init;(string envvar)," is not defined. Defining it to ",val:qhome[],"/",default];  
+  .lg.o[`init;(string envvar)," is not defined. Defining it to ",val:qhome[],"/",default];	
   setenv[envvar; val]];}
 
 // make sure the path separators are the right way around if running on windows
@@ -200,11 +200,11 @@ pubmap:@[value;`pubmap;`ERROR`ERR`INF`WARN!1 1 0 1]
 
 // Log a message
 l:{[loglevel;proctype;proc;id;message;dict]
-  $[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
-    neg[redir] .lg.format[loglevel;proctype;proc;id;message];
-    ext[loglevel;proctype;proc;id;message;dict]];
-        publish[loglevel;proctype;proc;id;message]; 
-  }
+	$[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
+		neg[redir] .lg.format[loglevel;proctype;proc;id;message];
+		ext[loglevel;proctype;proc;id;message;dict]];
+        publish[loglevel;proctype;proc;id;message];	
+	}
 
 // Log an error.  
 // If the process is fully initialised, throw the error
@@ -212,9 +212,9 @@ l:{[loglevel;proctype;proc;id;message;dict]
 err:{[loglevel;proctype;proc;id;message;dict]
         l[loglevel;proctype;proc;id;message;dict];
         if[.proc.stop;'message];
-  if[.proc.initialised;:()];
+ 	if[.proc.initialised;:()];
         if[not .proc.trap; exit 3];
-  }
+	}
 
 // log out and log err
 // The process name is temporary which we will reset later - once we know what type of process this is
@@ -259,21 +259,21 @@ usage:{ex[`usage;.proc.getusage[];1]}
 
 // Throw an error if all the required parameters aren't passed in
 param:{[paramdict;reqparams] 
-  if[count missing:(reqparams,:()) except key paramdict; 
-    .lg.e[`init;"missing required command line parameter(s) "," " sv string missing];
-    usage[]]}
+	if[count missing:(reqparams,:()) except key paramdict; 
+		.lg.e[`init;"missing required command line parameter(s) "," " sv string missing];
+		usage[]]}
 
 // Throw an error if all the requried envinonment variables aren't set
 env:{[reqenv]
-  if[count missing:reqenv where 0=count each getenv each reqenv,:();
-    .lg.e[`init;"required environment variable(s) not set - "," " sv string missing];
-    usage[]]}
+	if[count missing:reqenv where 0=count each getenv each reqenv,:();
+		.lg.e[`init;"required environment variable(s) not set - "," " sv string missing];
+		usage[]]}
 
 // Check if a variable is null
 exitifnull:{[variable] 
-  if[null value variable; 
-    .lg.e[`init;"Variable ",(string variable)," is null but must be set"];
-    usage[]]}
+	if[null value variable; 
+		.lg.e[`init;"Variable ",(string variable)," is null but must be set"];
+		usage[]]}
 
 
 // Function for replacing environment variables with the associated full path
@@ -281,17 +281,17 @@ exitifnull:{[variable]
 \d .rmvr
 
 removeenvvar:{
-  // positions of {}
-  pos:ss[x]each"{}";
-  // check the formatting is ok
-  $[0=count first pos; :x;
-  1<count distinct count each pos; '"environment variable contains unmatched brackets: ",x;
-  (any pos[0]>pos[1]) or any pos[0]<prev pos[1]; '"failed to match environment variable brackets on supplied string: ",x;
-  ()];
+ 	// positions of {}
+	pos:ss[x]each"{}";
+	// check the formatting is ok
+	$[0=count first pos; :x;
+	1<count distinct count each pos; '"environment variable contains unmatched brackets: ",x;
+	(any pos[0]>pos[1]) or any pos[0]<prev pos[1]; '"failed to match environment variable brackets on supplied string: ",x;
+	()];
 
-  // cut out each environment variable, and retrieve the meaning
-  raze {$["{"=first x;getenv`$1 _ -1 _ x;x]}each (raze flip 0 1+pos) cut x}   
-    
+	// cut out each environment variable, and retrieve the meaning
+	raze {$["{"=first x;getenv`$1 _ -1 _ x;x]}each (raze flip 0 1+pos) cut x}		
+		
 // Process initialisation
 \d .proc
 
@@ -301,8 +301,8 @@ params:.Q.opt .z.x
 if[`usage in key params; -1 .proc.getusage[]; exit 0];
 
 $[`localtime in key .proc.params;
-  [cp:{.z.P};cd:{.z.D};ct:{.z.T}];
-  [cp:{.z.p};cd:{.z.d};ct:{.z.t}]];
+	[cp:{.z.P};cd:{.z.D};ct:{.z.T}];
+	[cp:{.z.p};cd:{.z.d};ct:{.z.t}]];
 
 localtime:`localtime in key .proc.params
 
@@ -329,83 +329,81 @@ settorqenv'[`KDBCODE`KDBCONFIG`KDBLOG`KDBLIB`KDBHTML;("code";"config";"logs";"li
 // The could also be set in a wrapper script
 reqset:0b
 if[any req in key `.proc;
-  $[all req in key `.proc;
-    $[any null `.proc req;
-      .lg.o[`init;"some of the required process parameters supplied in the  wrapper script are set to null.  All must be set. Resetting all to null"];
-      reqset:1b]; 
-    .lg.o[`init;"some but not all required process parameters have been set from the wrapper script - resetting all to null"]]];
+	$[all req in key `.proc;
+		$[any null `.proc req;
+			.lg.o[`init;"some of the required process parameters supplied in the  wrapper script are set to null.  All must be set. Resetting all to null"];
+			reqset:1b]; 
+	  .lg.o[`init;"some but not all required process parameters have been set from the wrapper script - resetting all to null"]]];
 
 if[not reqset; @[`.proc;req;:;`]];
 
 $[count[req] = count req inter key params;
-  [@[`.proc;req;:;first each `$params req];
-   reqset:1b];
+	[@[`.proc;req;:;first each `$params req];
+	 reqset:1b];
   0<count req inter key params;
-  .lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
-  ()];     
+	.lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
+  ()];		 
+
+// If parentproctype has been supplied then set it
+parentproctype:$[`parentproctype in key params;
+  first `$params `parentproctype;
+  ()];
 
 checkdependency[getconfig["dependency.csv";1]]
 
 // If any of the required parameters are null, try to read them from a file
 // The file can come from the command line, or from the environment path
-parentproctype:();
-if[`parentproctype in key params; 
-  parentproctype:first `$params `parentproctype;
-  .lg.o[`init;"read in process parameter of parentproctype=",string parentproctype]];
-
-// If any of the required parameters are null, try to read them from a file
-// The file can come from the command line, or from the environment path
 file:$[`procfile in key params; 
-  first `$params `procfile;
-  first getconfigfile["process.csv"]];
+	first `$params `procfile;
+ 	first getconfigfile["process.csv"]];
 
 // read the process file and convert port field to integer list and all other fields
 // to symbol lists
 readprocs:{[file]
-  // Updates the process table to convert strings to integer and symbols
-  updateprocs:{
-    // Gets the value of the input expression and returns it as an integer
-    // list if the expression can be evaluated, else return null
-    errcheckport:{@[{"I"$string value x};x;0N]};
-    
-    // begin updating process file table
-    t:update port:errcheckport each .rmvr.removeenvvar each port from x;
-    t:update host:"S"$.rmvr.removeenvvar each host from t;
-    t:update procname:"S"$.rmvr.removeenvvar each procname from t;
-    t:update proctype:"S"$.rmvr.removeenvvar each proctype from t;
-    // return updated process file table
-    t
-    };
-  // error trap loading and processing of process file and returns finished table
-  @[updateprocs ("****";enlist",")0:;file;
-  {.lg.e[`procfile;"failed to read process file ",(string x)," : ",y]}[file]]
-  }
+	// Updates the process table to convert strings to integer and symbols
+	updateprocs:{
+		// Gets the value of the input expression and returns it as an integer
+		// list if the expression can be evaluated, else return null
+		errcheckport:{@[{"I"$string value x};x;0N]};
+		
+		// begin updating process file table
+		t:update port:errcheckport each .rmvr.removeenvvar each port from x;
+		t:update host:"S"$.rmvr.removeenvvar each host from t;
+		t:update procname:"S"$.rmvr.removeenvvar each procname from t;
+		t:update proctype:"S"$.rmvr.removeenvvar each proctype from t;
+		// return updated process file table
+		t
+		};
+	// error trap loading and processing of process file and returns finished table
+	@[updateprocs ("****";enlist",")0:;file;
+	{.lg.e[`procfile;"failed to read process file ",(string x)," : ",y]}[file]]
+	}
 
 // Read in the processfile
 // Pull out the applicable rows
 readprocfile:{[file]
-  //order of preference for hostnames
-  prefs:(.z.h;`$"." sv string "i"$0x0 vs .z.a;`localhost);
-  res:@[{t:select from readprocs[file] where not null host;
-  // allow host=localhost for ease of startup
-  $[not any null `.proc req;
-    select from t where proctype=.proc.proctype,procname=.proc.procname;
-    select from t where abs[port]=abs system"p",(lower[host]=lower .z.h) or (host=`localhost) or host=`$"." sv string "i"$0x0 vs .z.a]
-    };file;{.err.ex[`init;"failed to read process file ",(string x)," : ",y;2]}[file]];
-    if[0=count res;
-    .lg.o[`readprocfile;"failed to read any rows from ",(string file)," which relate to this process; Host=",(string .z.h),", IP=",("." sv string "i"$0x0 vs .z.a),", port=",string system"p"];
-    :`host`port`proctype`procname!(`;0;proctype;procname)];
-    // if more than one result, take the most preferred one
-  output:$[1<count res;
-    // map hostnames in res to order of preference, select most preferred
-    first res iasc prefs?res[`host];
-    first res];
-  if[not output[`port] = system"p";
-    @[system;"p ",string[output[`port]];.err.ex[`readprocfile;"failed to set port to ",string[output[`port]]]];
-    .lg.o[`readprocfile;"port set to ",string[output[`port]]]
-    ];
-  output
-  } 
+	//order of preference for hostnames
+	prefs:(.z.h;`$"." sv string "i"$0x0 vs .z.a;`localhost);
+	res:@[{t:select from readprocs[file] where not null host;
+	// allow host=localhost for ease of startup
+	$[not any null `.proc req;
+		select from t where proctype=.proc.proctype,procname=.proc.procname;
+		select from t where abs[port]=abs system"p",(lower[host]=lower .z.h) or (host=`localhost) or host=`$"." sv string "i"$0x0 vs .z.a]
+		};file;{.err.ex[`init;"failed to read process file ",(string x)," : ",y;2]}[file]];
+		if[0=count res;
+		.lg.o[`readprocfile;"failed to read any rows from ",(string file)," which relate to this process; Host=",(string .z.h),", IP=",("." sv string "i"$0x0 vs .z.a),", port=",string system"p"];
+		:`host`port`proctype`procname!(`;0;proctype;procname)];
+		// if more than one result, take the most preferred one
+	output:$[1<count res;
+		// map hostnames in res to order of preference, select most preferred
+		first res iasc prefs?res[`host];
+		first res];
+	if[not output[`port] = system"p";
+		@[system;"p ",string[output[`port]];.err.ex[`readprocfile;"failed to set port to ",string[output[`port]]]];
+		.lg.o[`readprocfile;"port set to ",string[output[`port]]]
+		];
+	output
+	}	
 
 .lg.o[`init;"attempting to read required process parameters ",("," sv string req)," from file ",string file];
 // Read in the file, pull out the rows which are applicable and set the local variables
@@ -413,8 +411,8 @@ readprocfile:{[file]
 
 // Check if all the required variables have now been set properly
 $[any null `.proc req;
-  .err.ex[`init;"not all required variables have been set - missing ",(" " sv string req where null `.proc req);2]; 
-  .lg.o[`init;"read in process parameters of ","; " sv "=" sv' string flip(req;`.proc req)]]
+	.err.ex[`init;"not all required variables have been set - missing ",(" " sv string req where null `.proc req);2];	
+	.lg.o[`init;"read in process parameters of ","; " sv "=" sv' string flip(req;`.proc req)]]
 
 // reset the logging functions to now use the name of the process
 .lg.o:.lg.l[`INF;proctype;procname;;;()!()]
@@ -425,35 +423,35 @@ $[any null `.proc req;
 // if alias is not null, a softlink will be created back to the actual file
 // handle can either be 1 or 2
 fileredirect:{[logdir;filename;alias;handle]
-  if[not (h:string handle) in (enlist "1";enlist "2"); 
-    '"handle must be 1 or 2"];
-  .lg.o[`logging;"re-directing ",h," to",f:" ",logdir,"/",filename];
-  @[system;s;{.lg.e[`logging;"failed to redirect ",x," : ",y]}[s:h,f]];
-  if[not null `$alias; createalias[logdir;filename;alias]]}
+	if[not (h:string handle) in (enlist "1";enlist "2"); 
+		'"handle must be 1 or 2"];
+	.lg.o[`logging;"re-directing ",h," to",f:" ",logdir,"/",filename];
+	@[system;s;{.lg.e[`logging;"failed to redirect ",x," : ",y]}[s:h,f]];
+	if[not null `$alias; createalias[logdir;filename;alias]]}
 
 createalias:{[logdir;filename;alias] 
-  $[.z.o like "w*"; 
-      .lg.o[`logging;"cannot create alias on windows OS"];
-    [.lg.o[`logging;"creating alias using command ",s:"ln -sf ",filename," ",logdir,"/",alias];
-     @[system;s;{.lg.e[`init;"failed to create alias ",x," : ",y]}[s]]]]}
+	$[.z.o like "w*"; 
+  		.lg.o[`logging;"cannot create alias on windows OS"];
+ 		[.lg.o[`logging;"creating alias using command ",s:"ln -sf ",filename," ",logdir,"/",alias];
+		 @[system;s;{.lg.e[`init;"failed to create alias ",x," : ",y]}[s]]]]}
 
 // Create log files
 // logname = base of log file
 // timestamp = optional timestamp value (e.g. .z.d, .z.p)
 // makealias = if true, will create alias files without the timestamp value
 createlog:{[logdir;logname;timestamp;suppressalias]
-  basename:(string logname),"_",(string timestamp),".log";
-  alias:$[suppressalias;"";(string logname),".log"];
-  fileredirect[logdir;"err_",basename;"err_",alias;2];
-  fileredirect[logdir;"out_",basename;"out_",alias;1];
-  .lg.banner[]}
+	basename:(string logname),"_",(string timestamp),".log";
+	alias:$[suppressalias;"";(string logname),".log"];
+	fileredirect[logdir;"err_",basename;"err_",alias;2];
+	fileredirect[logdir;"out_",basename;"out_",alias;1];
+	.lg.banner[]}
 
 // function to produce the timestamp value for the log file
 logtimestamp:@[value;`logtimestamp;{[x] {[]`$ssr[;;"_"]/[string .z.z;".:T"]}}]
 
 rolllogauto:{[] 
-  .lg.o[`logging;"creating standard out and standard err logs"];
-  createlog[getenv`KDBLOG;procname;logtimestamp[];`suppressalias in key params]}
+	.lg.o[`logging;"creating standard out and standard err logs"];
+	createlog[getenv`KDBLOG;procname;logtimestamp[];`suppressalias in key params]}
 
 // Create log files as long as they haven't been switched off 
 if[not any `debug`noredirect in key params; rolllogauto[]];
@@ -461,109 +459,109 @@ if[not any `debug`noredirect in key params; rolllogauto[]];
 // utilities to load individual files / paths, and also a complete directory
 // this should then be enough to bootstrap
 loadf:{
-  .lg.o[`fileload;"loading ",x];
-  
-  $[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
-  .lg.o[`fileload;"successfully loaded ",x]}
+	.lg.o[`fileload;"loading ",x];
+	
+	$[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
+	.lg.o[`fileload;"successfully loaded ",x]}
 
 loaddir:{
-  .lg.o[`fileload;"loading q and k files from directory ",x];
-  // Check the directory exists
-  $[()~files:key hsym `$x; .lg.o[`fileload;"specified directory ",x," doesn't exist"];
-  // Try to read in a load order file
-    [
-          $[`order.txt in files:key hsym `$x;
-                  [.lg.o[`fileload;"found load order file order.txt"];
-                  order:(`$read0 `$x,"/order.txt") inter files;
-                  .lg.o[`fileload;"loading files in order "," " sv string order]];
-                  order:`symbol$()];
-          files:files where any files like/: ("*.q";"*.k");
-          // rearrange the ordering
-          files:order,files except order;
-          loadf each (x,"/"),/:string files
-    ]
-  ];
-  }
+	.lg.o[`fileload;"loading q and k files from directory ",x];
+	// Check the directory exists
+	$[()~files:key hsym `$x; .lg.o[`fileload;"specified directory ",x," doesn't exist"];
+	// Try to read in a load order file
+		[
+        	$[`order.txt in files:key hsym `$x;
+                	[.lg.o[`fileload;"found load order file order.txt"];
+                 	order:(`$read0 `$x,"/order.txt") inter files;
+                 	.lg.o[`fileload;"loading files in order "," " sv string order]];
+                	order:`symbol$()];
+        	files:files where any files like/: ("*.q";"*.k");
+        	// rearrange the ordering
+        	files:order,files except order;
+        	loadf each (x,"/"),/:string files
+		]
+	];
+	}
 
 // load a config file
 loadconfig:{
-  file:x,(string y),".q";
-  $[()~key hsym`$file;
-    .lg.o[`fileload;"config file ",file," not found"];
-    [.lg.o[`fileload;"config file ",file," found"];
-     loadf file]]}
+	file:x,(string y),".q";
+	$[()~key hsym`$file;
+		.lg.o[`fileload;"config file ",file," not found"];
+		[.lg.o[`fileload;"config file ",file," found"];
+		 loadf file]]}
 
 // Get the attributes of this process.  This should be overridden for each process
 getattributes:{()!()}
 
 // override config variables with parameters from the commandline
 overrideconfig:{[params]
-  // work out which are the potential variables to override
-  ov:key[params] where key[params] like ".*";
-  // can only can do those which are already set 
-  ov:ov where @[{value x;1b};;0b] each ov;
-  if[count ov;
-    .lg.o[`init;"attempting to override variables ",("," sv string ov)," from the command line"];
-    {if[not (abs t:type value y) within (1;-1+count .Q.t);
-      .lg.e[`init;"Cannot override ",(string y)," as it is not a basic type"];
-      :()];
-     // parse out the values 
-     vals:(upper .Q.t abs t)$'x[y];
-     if[t<0;vals:first vals];
-     // check for nulls
-     if[any null each vals; .lg.e[`init;"Cannot override ",(string y)," with command line parameters as null values have been supplied"]];
-     .lg.o[`init;"Setting ",(string y)," to ",-3!vals];
-     set[y;vals]}[params] each ov]} 
+	// work out which are the potential variables to override
+	ov:key[params] where key[params] like ".*";
+	// can only can do those which are already set 
+	ov:ov where @[{value x;1b};;0b] each ov;
+	if[count ov;
+		.lg.o[`init;"attempting to override variables ",("," sv string ov)," from the command line"];
+		{if[not (abs t:type value y) within (1;-1+count .Q.t);
+			.lg.e[`init;"Cannot override ",(string y)," as it is not a basic type"];
+			:()];
+		 // parse out the values 
+		 vals:(upper .Q.t abs t)$'x[y];
+		 if[t<0;vals:first vals];
+		 // check for nulls
+		 if[any null each vals; .lg.e[`init;"Cannot override ",(string y)," with command line parameters as null values have been supplied"]];
+		 .lg.o[`init;"Setting ",(string y)," to ",-3!vals];
+		 set[y;vals]}[params] each ov]}	
 
 override:{overrideconfig[.proc.params]}
 
 loadspeccode:{[ext;dir]
-  $[""~getenv dir;
-   .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
-   loaddir getenv[dir],ext
+	$[""~getenv dir;
+	 .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
+	 loaddir getenv[dir],ext
    ];
-  };
+	};
 
 reloadcommoncode:{
-  // Load common code from each directory if it exists
-  loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-  };
+	// Load common code from each directory if it exists
+	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 reloadparentprocesscode:{
-  // Load proctype code from each directory if it exists
+  // Load parentproctype code from each directory if it exists
   loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
   };
 reloadprocesscode:{
-  // Load proctype code from each directory if it exists
-  loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-  };
+	// Load proctype code from each directory if it exists
+	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 reloadnamecode:{
-  // Load procname code from each directory if it exists
-  loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-  };
+	// Load procname code from each directory if it exists
+	loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 
 \d . 
 // Load configuration
 // TorQ loads configuration modules in the order: TorQ Default, Service Specific and then Application Specific
 // Each module loads configuration in the order: default configuration, then process type specific, then process specific
 if[not `noconfig in key .proc.params;
-  // load TorQ Default configuration module
-  .proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
+	// load TorQ Default configuration module
+	.proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
   // check if KDBSERVCONFIG is set and load Service Layer specific configuration module
   $[""~getenv`KDBSERVCONFIG;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG not set, not loading app specific config"];
     [.proc.servconfig:getenv[`KDBAPPCONFIG],"/settings/";
     .lg.o[`fileload;"environment variable KDBSERVCONFIG set, loading app specific config from ",.proc.servconfig];
-    .proc.loadconfig[.proc.servconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
+    .proc.loadconfig[.proc.servconfig;] each `default,.proc.proctype,.proc.procname]
   ];
-  // check if KDBAPPCONFIG is set and load Appliation specific configuration module 
-  $[""~getenv`KDBAPPCONFIG; 
-    .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
-    [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
-    .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
-    .proc.loadconfig[.proc.appconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
+	// check if KDBAPPCONFIG is set and load Appliation specific configuration module 
+  $[""~getenv`KDBAPPCONFIG;	
+	  .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
+	  [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
+	  .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
+	  .proc.loadconfig[.proc.appconfig;] each `default,.proc.proctype,.proc.procname]
   ];
-  // Override config from the command line
-  .proc.override[]]
+	// Override config from the command line
+	.proc.override[]]
 
 // Load library code 
 .proc.loadcommoncode:@[value;`.proc.loadcommoncode;1b];
@@ -582,25 +580,25 @@ if[.proc.loadprocesscode;.proc.reloadprocesscode[]]
 if[.proc.loadnamecode;.proc.reloadnamecode[]]
 
 if[`loaddir in key .proc.params;
-  .lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];
-  .proc.loaddir each .proc.params`loaddir]
+	.lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];
+	.proc.loaddir each .proc.params`loaddir]
 
 // Load message handlers after all the other library code
 .proc.loaddir each(getenv$[.proc.loadhandlers & not ""~getenv`KDBSERVCODE;`KDBCODE`KDBSERVCODE;(),`KDBCODE]),\:"/handlers";
 
 // If the timer is loaded, and logrolling is set to true, try to log the roll file on a daily basis
 if[.proc.logroll and not any `debug`noredirect in key .proc.params;
-  $[@[value;`.timer.enabled;0b];
-    [.lg.o[`init;"adding timer function to roll std out/err logs on a daily schedule starting at ",string `timestamp$(.proc.cd[]+1)+00:00];
-     .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.proc.rolllogauto;`);0h;"roll standard out/standard error logs";1b]];
-    .lg.e[`init;".proc.logroll is set to true, but timer functionality is not loaded - cannot roll logs"]]];
-  
+	$[@[value;`.timer.enabled;0b];
+		[.lg.o[`init;"adding timer function to roll std out/err logs on a daily schedule starting at ",string `timestamp$(.proc.cd[]+1)+00:00];
+		 .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.proc.rolllogauto;`);0h;"roll standard out/standard error logs";1b]];
+		.lg.e[`init;".proc.logroll is set to true, but timer functionality is not loaded - cannot roll logs"]]];
+	
 // Load the file specified on the command line
 if[`load in key .proc.params; .proc.loadf each .proc.params`load]
 
 if[any`debug`nopi in key .proc.params;
-  .lg.o[`init;"Resetting .z.pi to kdb+ default value"];
-  .z.pi:show@value@;]
+	.lg.o[`init;"Resetting .z.pi to kdb+ default value"];
+	.z.pi:show@value@;]
 
 // initialise pubsub
 if[@[value;`.ps.loaded;0b]; .ps.initialise[]]
@@ -609,12 +607,12 @@ if[@[value;`.servers.STARTUP;0b]; .servers.startup[]]
 
 // function to execute functions in .proc.initlist
 .proc.init:{
-  $[count .proc.initlist;
-    [{[a].lg.o[`init;"attemping to run initialisation: ",-3!a];
-    @[value;a;
-    {[x;a].lg.e[`init;x," error - failed to run initialisation: ",-3!a]}[;a]]}
-    each .proc.initlist;.proc.initlist:()];
-    .lg.o[`init;"no initialisation functions found"]];
+	$[count .proc.initlist;
+		[{[a].lg.o[`init;"attemping to run initialisation: ",-3!a];
+		@[value;a;
+		{[x;a].lg.e[`init;x," error - failed to run initialisation: ",-3!a]}[;a]]}
+		each .proc.initlist;.proc.initlist:()];
+		.lg.o[`init;"no initialisation functions found"]];
  }
 
 if[count .proc.initlist;.proc.init[]]

--- a/torq.q
+++ b/torq.q
@@ -528,9 +528,9 @@ reloadcommoncode:{
 	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
 	};
 reloadparentprocesscode:{
-  // Load parentproctype code from each directory if it exists
-  loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-  };
+    // Load parentproctype code from each directory if it exists
+    loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+    };
 reloadprocesscode:{
 	// Load proctype code from each directory if it exists
 	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];

--- a/torq.q
+++ b/torq.q
@@ -82,9 +82,9 @@ configusage:@[value;`configusage;"Config management:
 helpusage:@[value;`helpusage;"Help: 
  if help.q from code.kx is loaded, use help` for more information.
  if api.q is loaded, you should be able to access api information from the commandline.  Use 
-	.api.f[symbol or string pattern] e.g. .api.f[`proc] to find a function/variable
-	.api.p[symbol or string pattern] e.g. .api.p[`timer] to find a publically marked function/variable
-	.api.u[symbol or string pattern] e.g. .api.u[`] to find a publically marked, user defined function (i.e. don't show .q functions)"] 
+  .api.f[symbol or string pattern] e.g. .api.f[`proc] to find a function/variable
+  .api.p[symbol or string pattern] e.g. .api.p[`timer] to find a publically marked function/variable
+  .api.u[symbol or string pattern] e.g. .api.u[`] to find a publically marked, user defined function (i.e. don't show .q functions)"] 
 
 // If the usage value has been overridden, use that.  Else concat the req environment, with the stdoptions, with the extra usage info
 getusage:{@[value;`.proc.usage;generalusage,"\n\n",envusage,"\n\n",envoptusage,"\n\n",stdoptionusage,"\n\n",extrausage,"\n\n",configusage,"\n\n",helpusage,"\n\n"]}
@@ -101,7 +101,7 @@ envvars:distinct `KDBCODE`KDBCONFIG`KDBLOG`KDBHTML`KDBLIB,envvars
 qhome:{q:getenv[`QHOME]; if[q~""; q:$[.z.o like "w*"; "c:/q"; getenv[`HOME],"/q"]]; q}
 settorqenv:{[envvar; default] 
  if[""~getenv[envvar]; 
-  .lg.o[`init;(string envvar)," is not defined. Defining it to ",val:qhome[],"/",default];	
+  .lg.o[`init;(string envvar)," is not defined. Defining it to ",val:qhome[],"/",default];  
   setenv[envvar; val]];}
 
 // make sure the path separators are the right way around if running on windows
@@ -200,11 +200,11 @@ pubmap:@[value;`pubmap;`ERROR`ERR`INF`WARN!1 1 0 1]
 
 // Log a message
 l:{[loglevel;proctype;proc;id;message;dict]
-	$[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
-		neg[redir] .lg.format[loglevel;proctype;proc;id;message];
-		ext[loglevel;proctype;proc;id;message;dict]];
-        publish[loglevel;proctype;proc;id;message];	
-	}
+  $[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
+    neg[redir] .lg.format[loglevel;proctype;proc;id;message];
+    ext[loglevel;proctype;proc;id;message;dict]];
+        publish[loglevel;proctype;proc;id;message]; 
+  }
 
 // Log an error.  
 // If the process is fully initialised, throw the error
@@ -212,9 +212,9 @@ l:{[loglevel;proctype;proc;id;message;dict]
 err:{[loglevel;proctype;proc;id;message;dict]
         l[loglevel;proctype;proc;id;message;dict];
         if[.proc.stop;'message];
- 	if[.proc.initialised;:()];
+  if[.proc.initialised;:()];
         if[not .proc.trap; exit 3];
-	}
+  }
 
 // log out and log err
 // The process name is temporary which we will reset later - once we know what type of process this is
@@ -259,21 +259,21 @@ usage:{ex[`usage;.proc.getusage[];1]}
 
 // Throw an error if all the required parameters aren't passed in
 param:{[paramdict;reqparams] 
-	if[count missing:(reqparams,:()) except key paramdict; 
-		.lg.e[`init;"missing required command line parameter(s) "," " sv string missing];
-		usage[]]}
+  if[count missing:(reqparams,:()) except key paramdict; 
+    .lg.e[`init;"missing required command line parameter(s) "," " sv string missing];
+    usage[]]}
 
 // Throw an error if all the requried envinonment variables aren't set
 env:{[reqenv]
-	if[count missing:reqenv where 0=count each getenv each reqenv,:();
-		.lg.e[`init;"required environment variable(s) not set - "," " sv string missing];
-		usage[]]}
+  if[count missing:reqenv where 0=count each getenv each reqenv,:();
+    .lg.e[`init;"required environment variable(s) not set - "," " sv string missing];
+    usage[]]}
 
 // Check if a variable is null
 exitifnull:{[variable] 
-	if[null value variable; 
-		.lg.e[`init;"Variable ",(string variable)," is null but must be set"];
-		usage[]]}
+  if[null value variable; 
+    .lg.e[`init;"Variable ",(string variable)," is null but must be set"];
+    usage[]]}
 
 
 // Function for replacing environment variables with the associated full path
@@ -281,17 +281,17 @@ exitifnull:{[variable]
 \d .rmvr
 
 removeenvvar:{
- 	// positions of {}
-	pos:ss[x]each"{}";
-	// check the formatting is ok
-	$[0=count first pos; :x;
-	1<count distinct count each pos; '"environment variable contains unmatched brackets: ",x;
-	(any pos[0]>pos[1]) or any pos[0]<prev pos[1]; '"failed to match environment variable brackets on supplied string: ",x;
-	()];
+  // positions of {}
+  pos:ss[x]each"{}";
+  // check the formatting is ok
+  $[0=count first pos; :x;
+  1<count distinct count each pos; '"environment variable contains unmatched brackets: ",x;
+  (any pos[0]>pos[1]) or any pos[0]<prev pos[1]; '"failed to match environment variable brackets on supplied string: ",x;
+  ()];
 
-	// cut out each environment variable, and retrieve the meaning
-	raze {$["{"=first x;getenv`$1 _ -1 _ x;x]}each (raze flip 0 1+pos) cut x}		
-		
+  // cut out each environment variable, and retrieve the meaning
+  raze {$["{"=first x;getenv`$1 _ -1 _ x;x]}each (raze flip 0 1+pos) cut x}   
+    
 // Process initialisation
 \d .proc
 
@@ -301,8 +301,8 @@ params:.Q.opt .z.x
 if[`usage in key params; -1 .proc.getusage[]; exit 0];
 
 $[`localtime in key .proc.params;
-	[cp:{.z.P};cd:{.z.D};ct:{.z.T}];
-	[cp:{.z.p};cd:{.z.d};ct:{.z.t}]];
+  [cp:{.z.P};cd:{.z.D};ct:{.z.T}];
+  [cp:{.z.p};cd:{.z.d};ct:{.z.t}]];
 
 localtime:`localtime in key .proc.params
 
@@ -329,81 +329,83 @@ settorqenv'[`KDBCODE`KDBCONFIG`KDBLOG`KDBLIB`KDBHTML;("code";"config";"logs";"li
 // The could also be set in a wrapper script
 reqset:0b
 if[any req in key `.proc;
-	$[all req in key `.proc;
-		$[any null `.proc req;
-			.lg.o[`init;"some of the required process parameters supplied in the  wrapper script are set to null.  All must be set. Resetting all to null"];
-			reqset:1b]; 
-	  .lg.o[`init;"some but not all required process parameters have been set from the wrapper script - resetting all to null"]]];
+  $[all req in key `.proc;
+    $[any null `.proc req;
+      .lg.o[`init;"some of the required process parameters supplied in the  wrapper script are set to null.  All must be set. Resetting all to null"];
+      reqset:1b]; 
+    .lg.o[`init;"some but not all required process parameters have been set from the wrapper script - resetting all to null"]]];
 
 if[not reqset; @[`.proc;req;:;`]];
 
 $[count[req] = count req inter key params;
-	[@[`.proc;req;:;first each `$params req];
-	 reqset:1b];
+  [@[`.proc;req;:;first each `$params req];
+   reqset:1b];
   0<count req inter key params;
-	.lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
-  ()];		 
-
-// If parentproctype has been supplied then set it
-parentproctype:$[`parentproctype in key params;
-  first `$params `parentproctype;
-  ()];
+  .lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
+  ()];     
 
 checkdependency[getconfig["dependency.csv";1]]
 
 // If any of the required parameters are null, try to read them from a file
 // The file can come from the command line, or from the environment path
+parentproctype:();
+if[`parentproctype in key params; 
+  parentproctype:first `$params `parentproctype;
+  .lg.o[`init;"read in process parameter of parentproctype=",string parentproctype]];
+
+// If any of the required parameters are null, try to read them from a file
+// The file can come from the command line, or from the environment path
 file:$[`procfile in key params; 
-	first `$params `procfile;
- 	first getconfigfile["process.csv"]];
+  first `$params `procfile;
+  first getconfigfile["process.csv"]];
 
 // read the process file and convert port field to integer list and all other fields
 // to symbol lists
 readprocs:{[file]
-	// Updates the process table to convert strings to integer and symbols
-	updateprocs:{
-		// Gets the value of the input expression and returns it as an integer
-		// list if the expression can be evaluated, else return null
-		errcheckport:{@[{"I"$string value x};x;0N]};
-		
-		// begin updating process file table
-		t:update port:errcheckport each .rmvr.removeenvvar each port from x;
-		t:update host:"S"$.rmvr.removeenvvar each host from t;
-		t:update procname:"S"$.rmvr.removeenvvar each procname from t;
-		t:update proctype:"S"$.rmvr.removeenvvar each proctype from t;
-		// return updated process file table
-		t
-		};
-	// error trap loading and processing of process file and returns finished table
-	@[updateprocs ("****";enlist",")0:;file;
-	{.lg.e[`procfile;"failed to read process file ",(string x)," : ",y]}[file]]
-	}
+  // Updates the process table to convert strings to integer and symbols
+  updateprocs:{
+    // Gets the value of the input expression and returns it as an integer
+    // list if the expression can be evaluated, else return null
+    errcheckport:{@[{"I"$string value x};x;0N]};
+    
+    // begin updating process file table
+    t:update port:errcheckport each .rmvr.removeenvvar each port from x;
+    t:update host:"S"$.rmvr.removeenvvar each host from t;
+    t:update procname:"S"$.rmvr.removeenvvar each procname from t;
+    t:update proctype:"S"$.rmvr.removeenvvar each proctype from t;
+    // return updated process file table
+    t
+    };
+  // error trap loading and processing of process file and returns finished table
+  @[updateprocs ("****";enlist",")0:;file;
+  {.lg.e[`procfile;"failed to read process file ",(string x)," : ",y]}[file]]
+  }
 
 // Read in the processfile
 // Pull out the applicable rows
 readprocfile:{[file]
-	//order of preference for hostnames
-	prefs:(.z.h;`$"." sv string "i"$0x0 vs .z.a;`localhost);
-	res:@[{t:select from readprocs[file] where not null host;
-	// allow host=localhost for ease of startup
-	$[not any null `.proc req;
-		select from t where proctype=.proc.proctype,procname=.proc.procname;
-		select from t where abs[port]=abs system"p",(lower[host]=lower .z.h) or (host=`localhost) or host=`$"." sv string "i"$0x0 vs .z.a]
-		};file;{.err.ex[`init;"failed to read process file ",(string x)," : ",y;2]}[file]];
-		if[0=count res;
-		.lg.o[`readprocfile;"failed to read any rows from ",(string file)," which relate to this process; Host=",(string .z.h),", IP=",("." sv string "i"$0x0 vs .z.a),", port=",string system"p"];
-		:`host`port`proctype`procname!(`;0;proctype;procname)];
-		// if more than one result, take the most preferred one
-	output:$[1<count res;
-		// map hostnames in res to order of preference, select most preferred
-		first res iasc prefs?res[`host];
-		first res];
-	if[not output[`port] = system"p";
-		@[system;"p ",string[output[`port]];.err.ex[`readprocfile;"failed to set port to ",string[output[`port]]]];
-		.lg.o[`readprocfile;"port set to ",string[output[`port]]]
-		];
-	output
-	}	
+  //order of preference for hostnames
+  prefs:(.z.h;`$"." sv string "i"$0x0 vs .z.a;`localhost);
+  res:@[{t:select from readprocs[file] where not null host;
+  // allow host=localhost for ease of startup
+  $[not any null `.proc req;
+    select from t where proctype=.proc.proctype,procname=.proc.procname;
+    select from t where abs[port]=abs system"p",(lower[host]=lower .z.h) or (host=`localhost) or host=`$"." sv string "i"$0x0 vs .z.a]
+    };file;{.err.ex[`init;"failed to read process file ",(string x)," : ",y;2]}[file]];
+    if[0=count res;
+    .lg.o[`readprocfile;"failed to read any rows from ",(string file)," which relate to this process; Host=",(string .z.h),", IP=",("." sv string "i"$0x0 vs .z.a),", port=",string system"p"];
+    :`host`port`proctype`procname!(`;0;proctype;procname)];
+    // if more than one result, take the most preferred one
+  output:$[1<count res;
+    // map hostnames in res to order of preference, select most preferred
+    first res iasc prefs?res[`host];
+    first res];
+  if[not output[`port] = system"p";
+    @[system;"p ",string[output[`port]];.err.ex[`readprocfile;"failed to set port to ",string[output[`port]]]];
+    .lg.o[`readprocfile;"port set to ",string[output[`port]]]
+    ];
+  output
+  } 
 
 .lg.o[`init;"attempting to read required process parameters ",("," sv string req)," from file ",string file];
 // Read in the file, pull out the rows which are applicable and set the local variables
@@ -411,8 +413,8 @@ readprocfile:{[file]
 
 // Check if all the required variables have now been set properly
 $[any null `.proc req;
-	.err.ex[`init;"not all required variables have been set - missing ",(" " sv string req where null `.proc req);2];	
-	.lg.o[`init;"read in process parameters of ","; " sv "=" sv' string flip(req;`.proc req)]]
+  .err.ex[`init;"not all required variables have been set - missing ",(" " sv string req where null `.proc req);2]; 
+  .lg.o[`init;"read in process parameters of ","; " sv "=" sv' string flip(req;`.proc req)]]
 
 // reset the logging functions to now use the name of the process
 .lg.o:.lg.l[`INF;proctype;procname;;;()!()]
@@ -423,35 +425,35 @@ $[any null `.proc req;
 // if alias is not null, a softlink will be created back to the actual file
 // handle can either be 1 or 2
 fileredirect:{[logdir;filename;alias;handle]
-	if[not (h:string handle) in (enlist "1";enlist "2"); 
-		'"handle must be 1 or 2"];
-	.lg.o[`logging;"re-directing ",h," to",f:" ",logdir,"/",filename];
-	@[system;s;{.lg.e[`logging;"failed to redirect ",x," : ",y]}[s:h,f]];
-	if[not null `$alias; createalias[logdir;filename;alias]]}
+  if[not (h:string handle) in (enlist "1";enlist "2"); 
+    '"handle must be 1 or 2"];
+  .lg.o[`logging;"re-directing ",h," to",f:" ",logdir,"/",filename];
+  @[system;s;{.lg.e[`logging;"failed to redirect ",x," : ",y]}[s:h,f]];
+  if[not null `$alias; createalias[logdir;filename;alias]]}
 
 createalias:{[logdir;filename;alias] 
-	$[.z.o like "w*"; 
-  		.lg.o[`logging;"cannot create alias on windows OS"];
- 		[.lg.o[`logging;"creating alias using command ",s:"ln -sf ",filename," ",logdir,"/",alias];
-		 @[system;s;{.lg.e[`init;"failed to create alias ",x," : ",y]}[s]]]]}
+  $[.z.o like "w*"; 
+      .lg.o[`logging;"cannot create alias on windows OS"];
+    [.lg.o[`logging;"creating alias using command ",s:"ln -sf ",filename," ",logdir,"/",alias];
+     @[system;s;{.lg.e[`init;"failed to create alias ",x," : ",y]}[s]]]]}
 
 // Create log files
 // logname = base of log file
 // timestamp = optional timestamp value (e.g. .z.d, .z.p)
 // makealias = if true, will create alias files without the timestamp value
 createlog:{[logdir;logname;timestamp;suppressalias]
-	basename:(string logname),"_",(string timestamp),".log";
-	alias:$[suppressalias;"";(string logname),".log"];
-	fileredirect[logdir;"err_",basename;"err_",alias;2];
-	fileredirect[logdir;"out_",basename;"out_",alias;1];
-	.lg.banner[]}
+  basename:(string logname),"_",(string timestamp),".log";
+  alias:$[suppressalias;"";(string logname),".log"];
+  fileredirect[logdir;"err_",basename;"err_",alias;2];
+  fileredirect[logdir;"out_",basename;"out_",alias;1];
+  .lg.banner[]}
 
 // function to produce the timestamp value for the log file
 logtimestamp:@[value;`logtimestamp;{[x] {[]`$ssr[;;"_"]/[string .z.z;".:T"]}}]
 
 rolllogauto:{[] 
-	.lg.o[`logging;"creating standard out and standard err logs"];
-	createlog[getenv`KDBLOG;procname;logtimestamp[];`suppressalias in key params]}
+  .lg.o[`logging;"creating standard out and standard err logs"];
+  createlog[getenv`KDBLOG;procname;logtimestamp[];`suppressalias in key params]}
 
 // Create log files as long as they haven't been switched off 
 if[not any `debug`noredirect in key params; rolllogauto[]];
@@ -459,109 +461,109 @@ if[not any `debug`noredirect in key params; rolllogauto[]];
 // utilities to load individual files / paths, and also a complete directory
 // this should then be enough to bootstrap
 loadf:{
-	.lg.o[`fileload;"loading ",x];
-	
-	$[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
-	.lg.o[`fileload;"successfully loaded ",x]}
+  .lg.o[`fileload;"loading ",x];
+  
+  $[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
+  .lg.o[`fileload;"successfully loaded ",x]}
 
 loaddir:{
-	.lg.o[`fileload;"loading q and k files from directory ",x];
-	// Check the directory exists
-	$[()~files:key hsym `$x; .lg.o[`fileload;"specified directory ",x," doesn't exist"];
-	// Try to read in a load order file
-		[
-        	$[`order.txt in files:key hsym `$x;
-                	[.lg.o[`fileload;"found load order file order.txt"];
-                 	order:(`$read0 `$x,"/order.txt") inter files;
-                 	.lg.o[`fileload;"loading files in order "," " sv string order]];
-                	order:`symbol$()];
-        	files:files where any files like/: ("*.q";"*.k");
-        	// rearrange the ordering
-        	files:order,files except order;
-        	loadf each (x,"/"),/:string files
-		]
-	];
-	}
+  .lg.o[`fileload;"loading q and k files from directory ",x];
+  // Check the directory exists
+  $[()~files:key hsym `$x; .lg.o[`fileload;"specified directory ",x," doesn't exist"];
+  // Try to read in a load order file
+    [
+          $[`order.txt in files:key hsym `$x;
+                  [.lg.o[`fileload;"found load order file order.txt"];
+                  order:(`$read0 `$x,"/order.txt") inter files;
+                  .lg.o[`fileload;"loading files in order "," " sv string order]];
+                  order:`symbol$()];
+          files:files where any files like/: ("*.q";"*.k");
+          // rearrange the ordering
+          files:order,files except order;
+          loadf each (x,"/"),/:string files
+    ]
+  ];
+  }
 
 // load a config file
 loadconfig:{
-	file:x,(string y),".q";
-	$[()~key hsym`$file;
-		.lg.o[`fileload;"config file ",file," not found"];
-		[.lg.o[`fileload;"config file ",file," found"];
-		 loadf file]]}
+  file:x,(string y),".q";
+  $[()~key hsym`$file;
+    .lg.o[`fileload;"config file ",file," not found"];
+    [.lg.o[`fileload;"config file ",file," found"];
+     loadf file]]}
 
 // Get the attributes of this process.  This should be overridden for each process
 getattributes:{()!()}
 
 // override config variables with parameters from the commandline
 overrideconfig:{[params]
-	// work out which are the potential variables to override
-	ov:key[params] where key[params] like ".*";
-	// can only can do those which are already set 
-	ov:ov where @[{value x;1b};;0b] each ov;
-	if[count ov;
-		.lg.o[`init;"attempting to override variables ",("," sv string ov)," from the command line"];
-		{if[not (abs t:type value y) within (1;-1+count .Q.t);
-			.lg.e[`init;"Cannot override ",(string y)," as it is not a basic type"];
-			:()];
-		 // parse out the values 
-		 vals:(upper .Q.t abs t)$'x[y];
-		 if[t<0;vals:first vals];
-		 // check for nulls
-		 if[any null each vals; .lg.e[`init;"Cannot override ",(string y)," with command line parameters as null values have been supplied"]];
-		 .lg.o[`init;"Setting ",(string y)," to ",-3!vals];
-		 set[y;vals]}[params] each ov]}	
+  // work out which are the potential variables to override
+  ov:key[params] where key[params] like ".*";
+  // can only can do those which are already set 
+  ov:ov where @[{value x;1b};;0b] each ov;
+  if[count ov;
+    .lg.o[`init;"attempting to override variables ",("," sv string ov)," from the command line"];
+    {if[not (abs t:type value y) within (1;-1+count .Q.t);
+      .lg.e[`init;"Cannot override ",(string y)," as it is not a basic type"];
+      :()];
+     // parse out the values 
+     vals:(upper .Q.t abs t)$'x[y];
+     if[t<0;vals:first vals];
+     // check for nulls
+     if[any null each vals; .lg.e[`init;"Cannot override ",(string y)," with command line parameters as null values have been supplied"]];
+     .lg.o[`init;"Setting ",(string y)," to ",-3!vals];
+     set[y;vals]}[params] each ov]} 
 
 override:{overrideconfig[.proc.params]}
 
 loadspeccode:{[ext;dir]
-	$[""~getenv dir;
-	 .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
-	 loaddir getenv[dir],ext
+  $[""~getenv dir;
+   .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
+   loaddir getenv[dir],ext
    ];
-	};
+  };
 
 reloadcommoncode:{
-	// Load common code from each directory if it exists
-	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-	};
+  // Load common code from each directory if it exists
+  loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+  };
 reloadparentprocesscode:{
-  // Load parentproctype code from each directory if it exists
+  // Load proctype code from each directory if it exists
   loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
   };
 reloadprocesscode:{
-	// Load proctype code from each directory if it exists
-	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-	};
+  // Load proctype code from each directory if it exists
+  loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+  };
 reloadnamecode:{
-	// Load procname code from each directory if it exists
-	loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-	};
+  // Load procname code from each directory if it exists
+  loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+  };
 
 \d . 
 // Load configuration
 // TorQ loads configuration modules in the order: TorQ Default, Service Specific and then Application Specific
 // Each module loads configuration in the order: default configuration, then process type specific, then process specific
 if[not `noconfig in key .proc.params;
-	// load TorQ Default configuration module
-	.proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
+  // load TorQ Default configuration module
+  .proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
   // check if KDBSERVCONFIG is set and load Service Layer specific configuration module
   $[""~getenv`KDBSERVCONFIG;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG not set, not loading app specific config"];
     [.proc.servconfig:getenv[`KDBAPPCONFIG],"/settings/";
     .lg.o[`fileload;"environment variable KDBSERVCONFIG set, loading app specific config from ",.proc.servconfig];
-    .proc.loadconfig[.proc.servconfig;] each `default,.proc.proctype,.proc.procname]
+    .proc.loadconfig[.proc.servconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
-	// check if KDBAPPCONFIG is set and load Appliation specific configuration module 
-  $[""~getenv`KDBAPPCONFIG;	
-	  .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
-	  [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
-	  .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
-	  .proc.loadconfig[.proc.appconfig;] each `default,.proc.proctype,.proc.procname]
+  // check if KDBAPPCONFIG is set and load Appliation specific configuration module 
+  $[""~getenv`KDBAPPCONFIG; 
+    .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
+    [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
+    .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
+    .proc.loadconfig[.proc.appconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
-	// Override config from the command line
-	.proc.override[]]
+  // Override config from the command line
+  .proc.override[]]
 
 // Load library code 
 .proc.loadcommoncode:@[value;`.proc.loadcommoncode;1b];
@@ -580,25 +582,25 @@ if[.proc.loadprocesscode;.proc.reloadprocesscode[]]
 if[.proc.loadnamecode;.proc.reloadnamecode[]]
 
 if[`loaddir in key .proc.params;
-	.lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];
-	.proc.loaddir each .proc.params`loaddir]
+  .lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];
+  .proc.loaddir each .proc.params`loaddir]
 
 // Load message handlers after all the other library code
 .proc.loaddir each(getenv$[.proc.loadhandlers & not ""~getenv`KDBSERVCODE;`KDBCODE`KDBSERVCODE;(),`KDBCODE]),\:"/handlers";
 
 // If the timer is loaded, and logrolling is set to true, try to log the roll file on a daily basis
 if[.proc.logroll and not any `debug`noredirect in key .proc.params;
-	$[@[value;`.timer.enabled;0b];
-		[.lg.o[`init;"adding timer function to roll std out/err logs on a daily schedule starting at ",string `timestamp$(.proc.cd[]+1)+00:00];
-		 .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.proc.rolllogauto;`);0h;"roll standard out/standard error logs";1b]];
-		.lg.e[`init;".proc.logroll is set to true, but timer functionality is not loaded - cannot roll logs"]]];
-	
+  $[@[value;`.timer.enabled;0b];
+    [.lg.o[`init;"adding timer function to roll std out/err logs on a daily schedule starting at ",string `timestamp$(.proc.cd[]+1)+00:00];
+     .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.proc.rolllogauto;`);0h;"roll standard out/standard error logs";1b]];
+    .lg.e[`init;".proc.logroll is set to true, but timer functionality is not loaded - cannot roll logs"]]];
+  
 // Load the file specified on the command line
 if[`load in key .proc.params; .proc.loadf each .proc.params`load]
 
 if[any`debug`nopi in key .proc.params;
-	.lg.o[`init;"Resetting .z.pi to kdb+ default value"];
-	.z.pi:show@value@;]
+  .lg.o[`init;"Resetting .z.pi to kdb+ default value"];
+  .z.pi:show@value@;]
 
 // initialise pubsub
 if[@[value;`.ps.loaded;0b]; .ps.initialise[]]
@@ -607,12 +609,12 @@ if[@[value;`.servers.STARTUP;0b]; .servers.startup[]]
 
 // function to execute functions in .proc.initlist
 .proc.init:{
-	$[count .proc.initlist;
-		[{[a].lg.o[`init;"attemping to run initialisation: ",-3!a];
-		@[value;a;
-		{[x;a].lg.e[`init;x," error - failed to run initialisation: ",-3!a]}[;a]]}
-		each .proc.initlist;.proc.initlist:()];
-		.lg.o[`init;"no initialisation functions found"]];
+  $[count .proc.initlist;
+    [{[a].lg.o[`init;"attemping to run initialisation: ",-3!a];
+    @[value;a;
+    {[x;a].lg.e[`init;x," error - failed to run initialisation: ",-3!a]}[;a]]}
+    each .proc.initlist;.proc.initlist:()];
+    .lg.o[`init;"no initialisation functions found"]];
  }
 
 if[count .proc.initlist;.proc.init[]]

--- a/torq.q
+++ b/torq.q
@@ -82,9 +82,9 @@ configusage:@[value;`configusage;"Config management:
 helpusage:@[value;`helpusage;"Help: 
  if help.q from code.kx is loaded, use help` for more information.
  if api.q is loaded, you should be able to access api information from the commandline.  Use 
-	.api.f[symbol or string pattern] e.g. .api.f[`proc] to find a function/variable
-	.api.p[symbol or string pattern] e.g. .api.p[`timer] to find a publically marked function/variable
-	.api.u[symbol or string pattern] e.g. .api.u[`] to find a publically marked, user defined function (i.e. don't show .q functions)"] 
+    .api.f[symbol or string pattern] e.g. .api.f[`proc] to find a function/variable
+    .api.p[symbol or string pattern] e.g. .api.p[`timer] to find a publically marked function/variable
+    .api.u[symbol or string pattern] e.g. .api.u[`] to find a publically marked, user defined function (i.e. don't show .q functions)"] 
 
 // If the usage value has been overridden, use that.  Else concat the req environment, with the stdoptions, with the extra usage info
 getusage:{@[value;`.proc.usage;generalusage,"\n\n",envusage,"\n\n",envoptusage,"\n\n",stdoptionusage,"\n\n",extrausage,"\n\n",configusage,"\n\n",helpusage,"\n\n"]}
@@ -101,7 +101,7 @@ envvars:distinct `KDBCODE`KDBCONFIG`KDBLOG`KDBHTML`KDBLIB,envvars
 qhome:{q:getenv[`QHOME]; if[q~""; q:$[.z.o like "w*"; "c:/q"; getenv[`HOME],"/q"]]; q}
 settorqenv:{[envvar; default] 
  if[""~getenv[envvar]; 
-  .lg.o[`init;(string envvar)," is not defined. Defining it to ",val:qhome[],"/",default];	
+  .lg.o[`init;(string envvar)," is not defined. Defining it to ",val:qhome[],"/",default];  
   setenv[envvar; val]];}
 
 // make sure the path separators are the right way around if running on windows
@@ -200,11 +200,11 @@ pubmap:@[value;`pubmap;`ERROR`ERR`INF`WARN!1 1 0 1]
 
 // Log a message
 l:{[loglevel;proctype;proc;id;message;dict]
-	$[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
-		neg[redir] .lg.format[loglevel;proctype;proc;id;message];
-		ext[loglevel;proctype;proc;id;message;dict]];
-        publish[loglevel;proctype;proc;id;message];	
-	}
+    $[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
+        neg[redir] .lg.format[loglevel;proctype;proc;id;message];
+        ext[loglevel;proctype;proc;id;message;dict]];
+        publish[loglevel;proctype;proc;id;message]; 
+    }
 
 // Log an error.  
 // If the process is fully initialised, throw the error
@@ -212,9 +212,9 @@ l:{[loglevel;proctype;proc;id;message;dict]
 err:{[loglevel;proctype;proc;id;message;dict]
         l[loglevel;proctype;proc;id;message;dict];
         if[.proc.stop;'message];
- 	if[.proc.initialised;:()];
+    if[.proc.initialised;:()];
         if[not .proc.trap; exit 3];
-	}
+    }
 
 // log out and log err
 // The process name is temporary which we will reset later - once we know what type of process this is
@@ -259,21 +259,21 @@ usage:{ex[`usage;.proc.getusage[];1]}
 
 // Throw an error if all the required parameters aren't passed in
 param:{[paramdict;reqparams] 
-	if[count missing:(reqparams,:()) except key paramdict; 
-		.lg.e[`init;"missing required command line parameter(s) "," " sv string missing];
-		usage[]]}
+    if[count missing:(reqparams,:()) except key paramdict; 
+        .lg.e[`init;"missing required command line parameter(s) "," " sv string missing];
+        usage[]]}
 
 // Throw an error if all the requried envinonment variables aren't set
 env:{[reqenv]
-	if[count missing:reqenv where 0=count each getenv each reqenv,:();
-		.lg.e[`init;"required environment variable(s) not set - "," " sv string missing];
-		usage[]]}
+    if[count missing:reqenv where 0=count each getenv each reqenv,:();
+        .lg.e[`init;"required environment variable(s) not set - "," " sv string missing];
+        usage[]]}
 
 // Check if a variable is null
 exitifnull:{[variable] 
-	if[null value variable; 
-		.lg.e[`init;"Variable ",(string variable)," is null but must be set"];
-		usage[]]}
+    if[null value variable; 
+        .lg.e[`init;"Variable ",(string variable)," is null but must be set"];
+        usage[]]}
 
 
 // Function for replacing environment variables with the associated full path
@@ -281,17 +281,17 @@ exitifnull:{[variable]
 \d .rmvr
 
 removeenvvar:{
- 	// positions of {}
-	pos:ss[x]each"{}";
-	// check the formatting is ok
-	$[0=count first pos; :x;
-	1<count distinct count each pos; '"environment variable contains unmatched brackets: ",x;
-	(any pos[0]>pos[1]) or any pos[0]<prev pos[1]; '"failed to match environment variable brackets on supplied string: ",x;
-	()];
+    // positions of {}
+    pos:ss[x]each"{}";
+    // check the formatting is ok
+    $[0=count first pos; :x;
+    1<count distinct count each pos; '"environment variable contains unmatched brackets: ",x;
+    (any pos[0]>pos[1]) or any pos[0]<prev pos[1]; '"failed to match environment variable brackets on supplied string: ",x;
+    ()];
 
-	// cut out each environment variable, and retrieve the meaning
-	raze {$["{"=first x;getenv`$1 _ -1 _ x;x]}each (raze flip 0 1+pos) cut x}		
-		
+    // cut out each environment variable, and retrieve the meaning
+    raze {$["{"=first x;getenv`$1 _ -1 _ x;x]}each (raze flip 0 1+pos) cut x}       
+        
 // Process initialisation
 \d .proc
 
@@ -301,8 +301,8 @@ params:.Q.opt .z.x
 if[`usage in key params; -1 .proc.getusage[]; exit 0];
 
 $[`localtime in key .proc.params;
-	[cp:{.z.P};cd:{.z.D};ct:{.z.T}];
-	[cp:{.z.p};cd:{.z.d};ct:{.z.t}]];
+    [cp:{.z.P};cd:{.z.D};ct:{.z.T}];
+    [cp:{.z.p};cd:{.z.d};ct:{.z.t}]];
 
 localtime:`localtime in key .proc.params
 
@@ -329,20 +329,20 @@ settorqenv'[`KDBCODE`KDBCONFIG`KDBLOG`KDBLIB`KDBHTML;("code";"config";"logs";"li
 // The could also be set in a wrapper script
 reqset:0b
 if[any req in key `.proc;
-	$[all req in key `.proc;
-		$[any null `.proc req;
-			.lg.o[`init;"some of the required process parameters supplied in the  wrapper script are set to null.  All must be set. Resetting all to null"];
-			reqset:1b]; 
-	  .lg.o[`init;"some but not all required process parameters have been set from the wrapper script - resetting all to null"]]];
+    $[all req in key `.proc;
+        $[any null `.proc req;
+            .lg.o[`init;"some of the required process parameters supplied in the  wrapper script are set to null.  All must be set. Resetting all to null"];
+            reqset:1b]; 
+      .lg.o[`init;"some but not all required process parameters have been set from the wrapper script - resetting all to null"]]];
 
 if[not reqset; @[`.proc;req;:;`]];
 
 $[count[req] = count req inter key params;
-	[@[`.proc;req;:;first each `$params req];
-	 reqset:1b];
+    [@[`.proc;req;:;first each `$params req];
+     reqset:1b];
   0<count req inter key params;
-	.lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
-  ()];		 
+    .lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
+  ()];       
 
 // If parentproctype has been supplied then set it
 parentproctype:`$();
@@ -355,56 +355,56 @@ checkdependency[getconfig["dependency.csv";1]]
 // If any of the required parameters are null, try to read them from a file
 // The file can come from the command line, or from the environment path
 file:$[`procfile in key params; 
-	first `$params `procfile;
- 	first getconfigfile["process.csv"]];
+    first `$params `procfile;
+    first getconfigfile["process.csv"]];
 
 // read the process file and convert port field to integer list and all other fields
 // to symbol lists
 readprocs:{[file]
-	// Updates the process table to convert strings to integer and symbols
-	updateprocs:{
-		// Gets the value of the input expression and returns it as an integer
-		// list if the expression can be evaluated, else return null
-		errcheckport:{@[{"I"$string value x};x;0N]};
-		
-		// begin updating process file table
-		t:update port:errcheckport each .rmvr.removeenvvar each port from x;
-		t:update host:"S"$.rmvr.removeenvvar each host from t;
-		t:update procname:"S"$.rmvr.removeenvvar each procname from t;
-		t:update proctype:"S"$.rmvr.removeenvvar each proctype from t;
-		// return updated process file table
-		t
-		};
-	// error trap loading and processing of process file and returns finished table
-	@[updateprocs ("****";enlist",")0:;file;
-	{.lg.e[`procfile;"failed to read process file ",(string x)," : ",y]}[file]]
-	}
+    // Updates the process table to convert strings to integer and symbols
+    updateprocs:{
+        // Gets the value of the input expression and returns it as an integer
+        // list if the expression can be evaluated, else return null
+        errcheckport:{@[{"I"$string value x};x;0N]};
+        
+        // begin updating process file table
+        t:update port:errcheckport each .rmvr.removeenvvar each port from x;
+        t:update host:"S"$.rmvr.removeenvvar each host from t;
+        t:update procname:"S"$.rmvr.removeenvvar each procname from t;
+        t:update proctype:"S"$.rmvr.removeenvvar each proctype from t;
+        // return updated process file table
+        t
+        };
+    // error trap loading and processing of process file and returns finished table
+    @[updateprocs ("****";enlist",")0:;file;
+    {.lg.e[`procfile;"failed to read process file ",(string x)," : ",y]}[file]]
+    }
 
 // Read in the processfile
 // Pull out the applicable rows
 readprocfile:{[file]
-	//order of preference for hostnames
-	prefs:(.z.h;`$"." sv string "i"$0x0 vs .z.a;`localhost);
-	res:@[{t:select from readprocs[file] where not null host;
-	// allow host=localhost for ease of startup
-	$[not any null `.proc req;
-		select from t where proctype=.proc.proctype,procname=.proc.procname;
-		select from t where abs[port]=abs system"p",(lower[host]=lower .z.h) or (host=`localhost) or host=`$"." sv string "i"$0x0 vs .z.a]
-		};file;{.err.ex[`init;"failed to read process file ",(string x)," : ",y;2]}[file]];
-		if[0=count res;
-		.lg.o[`readprocfile;"failed to read any rows from ",(string file)," which relate to this process; Host=",(string .z.h),", IP=",("." sv string "i"$0x0 vs .z.a),", port=",string system"p"];
-		:`host`port`proctype`procname!(`;0;proctype;procname)];
-		// if more than one result, take the most preferred one
-	output:$[1<count res;
-		// map hostnames in res to order of preference, select most preferred
-		first res iasc prefs?res[`host];
-		first res];
-	if[not output[`port] = system"p";
-		@[system;"p ",string[output[`port]];.err.ex[`readprocfile;"failed to set port to ",string[output[`port]]]];
-		.lg.o[`readprocfile;"port set to ",string[output[`port]]]
-		];
-	output
-	}	
+    //order of preference for hostnames
+    prefs:(.z.h;`$"." sv string "i"$0x0 vs .z.a;`localhost);
+    res:@[{t:select from readprocs[file] where not null host;
+    // allow host=localhost for ease of startup
+    $[not any null `.proc req;
+        select from t where proctype=.proc.proctype,procname=.proc.procname;
+        select from t where abs[port]=abs system"p",(lower[host]=lower .z.h) or (host=`localhost) or host=`$"." sv string "i"$0x0 vs .z.a]
+        };file;{.err.ex[`init;"failed to read process file ",(string x)," : ",y;2]}[file]];
+        if[0=count res;
+        .lg.o[`readprocfile;"failed to read any rows from ",(string file)," which relate to this process; Host=",(string .z.h),", IP=",("." sv string "i"$0x0 vs .z.a),", port=",string system"p"];
+        :`host`port`proctype`procname!(`;0;proctype;procname)];
+        // if more than one result, take the most preferred one
+    output:$[1<count res;
+        // map hostnames in res to order of preference, select most preferred
+        first res iasc prefs?res[`host];
+        first res];
+    if[not output[`port] = system"p";
+        @[system;"p ",string[output[`port]];.err.ex[`readprocfile;"failed to set port to ",string[output[`port]]]];
+        .lg.o[`readprocfile;"port set to ",string[output[`port]]]
+        ];
+    output
+    }   
 
 .lg.o[`init;"attempting to read required process parameters ",("," sv string req)," from file ",string file];
 // Read in the file, pull out the rows which are applicable and set the local variables
@@ -412,8 +412,8 @@ readprocfile:{[file]
 
 // Check if all the required variables have now been set properly
 $[any null `.proc req;
-	.err.ex[`init;"not all required variables have been set - missing ",(" " sv string req where null `.proc req);2];	
-	.lg.o[`init;"read in process parameters of ","; " sv "=" sv' string flip(req;`.proc req)]]
+    .err.ex[`init;"not all required variables have been set - missing ",(" " sv string req where null `.proc req);2];   
+    .lg.o[`init;"read in process parameters of ","; " sv "=" sv' string flip(req;`.proc req)]]
 
 // reset the logging functions to now use the name of the process
 .lg.o:.lg.l[`INF;proctype;procname;;;()!()]
@@ -424,35 +424,35 @@ $[any null `.proc req;
 // if alias is not null, a softlink will be created back to the actual file
 // handle can either be 1 or 2
 fileredirect:{[logdir;filename;alias;handle]
-	if[not (h:string handle) in (enlist "1";enlist "2"); 
-		'"handle must be 1 or 2"];
-	.lg.o[`logging;"re-directing ",h," to",f:" ",logdir,"/",filename];
-	@[system;s;{.lg.e[`logging;"failed to redirect ",x," : ",y]}[s:h,f]];
-	if[not null `$alias; createalias[logdir;filename;alias]]}
+    if[not (h:string handle) in (enlist "1";enlist "2"); 
+        '"handle must be 1 or 2"];
+    .lg.o[`logging;"re-directing ",h," to",f:" ",logdir,"/",filename];
+    @[system;s;{.lg.e[`logging;"failed to redirect ",x," : ",y]}[s:h,f]];
+    if[not null `$alias; createalias[logdir;filename;alias]]}
 
 createalias:{[logdir;filename;alias] 
-	$[.z.o like "w*"; 
-  		.lg.o[`logging;"cannot create alias on windows OS"];
- 		[.lg.o[`logging;"creating alias using command ",s:"ln -sf ",filename," ",logdir,"/",alias];
-		 @[system;s;{.lg.e[`init;"failed to create alias ",x," : ",y]}[s]]]]}
+    $[.z.o like "w*"; 
+        .lg.o[`logging;"cannot create alias on windows OS"];
+        [.lg.o[`logging;"creating alias using command ",s:"ln -sf ",filename," ",logdir,"/",alias];
+         @[system;s;{.lg.e[`init;"failed to create alias ",x," : ",y]}[s]]]]}
 
 // Create log files
 // logname = base of log file
 // timestamp = optional timestamp value (e.g. .z.d, .z.p)
 // makealias = if true, will create alias files without the timestamp value
 createlog:{[logdir;logname;timestamp;suppressalias]
-	basename:(string logname),"_",(string timestamp),".log";
-	alias:$[suppressalias;"";(string logname),".log"];
-	fileredirect[logdir;"err_",basename;"err_",alias;2];
-	fileredirect[logdir;"out_",basename;"out_",alias;1];
-	.lg.banner[]}
+    basename:(string logname),"_",(string timestamp),".log";
+    alias:$[suppressalias;"";(string logname),".log"];
+    fileredirect[logdir;"err_",basename;"err_",alias;2];
+    fileredirect[logdir;"out_",basename;"out_",alias;1];
+    .lg.banner[]}
 
 // function to produce the timestamp value for the log file
 logtimestamp:@[value;`logtimestamp;{[x] {[]`$ssr[;;"_"]/[string .z.z;".:T"]}}]
 
 rolllogauto:{[] 
-	.lg.o[`logging;"creating standard out and standard err logs"];
-	createlog[getenv`KDBLOG;procname;logtimestamp[];`suppressalias in key params]}
+    .lg.o[`logging;"creating standard out and standard err logs"];
+    createlog[getenv`KDBLOG;procname;logtimestamp[];`suppressalias in key params]}
 
 // Create log files as long as they haven't been switched off 
 if[not any `debug`noredirect in key params; rolllogauto[]];
@@ -460,93 +460,93 @@ if[not any `debug`noredirect in key params; rolllogauto[]];
 // utilities to load individual files / paths, and also a complete directory
 // this should then be enough to bootstrap
 loadf:{
-	.lg.o[`fileload;"loading ",x];
-	
-	$[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
-	.lg.o[`fileload;"successfully loaded ",x]}
+    .lg.o[`fileload;"loading ",x];
+    
+    $[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
+    .lg.o[`fileload;"successfully loaded ",x]}
 
 loaddir:{
-	.lg.o[`fileload;"loading q and k files from directory ",x];
-	// Check the directory exists
-	$[()~files:key hsym `$x; .lg.o[`fileload;"specified directory ",x," doesn't exist"];
-	// Try to read in a load order file
-		[
-        	$[`order.txt in files:key hsym `$x;
-                	[.lg.o[`fileload;"found load order file order.txt"];
-                 	order:(`$read0 `$x,"/order.txt") inter files;
-                 	.lg.o[`fileload;"loading files in order "," " sv string order]];
-                	order:`symbol$()];
-        	files:files where any files like/: ("*.q";"*.k");
-        	// rearrange the ordering
-        	files:order,files except order;
-        	loadf each (x,"/"),/:string files
-		]
-	];
-	}
+    .lg.o[`fileload;"loading q and k files from directory ",x];
+    // Check the directory exists
+    $[()~files:key hsym `$x; .lg.o[`fileload;"specified directory ",x," doesn't exist"];
+    // Try to read in a load order file
+        [
+            $[`order.txt in files:key hsym `$x;
+                    [.lg.o[`fileload;"found load order file order.txt"];
+                    order:(`$read0 `$x,"/order.txt") inter files;
+                    .lg.o[`fileload;"loading files in order "," " sv string order]];
+                    order:`symbol$()];
+            files:files where any files like/: ("*.q";"*.k");
+            // rearrange the ordering
+            files:order,files except order;
+            loadf each (x,"/"),/:string files
+        ]
+    ];
+    }
 
 // load a config file
 loadconfig:{
-	file:x,(string y),".q";
-	$[()~key hsym`$file;
-		.lg.o[`fileload;"config file ",file," not found"];
-		[.lg.o[`fileload;"config file ",file," found"];
-		 loadf file]]}
+    file:x,(string y),".q";
+    $[()~key hsym`$file;
+        .lg.o[`fileload;"config file ",file," not found"];
+        [.lg.o[`fileload;"config file ",file," found"];
+         loadf file]]}
 
 // Get the attributes of this process.  This should be overridden for each process
 getattributes:{()!()}
 
 // override config variables with parameters from the commandline
 overrideconfig:{[params]
-	// work out which are the potential variables to override
-	ov:key[params] where key[params] like ".*";
-	// can only can do those which are already set 
-	ov:ov where @[{value x;1b};;0b] each ov;
-	if[count ov;
-		.lg.o[`init;"attempting to override variables ",("," sv string ov)," from the command line"];
-		{if[not (abs t:type value y) within (1;-1+count .Q.t);
-			.lg.e[`init;"Cannot override ",(string y)," as it is not a basic type"];
-			:()];
-		 // parse out the values 
-		 vals:(upper .Q.t abs t)$'x[y];
-		 if[t<0;vals:first vals];
-		 // check for nulls
-		 if[any null each vals; .lg.e[`init;"Cannot override ",(string y)," with command line parameters as null values have been supplied"]];
-		 .lg.o[`init;"Setting ",(string y)," to ",-3!vals];
-		 set[y;vals]}[params] each ov]}	
+    // work out which are the potential variables to override
+    ov:key[params] where key[params] like ".*";
+    // can only can do those which are already set 
+    ov:ov where @[{value x;1b};;0b] each ov;
+    if[count ov;
+        .lg.o[`init;"attempting to override variables ",("," sv string ov)," from the command line"];
+        {if[not (abs t:type value y) within (1;-1+count .Q.t);
+            .lg.e[`init;"Cannot override ",(string y)," as it is not a basic type"];
+            :()];
+         // parse out the values 
+         vals:(upper .Q.t abs t)$'x[y];
+         if[t<0;vals:first vals];
+         // check for nulls
+         if[any null each vals; .lg.e[`init;"Cannot override ",(string y)," with command line parameters as null values have been supplied"]];
+         .lg.o[`init;"Setting ",(string y)," to ",-3!vals];
+         set[y;vals]}[params] each ov]} 
 
 override:{overrideconfig[.proc.params]}
 
 loadspeccode:{[ext;dir]
-	$[""~getenv dir;
-	 .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
-	 loaddir getenv[dir],ext
+    $[""~getenv dir;
+     .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
+     loaddir getenv[dir],ext
    ];
-	};
+    };
 
 reloadcommoncode:{
-	// Load common code from each directory if it exists
-	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-	};
+    // Load common code from each directory if it exists
+    loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+    };
 reloadparentprocesscode:{
     // Load parentproctype code from each directory if it exists
     loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
     };
 reloadprocesscode:{
-	// Load proctype code from each directory if it exists
-	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-	};
+    // Load proctype code from each directory if it exists
+    loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+    };
 reloadnamecode:{
-	// Load procname code from each directory if it exists
-	loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-	};
+    // Load procname code from each directory if it exists
+    loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+    };
 
 \d . 
 // Load configuration
 // TorQ loads configuration modules in the order: TorQ Default, Service Specific and then Application Specific
 // Each module loads configuration in the order: default configuration, then process type specific, then process specific
 if[not `noconfig in key .proc.params;
-	// load TorQ Default configuration module
-	.proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
+    // load TorQ Default configuration module
+    .proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
   // check if KDBSERVCONFIG is set and load Service Layer specific configuration module
   $[""~getenv`KDBSERVCONFIG;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG not set, not loading app specific config"];
@@ -554,15 +554,15 @@ if[not `noconfig in key .proc.params;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG set, loading app specific config from ",.proc.servconfig];
     .proc.loadconfig[.proc.servconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
-	// check if KDBAPPCONFIG is set and load Appliation specific configuration module 
-  $[""~getenv`KDBAPPCONFIG;	
-	  .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
-	  [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
-	  .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
-	  .proc.loadconfig[.proc.appconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
+    // check if KDBAPPCONFIG is set and load Appliation specific configuration module 
+  $[""~getenv`KDBAPPCONFIG; 
+      .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
+      [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
+      .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
+      .proc.loadconfig[.proc.appconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
-	// Override config from the command line
-	.proc.override[]]
+    // Override config from the command line
+    .proc.override[]]
 
 // Load library code 
 .proc.loadcommoncode:@[value;`.proc.loadcommoncode;1b];
@@ -582,25 +582,25 @@ if[.proc.loadprocesscode;.proc.reloadprocesscode[]]
 if[.proc.loadnamecode;.proc.reloadnamecode[]]
 
 if[`loaddir in key .proc.params;
-	.lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];
-	.proc.loaddir each .proc.params`loaddir]
+    .lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];
+    .proc.loaddir each .proc.params`loaddir]
 
 // Load message handlers after all the other library code
 .proc.loaddir each(getenv$[.proc.loadhandlers & not ""~getenv`KDBSERVCODE;`KDBCODE`KDBSERVCODE;(),`KDBCODE]),\:"/handlers";
 
 // If the timer is loaded, and logrolling is set to true, try to log the roll file on a daily basis
 if[.proc.logroll and not any `debug`noredirect in key .proc.params;
-	$[@[value;`.timer.enabled;0b];
-		[.lg.o[`init;"adding timer function to roll std out/err logs on a daily schedule starting at ",string `timestamp$(.proc.cd[]+1)+00:00];
-		 .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.proc.rolllogauto;`);0h;"roll standard out/standard error logs";1b]];
-		.lg.e[`init;".proc.logroll is set to true, but timer functionality is not loaded - cannot roll logs"]]];
-	
+    $[@[value;`.timer.enabled;0b];
+        [.lg.o[`init;"adding timer function to roll std out/err logs on a daily schedule starting at ",string `timestamp$(.proc.cd[]+1)+00:00];
+         .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.proc.rolllogauto;`);0h;"roll standard out/standard error logs";1b]];
+        .lg.e[`init;".proc.logroll is set to true, but timer functionality is not loaded - cannot roll logs"]]];
+    
 // Load the file specified on the command line
 if[`load in key .proc.params; .proc.loadf each .proc.params`load]
 
 if[any`debug`nopi in key .proc.params;
-	.lg.o[`init;"Resetting .z.pi to kdb+ default value"];
-	.z.pi:show@value@;]
+    .lg.o[`init;"Resetting .z.pi to kdb+ default value"];
+    .z.pi:show@value@;]
 
 // initialise pubsub
 if[@[value;`.ps.loaded;0b]; .ps.initialise[]]
@@ -609,12 +609,12 @@ if[@[value;`.servers.STARTUP;0b]; .servers.startup[]]
 
 // function to execute functions in .proc.initlist
 .proc.init:{
-	$[count .proc.initlist;
-		[{[a].lg.o[`init;"attemping to run initialisation: ",-3!a];
-		@[value;a;
-		{[x;a].lg.e[`init;x," error - failed to run initialisation: ",-3!a]}[;a]]}
-		each .proc.initlist;.proc.initlist:()];
-		.lg.o[`init;"no initialisation functions found"]];
+    $[count .proc.initlist;
+        [{[a].lg.o[`init;"attemping to run initialisation: ",-3!a];
+        @[value;a;
+        {[x;a].lg.e[`init;x," error - failed to run initialisation: ",-3!a]}[;a]]}
+        each .proc.initlist;.proc.initlist:()];
+        .lg.o[`init;"no initialisation functions found"]];
  }
 
 if[count .proc.initlist;.proc.init[]]

--- a/torq.q
+++ b/torq.q
@@ -528,9 +528,9 @@ reloadcommoncode:{
     loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
     };
 reloadparentprocesscode:{
-    // Load parentproctype code from each directory if it exists
-    loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-    };
+  // Load parentproctype code from each directory if it exists
+  loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+  };
 reloadprocesscode:{
     // Load proctype code from each directory if it exists
     loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];

--- a/torq.q
+++ b/torq.q
@@ -552,7 +552,7 @@ if[not `noconfig in key .proc.params;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG not set, not loading app specific config"];
     [.proc.servconfig:getenv[`KDBAPPCONFIG],"/settings/";
     .lg.o[`fileload;"environment variable KDBSERVCONFIG set, loading app specific config from ",.proc.servconfig];
-	.proc.loadconfig[.proc.servconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
+    .proc.loadconfig[.proc.servconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
 	// check if KDBAPPCONFIG is set and load Appliation specific configuration module 
   $[""~getenv`KDBAPPCONFIG;	

--- a/torq.q
+++ b/torq.q
@@ -347,8 +347,8 @@ $[count[req] = count req inter key params;
 // If parentproctype has been supplied then set it
 parentproctype:`$();
 if[`parentproctype in key params;
-    parentproctype:first `$params `parentproctype;
-    .lg.o[`init;"read in process parameter of parentproctype=",string parentproctype]];
+	parentproctype:first `$params `parentproctype;
+	.lg.o[`init;"read in process parameter of parentproctype=",string parentproctype]];
 
 checkdependency[getconfig["dependency.csv";1]]
 
@@ -528,9 +528,9 @@ reloadcommoncode:{
 	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
 	};
 reloadparentprocesscode:{
-  // Load parentproctype code from each directory if it exists
-  loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-  };
+	// Load parentproctype code from each directory if it exists
+	loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 reloadprocesscode:{
 	// Load proctype code from each directory if it exists
 	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];

--- a/torq.q
+++ b/torq.q
@@ -95,7 +95,7 @@ envvars:@[value;`envvars;`symbol$()]
 envvars:distinct `KDBCODE`KDBCONFIG`KDBLOG`KDBHTML`KDBLIB,envvars
 // The script may have optional environment variables
 // KDBAPPCONFIG may be defined for loading app specific config
-{if[not ""~getenv[x]; envvars::distinct x,envvars]}`KDBAPPCONFIG
+{if[not ""~getenv x; envvars::distinct x,envvars]}each `KDBAPPCONFIG`KDBSERVCONFIG
 
 // set the torq environment variables if not already set
 qhome:{q:getenv[`QHOME]; if[q~""; q:$[.z.o like "w*"; "c:/q"; getenv[`HOME],"/q"]]; q}
@@ -144,23 +144,29 @@ checkdependency:{[path]
         {[t;dict] runchk[dict;t;]'[t[`dependency]]}[;dict]'[t]]}
 
 getconfig:{[path;level]
-        /-check if KDBAPPCONFIG exists
-        keyappconf:$[not ""~kac:getenv[`KDBAPPCONFIG];
+        /- check if KDBSERVCONFIG exists
+        keyservconf:$[not ""~ksc:getenv`KDBSERVCONFIG;
+          key hsym servconf:`$ksc,"/",path;
+          ()];
+        /- check if KDBAPPCONFIG exists
+        keyappconf:$[not ""~kac:getenv`KDBAPPCONFIG;
           key hsym appconf:`$kac,"/",path;
           ()];
 
         /-if level=2 then all files are returned regardless
         if[level<2;
           if[()~keyappconf;
-            appconf:()]];
+            appconf:()];
+          if[()~keyservconf;
+            servconf:()]];
 
         /-get KDBCONFIG path
         conf:`$(kc:getenv[`KDBCONFIG]),"/",path;
 
-        /-if level is non-zero return appconfig and config files
+        /-if level is non-zero return appconfig, servconfig and config files
         (),$[level;
-          appconf,conf;
-          first appconf,conf]}
+          appconf,servconf,conf;
+          first appconf,servconf,conf]}
 
 getconfigfile:getconfig[;0]
 
@@ -504,44 +510,47 @@ overrideconfig:{[params]
 
 override:{overrideconfig[.proc.params]}
 
+loadspeccode:{[ext;dir]
+	$[""~getenv dir;
+	 .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
+	 loaddir getenv[dir],ext
+   ];
+	};
+
 reloadcommoncode:{
-	loaddir getenv[`KDBCODE],"/common";
-	// Optionally load common code from seperate directory
-	$[""~getenv(`KDBAPPCODE);
-		.lg.o[`init;"Environment variable KDBAPPCODE not set, not loading app specific common code"];
-		loaddir getenv[`KDBAPPCODE],"/common"
-	];
-	}
+	// Load common code from each directory if it exists
+	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 reloadprocesscode:{
-	loaddir getenv[`KDBCODE],"/",string proctype;
-	// Optionally load proctype code from seperate directory
-	$[""~getenv(`KDBAPPCODE);
-                .lg.o[`init;"Environment variable KDBAPPCODE not set, not loading app specific proctype code"];
-                loaddir getenv[`KDBAPPCODE],"/",string proctype
-        ];
-	}
+	// Load proctype code from each directory if it exists
+	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 reloadnamecode:{
-	loaddir getenv[`KDBCODE],"/",string procname;
-	// Optionally load procname code from seperate directory
-	$[""~getenv(`KDBAPPCODE);
-                .lg.o[`init;"Environment variable KDBAPPCODE not set, not loading app specific procname code"];
-                loaddir getenv[`KDBAPPCODE],"/",string procname
-        ];
-	}
+	// Load procname code from each directory if it exists
+	loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 
 \d . 
 // Load configuration
-// TorQ loads configuration modules in the order: TorQ Default, then Application Specific
+// TorQ loads configuration modules in the order: TorQ Default, Service Specific and then Application Specific
 // Each module loads configuration in the order: default configuration, then process type specific, then process specific
 if[not `noconfig in key .proc.params;
 	// load TorQ Default configuration module
 	.proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.proctype,.proc.procname;
-	// check if KDBAPPCONFIG is set and load Appliation specific configuration module
-	$[""~getenv(`KDBAPPCONFIG);	
-	.lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
-	[.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
-	.lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
-	.proc.loadconfig[.proc.appconfig;] each `default,.proc.proctype,.proc.procname]];
+  // check if KDBSERVCONFIG is set and load Service Layer specific configuration module
+  $[""~getenv`KDBSERVCONFIG;
+    .lg.o[`fileload;"environment variable KDBSERVCONFIG not set, not loading app specific config"];
+    [.proc.servconfig:getenv[`KDBAPPCONFIG],"/settings/";
+    .lg.o[`fileload;"environment variable KDBSERVCONFIG set, loading app specific config from ",.proc.servconfig];
+    .proc.loadconfig[.proc.servconfig;] each `default,.proc.proctype,.proc.procname]
+  ];
+	// check if KDBAPPCONFIG is set and load Appliation specific configuration module 
+  $[""~getenv`KDBAPPCONFIG;	
+	  .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
+	  [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
+	  .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
+	  .proc.loadconfig[.proc.appconfig;] each `default,.proc.proctype,.proc.procname]
+  ];
 	// Override config from the command line
 	.proc.override[]]
 
@@ -566,7 +575,7 @@ if[`loaddir in key .proc.params;
 	.proc.loaddir each .proc.params`loaddir]
 
 // Load message handlers after all the other library code
-if[.proc.loadhandlers;.proc.loaddir getenv[`KDBCODE],"/handlers"]
+.proc.loaddir each(getenv$[.proc.loadhandlers & not ""~getenv`KDBSERVCODE;`KDBCODE`KDBSERVCODE;(),`KDBCODE]),\:"/handlers";
 
 // If the timer is loaded, and logrolling is set to true, try to log the roll file on a daily basis
 if[.proc.logroll and not any `debug`noredirect in key .proc.params;

--- a/torq.q
+++ b/torq.q
@@ -552,14 +552,14 @@ if[not `noconfig in key .proc.params;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG not set, not loading app specific config"];
     [.proc.servconfig:getenv[`KDBAPPCONFIG],"/settings/";
     .lg.o[`fileload;"environment variable KDBSERVCONFIG set, loading app specific config from ",.proc.servconfig];
-    .proc.loadconfig[.proc.servconfig;] each `default,.proc.proctype,.proc.procname]
+	.proc.loadconfig[.proc.servconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
 	// check if KDBAPPCONFIG is set and load Appliation specific configuration module 
   $[""~getenv`KDBAPPCONFIG;	
 	  .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
 	  [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
 	  .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
-	  .proc.loadconfig[.proc.appconfig;] each `default,.proc.proctype,.proc.procname]
+	  .proc.loadconfig[.proc.appconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
 	// Override config from the command line
 	.proc.override[]]

--- a/torq.q
+++ b/torq.q
@@ -82,9 +82,9 @@ configusage:@[value;`configusage;"Config management:
 helpusage:@[value;`helpusage;"Help: 
  if help.q from code.kx is loaded, use help` for more information.
  if api.q is loaded, you should be able to access api information from the commandline.  Use 
-    .api.f[symbol or string pattern] e.g. .api.f[`proc] to find a function/variable
-    .api.p[symbol or string pattern] e.g. .api.p[`timer] to find a publically marked function/variable
-    .api.u[symbol or string pattern] e.g. .api.u[`] to find a publically marked, user defined function (i.e. don't show .q functions)"] 
+	.api.f[symbol or string pattern] e.g. .api.f[`proc] to find a function/variable
+	.api.p[symbol or string pattern] e.g. .api.p[`timer] to find a publically marked function/variable
+	.api.u[symbol or string pattern] e.g. .api.u[`] to find a publically marked, user defined function (i.e. don't show .q functions)"] 
 
 // If the usage value has been overridden, use that.  Else concat the req environment, with the stdoptions, with the extra usage info
 getusage:{@[value;`.proc.usage;generalusage,"\n\n",envusage,"\n\n",envoptusage,"\n\n",stdoptionusage,"\n\n",extrausage,"\n\n",configusage,"\n\n",helpusage,"\n\n"]}
@@ -101,7 +101,7 @@ envvars:distinct `KDBCODE`KDBCONFIG`KDBLOG`KDBHTML`KDBLIB,envvars
 qhome:{q:getenv[`QHOME]; if[q~""; q:$[.z.o like "w*"; "c:/q"; getenv[`HOME],"/q"]]; q}
 settorqenv:{[envvar; default] 
  if[""~getenv[envvar]; 
-  .lg.o[`init;(string envvar)," is not defined. Defining it to ",val:qhome[],"/",default];  
+  .lg.o[`init;(string envvar)," is not defined. Defining it to ",val:qhome[],"/",default];	
   setenv[envvar; val]];}
 
 // make sure the path separators are the right way around if running on windows
@@ -200,11 +200,11 @@ pubmap:@[value;`pubmap;`ERROR`ERR`INF`WARN!1 1 0 1]
 
 // Log a message
 l:{[loglevel;proctype;proc;id;message;dict]
-    $[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
-        neg[redir] .lg.format[loglevel;proctype;proc;id;message];
-        ext[loglevel;proctype;proc;id;message;dict]];
-        publish[loglevel;proctype;proc;id;message]; 
-    }
+	$[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
+		neg[redir] .lg.format[loglevel;proctype;proc;id;message];
+		ext[loglevel;proctype;proc;id;message;dict]];
+        publish[loglevel;proctype;proc;id;message];	
+	}
 
 // Log an error.  
 // If the process is fully initialised, throw the error
@@ -212,9 +212,9 @@ l:{[loglevel;proctype;proc;id;message;dict]
 err:{[loglevel;proctype;proc;id;message;dict]
         l[loglevel;proctype;proc;id;message;dict];
         if[.proc.stop;'message];
-    if[.proc.initialised;:()];
+ 	if[.proc.initialised;:()];
         if[not .proc.trap; exit 3];
-    }
+	}
 
 // log out and log err
 // The process name is temporary which we will reset later - once we know what type of process this is
@@ -259,21 +259,21 @@ usage:{ex[`usage;.proc.getusage[];1]}
 
 // Throw an error if all the required parameters aren't passed in
 param:{[paramdict;reqparams] 
-    if[count missing:(reqparams,:()) except key paramdict; 
-        .lg.e[`init;"missing required command line parameter(s) "," " sv string missing];
-        usage[]]}
+	if[count missing:(reqparams,:()) except key paramdict; 
+		.lg.e[`init;"missing required command line parameter(s) "," " sv string missing];
+		usage[]]}
 
 // Throw an error if all the requried envinonment variables aren't set
 env:{[reqenv]
-    if[count missing:reqenv where 0=count each getenv each reqenv,:();
-        .lg.e[`init;"required environment variable(s) not set - "," " sv string missing];
-        usage[]]}
+	if[count missing:reqenv where 0=count each getenv each reqenv,:();
+		.lg.e[`init;"required environment variable(s) not set - "," " sv string missing];
+		usage[]]}
 
 // Check if a variable is null
 exitifnull:{[variable] 
-    if[null value variable; 
-        .lg.e[`init;"Variable ",(string variable)," is null but must be set"];
-        usage[]]}
+	if[null value variable; 
+		.lg.e[`init;"Variable ",(string variable)," is null but must be set"];
+		usage[]]}
 
 
 // Function for replacing environment variables with the associated full path
@@ -281,17 +281,17 @@ exitifnull:{[variable]
 \d .rmvr
 
 removeenvvar:{
-    // positions of {}
-    pos:ss[x]each"{}";
-    // check the formatting is ok
-    $[0=count first pos; :x;
-    1<count distinct count each pos; '"environment variable contains unmatched brackets: ",x;
-    (any pos[0]>pos[1]) or any pos[0]<prev pos[1]; '"failed to match environment variable brackets on supplied string: ",x;
-    ()];
+ 	// positions of {}
+	pos:ss[x]each"{}";
+	// check the formatting is ok
+	$[0=count first pos; :x;
+	1<count distinct count each pos; '"environment variable contains unmatched brackets: ",x;
+	(any pos[0]>pos[1]) or any pos[0]<prev pos[1]; '"failed to match environment variable brackets on supplied string: ",x;
+	()];
 
-    // cut out each environment variable, and retrieve the meaning
-    raze {$["{"=first x;getenv`$1 _ -1 _ x;x]}each (raze flip 0 1+pos) cut x}       
-        
+	// cut out each environment variable, and retrieve the meaning
+	raze {$["{"=first x;getenv`$1 _ -1 _ x;x]}each (raze flip 0 1+pos) cut x}		
+		
 // Process initialisation
 \d .proc
 
@@ -301,8 +301,8 @@ params:.Q.opt .z.x
 if[`usage in key params; -1 .proc.getusage[]; exit 0];
 
 $[`localtime in key .proc.params;
-    [cp:{.z.P};cd:{.z.D};ct:{.z.T}];
-    [cp:{.z.p};cd:{.z.d};ct:{.z.t}]];
+	[cp:{.z.P};cd:{.z.D};ct:{.z.T}];
+	[cp:{.z.p};cd:{.z.d};ct:{.z.t}]];
 
 localtime:`localtime in key .proc.params
 
@@ -329,20 +329,20 @@ settorqenv'[`KDBCODE`KDBCONFIG`KDBLOG`KDBLIB`KDBHTML;("code";"config";"logs";"li
 // The could also be set in a wrapper script
 reqset:0b
 if[any req in key `.proc;
-    $[all req in key `.proc;
-        $[any null `.proc req;
-            .lg.o[`init;"some of the required process parameters supplied in the  wrapper script are set to null.  All must be set. Resetting all to null"];
-            reqset:1b]; 
-      .lg.o[`init;"some but not all required process parameters have been set from the wrapper script - resetting all to null"]]];
+	$[all req in key `.proc;
+		$[any null `.proc req;
+			.lg.o[`init;"some of the required process parameters supplied in the  wrapper script are set to null.  All must be set. Resetting all to null"];
+			reqset:1b]; 
+	  .lg.o[`init;"some but not all required process parameters have been set from the wrapper script - resetting all to null"]]];
 
 if[not reqset; @[`.proc;req;:;`]];
 
 $[count[req] = count req inter key params;
-    [@[`.proc;req;:;first each `$params req];
-     reqset:1b];
+	[@[`.proc;req;:;first each `$params req];
+	 reqset:1b];
   0<count req inter key params;
-    .lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
-  ()];       
+	.lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
+  ()];		 
 
 // If parentproctype has been supplied then set it
 parentproctype:`$();
@@ -355,56 +355,56 @@ checkdependency[getconfig["dependency.csv";1]]
 // If any of the required parameters are null, try to read them from a file
 // The file can come from the command line, or from the environment path
 file:$[`procfile in key params; 
-    first `$params `procfile;
-    first getconfigfile["process.csv"]];
+	first `$params `procfile;
+ 	first getconfigfile["process.csv"]];
 
 // read the process file and convert port field to integer list and all other fields
 // to symbol lists
 readprocs:{[file]
-    // Updates the process table to convert strings to integer and symbols
-    updateprocs:{
-        // Gets the value of the input expression and returns it as an integer
-        // list if the expression can be evaluated, else return null
-        errcheckport:{@[{"I"$string value x};x;0N]};
-        
-        // begin updating process file table
-        t:update port:errcheckport each .rmvr.removeenvvar each port from x;
-        t:update host:"S"$.rmvr.removeenvvar each host from t;
-        t:update procname:"S"$.rmvr.removeenvvar each procname from t;
-        t:update proctype:"S"$.rmvr.removeenvvar each proctype from t;
-        // return updated process file table
-        t
-        };
-    // error trap loading and processing of process file and returns finished table
-    @[updateprocs ("****";enlist",")0:;file;
-    {.lg.e[`procfile;"failed to read process file ",(string x)," : ",y]}[file]]
-    }
+	// Updates the process table to convert strings to integer and symbols
+	updateprocs:{
+		// Gets the value of the input expression and returns it as an integer
+		// list if the expression can be evaluated, else return null
+		errcheckport:{@[{"I"$string value x};x;0N]};
+		
+		// begin updating process file table
+		t:update port:errcheckport each .rmvr.removeenvvar each port from x;
+		t:update host:"S"$.rmvr.removeenvvar each host from t;
+		t:update procname:"S"$.rmvr.removeenvvar each procname from t;
+		t:update proctype:"S"$.rmvr.removeenvvar each proctype from t;
+		// return updated process file table
+		t
+		};
+	// error trap loading and processing of process file and returns finished table
+	@[updateprocs ("****";enlist",")0:;file;
+	{.lg.e[`procfile;"failed to read process file ",(string x)," : ",y]}[file]]
+	}
 
 // Read in the processfile
 // Pull out the applicable rows
 readprocfile:{[file]
-    //order of preference for hostnames
-    prefs:(.z.h;`$"." sv string "i"$0x0 vs .z.a;`localhost);
-    res:@[{t:select from readprocs[file] where not null host;
-    // allow host=localhost for ease of startup
-    $[not any null `.proc req;
-        select from t where proctype=.proc.proctype,procname=.proc.procname;
-        select from t where abs[port]=abs system"p",(lower[host]=lower .z.h) or (host=`localhost) or host=`$"." sv string "i"$0x0 vs .z.a]
-        };file;{.err.ex[`init;"failed to read process file ",(string x)," : ",y;2]}[file]];
-        if[0=count res;
-        .lg.o[`readprocfile;"failed to read any rows from ",(string file)," which relate to this process; Host=",(string .z.h),", IP=",("." sv string "i"$0x0 vs .z.a),", port=",string system"p"];
-        :`host`port`proctype`procname!(`;0;proctype;procname)];
-        // if more than one result, take the most preferred one
-    output:$[1<count res;
-        // map hostnames in res to order of preference, select most preferred
-        first res iasc prefs?res[`host];
-        first res];
-    if[not output[`port] = system"p";
-        @[system;"p ",string[output[`port]];.err.ex[`readprocfile;"failed to set port to ",string[output[`port]]]];
-        .lg.o[`readprocfile;"port set to ",string[output[`port]]]
-        ];
-    output
-    }   
+	//order of preference for hostnames
+	prefs:(.z.h;`$"." sv string "i"$0x0 vs .z.a;`localhost);
+	res:@[{t:select from readprocs[file] where not null host;
+	// allow host=localhost for ease of startup
+	$[not any null `.proc req;
+		select from t where proctype=.proc.proctype,procname=.proc.procname;
+		select from t where abs[port]=abs system"p",(lower[host]=lower .z.h) or (host=`localhost) or host=`$"." sv string "i"$0x0 vs .z.a]
+		};file;{.err.ex[`init;"failed to read process file ",(string x)," : ",y;2]}[file]];
+		if[0=count res;
+		.lg.o[`readprocfile;"failed to read any rows from ",(string file)," which relate to this process; Host=",(string .z.h),", IP=",("." sv string "i"$0x0 vs .z.a),", port=",string system"p"];
+		:`host`port`proctype`procname!(`;0;proctype;procname)];
+		// if more than one result, take the most preferred one
+	output:$[1<count res;
+		// map hostnames in res to order of preference, select most preferred
+		first res iasc prefs?res[`host];
+		first res];
+	if[not output[`port] = system"p";
+		@[system;"p ",string[output[`port]];.err.ex[`readprocfile;"failed to set port to ",string[output[`port]]]];
+		.lg.o[`readprocfile;"port set to ",string[output[`port]]]
+		];
+	output
+	}	
 
 .lg.o[`init;"attempting to read required process parameters ",("," sv string req)," from file ",string file];
 // Read in the file, pull out the rows which are applicable and set the local variables
@@ -412,8 +412,8 @@ readprocfile:{[file]
 
 // Check if all the required variables have now been set properly
 $[any null `.proc req;
-    .err.ex[`init;"not all required variables have been set - missing ",(" " sv string req where null `.proc req);2];   
-    .lg.o[`init;"read in process parameters of ","; " sv "=" sv' string flip(req;`.proc req)]]
+	.err.ex[`init;"not all required variables have been set - missing ",(" " sv string req where null `.proc req);2];	
+	.lg.o[`init;"read in process parameters of ","; " sv "=" sv' string flip(req;`.proc req)]]
 
 // reset the logging functions to now use the name of the process
 .lg.o:.lg.l[`INF;proctype;procname;;;()!()]
@@ -424,35 +424,35 @@ $[any null `.proc req;
 // if alias is not null, a softlink will be created back to the actual file
 // handle can either be 1 or 2
 fileredirect:{[logdir;filename;alias;handle]
-    if[not (h:string handle) in (enlist "1";enlist "2"); 
-        '"handle must be 1 or 2"];
-    .lg.o[`logging;"re-directing ",h," to",f:" ",logdir,"/",filename];
-    @[system;s;{.lg.e[`logging;"failed to redirect ",x," : ",y]}[s:h,f]];
-    if[not null `$alias; createalias[logdir;filename;alias]]}
+	if[not (h:string handle) in (enlist "1";enlist "2"); 
+		'"handle must be 1 or 2"];
+	.lg.o[`logging;"re-directing ",h," to",f:" ",logdir,"/",filename];
+	@[system;s;{.lg.e[`logging;"failed to redirect ",x," : ",y]}[s:h,f]];
+	if[not null `$alias; createalias[logdir;filename;alias]]}
 
 createalias:{[logdir;filename;alias] 
-    $[.z.o like "w*"; 
-        .lg.o[`logging;"cannot create alias on windows OS"];
-        [.lg.o[`logging;"creating alias using command ",s:"ln -sf ",filename," ",logdir,"/",alias];
-         @[system;s;{.lg.e[`init;"failed to create alias ",x," : ",y]}[s]]]]}
+	$[.z.o like "w*"; 
+  		.lg.o[`logging;"cannot create alias on windows OS"];
+ 		[.lg.o[`logging;"creating alias using command ",s:"ln -sf ",filename," ",logdir,"/",alias];
+		 @[system;s;{.lg.e[`init;"failed to create alias ",x," : ",y]}[s]]]]}
 
 // Create log files
 // logname = base of log file
 // timestamp = optional timestamp value (e.g. .z.d, .z.p)
 // makealias = if true, will create alias files without the timestamp value
 createlog:{[logdir;logname;timestamp;suppressalias]
-    basename:(string logname),"_",(string timestamp),".log";
-    alias:$[suppressalias;"";(string logname),".log"];
-    fileredirect[logdir;"err_",basename;"err_",alias;2];
-    fileredirect[logdir;"out_",basename;"out_",alias;1];
-    .lg.banner[]}
+	basename:(string logname),"_",(string timestamp),".log";
+	alias:$[suppressalias;"";(string logname),".log"];
+	fileredirect[logdir;"err_",basename;"err_",alias;2];
+	fileredirect[logdir;"out_",basename;"out_",alias;1];
+	.lg.banner[]}
 
 // function to produce the timestamp value for the log file
 logtimestamp:@[value;`logtimestamp;{[x] {[]`$ssr[;;"_"]/[string .z.z;".:T"]}}]
 
 rolllogauto:{[] 
-    .lg.o[`logging;"creating standard out and standard err logs"];
-    createlog[getenv`KDBLOG;procname;logtimestamp[];`suppressalias in key params]}
+	.lg.o[`logging;"creating standard out and standard err logs"];
+	createlog[getenv`KDBLOG;procname;logtimestamp[];`suppressalias in key params]}
 
 // Create log files as long as they haven't been switched off 
 if[not any `debug`noredirect in key params; rolllogauto[]];
@@ -460,93 +460,93 @@ if[not any `debug`noredirect in key params; rolllogauto[]];
 // utilities to load individual files / paths, and also a complete directory
 // this should then be enough to bootstrap
 loadf:{
-    .lg.o[`fileload;"loading ",x];
-    
-    $[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
-    .lg.o[`fileload;"successfully loaded ",x]}
+	.lg.o[`fileload;"loading ",x];
+	
+	$[`debug in key .proc.params; system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]]];
+	.lg.o[`fileload;"successfully loaded ",x]}
 
 loaddir:{
-    .lg.o[`fileload;"loading q and k files from directory ",x];
-    // Check the directory exists
-    $[()~files:key hsym `$x; .lg.o[`fileload;"specified directory ",x," doesn't exist"];
-    // Try to read in a load order file
-        [
-            $[`order.txt in files:key hsym `$x;
-                    [.lg.o[`fileload;"found load order file order.txt"];
-                    order:(`$read0 `$x,"/order.txt") inter files;
-                    .lg.o[`fileload;"loading files in order "," " sv string order]];
-                    order:`symbol$()];
-            files:files where any files like/: ("*.q";"*.k");
-            // rearrange the ordering
-            files:order,files except order;
-            loadf each (x,"/"),/:string files
-        ]
-    ];
-    }
+	.lg.o[`fileload;"loading q and k files from directory ",x];
+	// Check the directory exists
+	$[()~files:key hsym `$x; .lg.o[`fileload;"specified directory ",x," doesn't exist"];
+	// Try to read in a load order file
+		[
+        	$[`order.txt in files:key hsym `$x;
+                	[.lg.o[`fileload;"found load order file order.txt"];
+                 	order:(`$read0 `$x,"/order.txt") inter files;
+                 	.lg.o[`fileload;"loading files in order "," " sv string order]];
+                	order:`symbol$()];
+        	files:files where any files like/: ("*.q";"*.k");
+        	// rearrange the ordering
+        	files:order,files except order;
+        	loadf each (x,"/"),/:string files
+		]
+	];
+	}
 
 // load a config file
 loadconfig:{
-    file:x,(string y),".q";
-    $[()~key hsym`$file;
-        .lg.o[`fileload;"config file ",file," not found"];
-        [.lg.o[`fileload;"config file ",file," found"];
-         loadf file]]}
+	file:x,(string y),".q";
+	$[()~key hsym`$file;
+		.lg.o[`fileload;"config file ",file," not found"];
+		[.lg.o[`fileload;"config file ",file," found"];
+		 loadf file]]}
 
 // Get the attributes of this process.  This should be overridden for each process
 getattributes:{()!()}
 
 // override config variables with parameters from the commandline
 overrideconfig:{[params]
-    // work out which are the potential variables to override
-    ov:key[params] where key[params] like ".*";
-    // can only can do those which are already set 
-    ov:ov where @[{value x;1b};;0b] each ov;
-    if[count ov;
-        .lg.o[`init;"attempting to override variables ",("," sv string ov)," from the command line"];
-        {if[not (abs t:type value y) within (1;-1+count .Q.t);
-            .lg.e[`init;"Cannot override ",(string y)," as it is not a basic type"];
-            :()];
-         // parse out the values 
-         vals:(upper .Q.t abs t)$'x[y];
-         if[t<0;vals:first vals];
-         // check for nulls
-         if[any null each vals; .lg.e[`init;"Cannot override ",(string y)," with command line parameters as null values have been supplied"]];
-         .lg.o[`init;"Setting ",(string y)," to ",-3!vals];
-         set[y;vals]}[params] each ov]} 
+	// work out which are the potential variables to override
+	ov:key[params] where key[params] like ".*";
+	// can only can do those which are already set 
+	ov:ov where @[{value x;1b};;0b] each ov;
+	if[count ov;
+		.lg.o[`init;"attempting to override variables ",("," sv string ov)," from the command line"];
+		{if[not (abs t:type value y) within (1;-1+count .Q.t);
+			.lg.e[`init;"Cannot override ",(string y)," as it is not a basic type"];
+			:()];
+		 // parse out the values 
+		 vals:(upper .Q.t abs t)$'x[y];
+		 if[t<0;vals:first vals];
+		 // check for nulls
+		 if[any null each vals; .lg.e[`init;"Cannot override ",(string y)," with command line parameters as null values have been supplied"]];
+		 .lg.o[`init;"Setting ",(string y)," to ",-3!vals];
+		 set[y;vals]}[params] each ov]}	
 
 override:{overrideconfig[.proc.params]}
 
 loadspeccode:{[ext;dir]
-    $[""~getenv dir;
-     .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
-     loaddir getenv[dir],ext
+	$[""~getenv dir;
+	 .lg.o[`init;"Environment variable ",string[dir]," not set, not loading specific ",ext," code"];
+	 loaddir getenv[dir],ext
    ];
-    };
+	};
 
 reloadcommoncode:{
-    // Load common code from each directory if it exists
-    loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-    };
+	// Load common code from each directory if it exists
+	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 reloadparentprocesscode:{
   // Load parentproctype code from each directory if it exists
   loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
   };
 reloadprocesscode:{
-    // Load proctype code from each directory if it exists
-    loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-    };
+	// Load proctype code from each directory if it exists
+	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 reloadnamecode:{
-    // Load procname code from each directory if it exists
-    loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
-    };
+	// Load procname code from each directory if it exists
+	loadspeccode["/",string procname]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+	};
 
 \d . 
 // Load configuration
 // TorQ loads configuration modules in the order: TorQ Default, Service Specific and then Application Specific
 // Each module loads configuration in the order: default configuration, then process type specific, then process specific
 if[not `noconfig in key .proc.params;
-    // load TorQ Default configuration module
-    .proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
+	// load TorQ Default configuration module
+	.proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
   // check if KDBSERVCONFIG is set and load Service Layer specific configuration module
   $[""~getenv`KDBSERVCONFIG;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG not set, not loading app specific config"];
@@ -554,15 +554,15 @@ if[not `noconfig in key .proc.params;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG set, loading app specific config from ",.proc.servconfig];
     .proc.loadconfig[.proc.servconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
-    // check if KDBAPPCONFIG is set and load Appliation specific configuration module 
-  $[""~getenv`KDBAPPCONFIG; 
-      .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
-      [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
-      .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
-      .proc.loadconfig[.proc.appconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
+	// check if KDBAPPCONFIG is set and load Appliation specific configuration module 
+  $[""~getenv`KDBAPPCONFIG;	
+	  .lg.o[`fileload;"environment variable KDBAPPCONFIG not set, not loading app specific config"];
+	  [.proc.appconfig:getenv[`KDBAPPCONFIG],"/settings/";
+	  .lg.o[`fileload;"environment variable KDBAPPCONFIG set, loading app specific config from ",.proc.appconfig];
+	  .proc.loadconfig[.proc.appconfig;] each `default,.proc.parentproctype,.proc.proctype,.proc.procname]
   ];
-    // Override config from the command line
-    .proc.override[]]
+	// Override config from the command line
+	.proc.override[]]
 
 // Load library code 
 .proc.loadcommoncode:@[value;`.proc.loadcommoncode;1b];
@@ -582,25 +582,25 @@ if[.proc.loadprocesscode;.proc.reloadprocesscode[]]
 if[.proc.loadnamecode;.proc.reloadnamecode[]]
 
 if[`loaddir in key .proc.params;
-    .lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];
-    .proc.loaddir each .proc.params`loaddir]
+	.lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];
+	.proc.loaddir each .proc.params`loaddir]
 
 // Load message handlers after all the other library code
 .proc.loaddir each(getenv$[.proc.loadhandlers & not ""~getenv`KDBSERVCODE;`KDBCODE`KDBSERVCODE;(),`KDBCODE]),\:"/handlers";
 
 // If the timer is loaded, and logrolling is set to true, try to log the roll file on a daily basis
 if[.proc.logroll and not any `debug`noredirect in key .proc.params;
-    $[@[value;`.timer.enabled;0b];
-        [.lg.o[`init;"adding timer function to roll std out/err logs on a daily schedule starting at ",string `timestamp$(.proc.cd[]+1)+00:00];
-         .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.proc.rolllogauto;`);0h;"roll standard out/standard error logs";1b]];
-        .lg.e[`init;".proc.logroll is set to true, but timer functionality is not loaded - cannot roll logs"]]];
-    
+	$[@[value;`.timer.enabled;0b];
+		[.lg.o[`init;"adding timer function to roll std out/err logs on a daily schedule starting at ",string `timestamp$(.proc.cd[]+1)+00:00];
+		 .timer.rep[`timestamp$.proc.cd[]+00:00;0Wp;1D;(`.proc.rolllogauto;`);0h;"roll standard out/standard error logs";1b]];
+		.lg.e[`init;".proc.logroll is set to true, but timer functionality is not loaded - cannot roll logs"]]];
+	
 // Load the file specified on the command line
 if[`load in key .proc.params; .proc.loadf each .proc.params`load]
 
 if[any`debug`nopi in key .proc.params;
-    .lg.o[`init;"Resetting .z.pi to kdb+ default value"];
-    .z.pi:show@value@;]
+	.lg.o[`init;"Resetting .z.pi to kdb+ default value"];
+	.z.pi:show@value@;]
 
 // initialise pubsub
 if[@[value;`.ps.loaded;0b]; .ps.initialise[]]
@@ -609,12 +609,12 @@ if[@[value;`.servers.STARTUP;0b]; .servers.startup[]]
 
 // function to execute functions in .proc.initlist
 .proc.init:{
-    $[count .proc.initlist;
-        [{[a].lg.o[`init;"attemping to run initialisation: ",-3!a];
-        @[value;a;
-        {[x;a].lg.e[`init;x," error - failed to run initialisation: ",-3!a]}[;a]]}
-        each .proc.initlist;.proc.initlist:()];
-        .lg.o[`init;"no initialisation functions found"]];
+	$[count .proc.initlist;
+		[{[a].lg.o[`init;"attemping to run initialisation: ",-3!a];
+		@[value;a;
+		{[x;a].lg.e[`init;x," error - failed to run initialisation: ",-3!a]}[;a]]}
+		each .proc.initlist;.proc.initlist:()];
+		.lg.o[`init;"no initialisation functions found"]];
  }
 
 if[count .proc.initlist;.proc.init[]]

--- a/torq.q
+++ b/torq.q
@@ -345,7 +345,7 @@ $[count[req] = count req inter key params;
   ()];		 
 
 // If parentproctype has been supplied then set it
-parentproctype:();
+parentproctype:`$();
 if[`parentproctype in key params;
     parentproctype:first `$params `parentproctype;
     .lg.o[`init;"read in process parameter of parentproctype=",string parentproctype]];
@@ -566,17 +566,20 @@ if[not `noconfig in key .proc.params;
 
 // Load library code 
 .proc.loadcommoncode:@[value;`.proc.loadcommoncode;1b];
+.proc.loadparentprocesscode:@[value;`.proc.loadparentprocesscode;1b];
 .proc.loadprocesscode:@[value;`.proc.loadprocesscode;1b];
 .proc.loadnamecode:@[value;`.proc.loadnamecode;0b];
 .proc.loadhandlers:@[value;`.proc.loadhandlers;1b];
 .proc.logroll:@[value;`.proc.logroll;1]
 .lg.o[`init;".proc.loadcommoncode flag set to ",string .proc.loadcommoncode];
+.lg.o[`init;".proc.loadparentprocesscode flag set to ",string .proc.loadparentprocesscode];
 .lg.o[`init;".proc.loadprocesscode flag set to ",string .proc.loadprocesscode];
 .lg.o[`init;".proc.loadnamecode flag set to ",string .proc.loadnamecode];
 .lg.o[`init;".proc.loadhandlers flag set to ",string .proc.loadhandlers];
 .lg.o[`init;".proc.logroll flag set to ",string .proc.logroll];
 
 if[.proc.loadcommoncode; .proc.reloadcommoncode[]]
+if[.proc.loadparentprocesscode & not null first .proc.parentproctype;.proc.reloadparentprocesscode[]]
 if[.proc.loadprocesscode;.proc.reloadprocesscode[]]
 if[.proc.loadnamecode;.proc.reloadnamecode[]]
 

--- a/torq.q
+++ b/torq.q
@@ -345,7 +345,7 @@ $[count[req] = count req inter key params;
   ()];		 
 
 // If parentproctype has been supplied then set it
-parentproctype:`$();
+parentproctype:();
 if[`parentproctype in key params;
 	parentproctype:first `$params `parentproctype;
 	.lg.o[`init;"read in process parameter of parentproctype=",string parentproctype]];
@@ -577,7 +577,7 @@ if[not `noconfig in key .proc.params;
 .lg.o[`init;".proc.logroll flag set to ",string .proc.logroll];
 
 if[.proc.loadcommoncode; .proc.reloadcommoncode[]]
-if[.proc.loadprocesscode & not null first .proc.parentproctype;.proc.reloadparentprocesscode[]]
+if[.proc.loadprocesscode & not null first `symbol$.proc.parentproctype;.proc.reloadparentprocesscode[]]
 if[.proc.loadprocesscode;.proc.reloadprocesscode[]]
 if[.proc.loadnamecode;.proc.reloadnamecode[]]
 

--- a/torq.q
+++ b/torq.q
@@ -576,10 +576,13 @@ if[not `noconfig in key .proc.params;
 .lg.o[`init;".proc.loadhandlers flag set to ",string .proc.loadhandlers];
 .lg.o[`init;".proc.logroll flag set to ",string .proc.logroll];
 
-if[.proc.loadcommoncode; .proc.reloadcommoncode[]]
-if[.proc.loadprocesscode & not null first `symbol$.proc.parentproctype;.proc.reloadparentprocesscode[]]
-if[.proc.loadprocesscode;.proc.reloadprocesscode[]]
-if[.proc.loadnamecode;.proc.reloadnamecode[]]
+.proc.reloadallcode:{
+	if[.proc.loadcommoncode; .proc.reloadcommoncode[]];
+	if[.proc.loadprocesscode & not null first `symbol$.proc.parentproctype;.proc.reloadparentprocesscode[]];
+	if[.proc.loadprocesscode;.proc.reloadprocesscode[]];
+	if[.proc.loadnamecode;.proc.reloadnamecode[]];
+	};
+.proc.reloadallcode[];
 
 if[`loaddir in key .proc.params;
 	.lg.o[`init;"loaddir flag found - loading files in directory ",first .proc.params`loaddir];

--- a/torq.q
+++ b/torq.q
@@ -566,20 +566,18 @@ if[not `noconfig in key .proc.params;
 
 // Load library code 
 .proc.loadcommoncode:@[value;`.proc.loadcommoncode;1b];
-.proc.loadparentprocesscode:@[value;`.proc.loadparentprocesscode;1b];
 .proc.loadprocesscode:@[value;`.proc.loadprocesscode;1b];
 .proc.loadnamecode:@[value;`.proc.loadnamecode;0b];
 .proc.loadhandlers:@[value;`.proc.loadhandlers;1b];
 .proc.logroll:@[value;`.proc.logroll;1]
 .lg.o[`init;".proc.loadcommoncode flag set to ",string .proc.loadcommoncode];
-.lg.o[`init;".proc.loadparentprocesscode flag set to ",string .proc.loadparentprocesscode];
 .lg.o[`init;".proc.loadprocesscode flag set to ",string .proc.loadprocesscode];
 .lg.o[`init;".proc.loadnamecode flag set to ",string .proc.loadnamecode];
 .lg.o[`init;".proc.loadhandlers flag set to ",string .proc.loadhandlers];
 .lg.o[`init;".proc.logroll flag set to ",string .proc.logroll];
 
 if[.proc.loadcommoncode; .proc.reloadcommoncode[]]
-if[.proc.loadparentprocesscode & not null first .proc.parentproctype;.proc.reloadparentprocesscode[]]
+if[.proc.loadprocesscode & not null first .proc.parentproctype;.proc.reloadparentprocesscode[]]
 if[.proc.loadprocesscode;.proc.reloadprocesscode[]]
 if[.proc.loadnamecode;.proc.reloadnamecode[]]
 

--- a/torq.q
+++ b/torq.q
@@ -344,6 +344,11 @@ $[count[req] = count req inter key params;
 	.lg.o[`init;"ignoring partial subset of required process parameters found on the command line - reading from file"];
   ()];		 
 
+// If parentproctype has been supplied then set it
+parentproctype:$[`parentproctype in key params;
+  first `$params `parentproctype;
+  ()];
+
 checkdependency[getconfig["dependency.csv";1]]
 
 // If any of the required parameters are null, try to read them from a file
@@ -521,6 +526,10 @@ reloadcommoncode:{
 	// Load common code from each directory if it exists
 	loadspeccode["/common"]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
 	};
+reloadparentprocesscode:{
+  // Load parentproctype code from each directory if it exists
+  loadspeccode["/",string parentproctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
+  };
 reloadprocesscode:{
 	// Load proctype code from each directory if it exists
 	loadspeccode["/",string proctype]'[`KDBCODE`KDBSERVCODE`KDBAPPCODE];
@@ -536,7 +545,7 @@ reloadnamecode:{
 // Each module loads configuration in the order: default configuration, then process type specific, then process specific
 if[not `noconfig in key .proc.params;
 	// load TorQ Default configuration module
-	.proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.proctype,.proc.procname;
+	.proc.loadconfig[getenv[`KDBCONFIG],"/settings/";] each `default,.proc.parentproctype,.proc.proctype,.proc.procname;
   // check if KDBSERVCONFIG is set and load Service Layer specific configuration module
   $[""~getenv`KDBSERVCONFIG;
     .lg.o[`fileload;"environment variable KDBSERVCONFIG not set, not loading app specific config"];


### PR DESCRIPTION
Add the ability to specify a parentproctype for a process when starting using torq.

If specified then the specified parent process configuration will be loaded after default.q but before the process type.

Then the parent process code in [parentproctype] subdirectory of the various code directories will be loaded after default and before the specific process