### PR TITLE
Update icounts and jcounts initialisation to typed dict

### DIFF
--- a/code/processes/chainedtp.q
+++ b/code/processes/chainedtp.q
@@ -16,7 +16,7 @@ clearlogonsubscription:@[value;`clearlogonsubscription;0b];	/- clear logfile on 
 
 
 tph:0N;								/- setting tickerplant handle to null
-.u.icounts:.u.jcounts:(`symbol$())!`long$();    /- initialise icounts & jcounts dict
+.u.icounts:.u.jcounts:(`symbol$())!0#0,();    /- initialise icounts & jcounts dict
 .u.i:.u.j:0;			
 /- clears log
 clearlog:{[lgfile]
@@ -122,7 +122,7 @@ refreshtp:{[d]
   if[@[value;`.u.l;0]; @[hclose;.u.l;()]];
   /- reset log and publish count
   .u.i:.u.j:0;
-  .u.icounts::.u.jcounts::(`symbol$())!`long$();
+  .u.icounts::.u.jcounts::(`symbol$())!0#0,();
   /- create new logfile name
   .u.L:createlogfilename[d];
   /- log file handle

--- a/code/processes/chainedtp.q
+++ b/code/processes/chainedtp.q
@@ -16,7 +16,8 @@ clearlogonsubscription:@[value;`clearlogonsubscription;0b];	/- clear logfile on 
 
 
 tph:0N;								/- setting tickerplant handle to null
-.u.icounts:.u.jcounts:()!();.u.i:.u.j:0;			/- initialise icounts & jcounts dict
+.u.icounts:.u.jcounts:(`symbol$())!`long$();    /- initialise icounts & jcounts dict
+.u.i:.u.j:0;			
 /- clears log
 clearlog:{[lgfile]
   if[not type key lgfile;:()];
@@ -121,7 +122,7 @@ refreshtp:{[d]
   if[@[value;`.u.l;0]; @[hclose;.u.l;()]];
   /- reset log and publish count
   .u.i:.u.j:0;
-  .u.icounts::.u.jcounts::()!();
+  .u.icounts::.u.jcounts::(`symbol$())!`long$();
   /- create new logfile name
   .u.L:createlogfilename[d];
   /- log file handle

--- a/code/processes/tickerplant.q
+++ b/code/processes/tickerplant.q
@@ -33,12 +33,12 @@
 upd:{[tab;x] .u.icounts[tab]+::count first x;}
 
 \d .u
-jcounts:(`symbol$())!`long$();
-icounts:(`symbol$())!`long$();  / set up dictionary for per table counts
+jcounts:(`symbol$())!0#0,();
+icounts:(`symbol$())!0#0,();  / set up dictionary for per table counts
 ld:{if[not type key L::`$(-10_string L),string x;.[L;();:;()]];i::j::@[-11!;L;i::-11!(-2;L)];jcounts::icounts;if[0 < type i;-2 (string L)," is a corrupt log. Truncate to length ",(string last i)," and restart";exit 1];hopen L};
 tick:{init[];if[not min(`time`sym~2#key flip value@)each t;'`timesym];@[;`sym;`g#]each t;d::.eodtime.d;if[l::count y;L::`$":",y,"/",x,10#".";l::ld d]};
 
-endofday:{end d;d+:1;icounts::(`symbol$())!`long$();if[.z.p>.eodtime.nextroll:.eodtime.getroll[.z.p];system"t 0";'"next roll is in the past"];.eodtime.dailyadj:.eodtime.getdailyadjustment[];if[l;hclose l;l::0(`.u.ld;d)]};
+endofday:{end d;d+:1;icounts::(`symbol$())!0#0,();if[.z.p>.eodtime.nextroll:.eodtime.getroll[.z.p];system"t 0";'"next roll is in the past"];.eodtime.dailyadj:.eodtime.getdailyadjustment[];if[l;hclose l;l::0(`.u.ld;d)]};
 ts:{if[.eodtime.nextroll < x;if[d<("d"$x)-1;system"t 0";'"more than one day?"];endofday[]]};
 
 

--- a/code/processes/tickerplant.q
+++ b/code/processes/tickerplant.q
@@ -33,8 +33,8 @@
 upd:{[tab;x] .u.icounts[tab]+::count first x;}
 
 \d .u
-jcounts:()!() 
-icounts:(`symbol$())!`long$()  / set up dictionary for per table counts
+jcounts:(`symbol$())!`long$();
+icounts:(`symbol$())!`long$();  / set up dictionary for per table counts
 ld:{if[not type key L::`$(-10_string L),string x;.[L;();:;()]];i::j::@[-11!;L;i::-11!(-2;L)];jcounts::icounts;if[0 < type i;-2 (string L)," is a corrupt log. Truncate to length ",(string last i)," and restart";exit 1];hopen L};
 tick:{init[];if[not min(`time`sym~2#key flip value@)each t;'`timesym];@[;`sym;`g#]each t;d::.eodtime.d;if[l::count y;L::`$":",y,"/",x,10#".";l::ld d]};
 

--- a/code/processes/tickerplant.q
+++ b/code/processes/tickerplant.q
@@ -34,11 +34,11 @@ upd:{[tab;x] .u.icounts[tab]+::count first x;}
 
 \d .u
 jcounts:()!() 
-icounts:()!()  / set up dictionary for per table counts
+icounts:(`symbol$())!`long$()  / set up dictionary for per table counts
 ld:{if[not type key L::`$(-10_string L),string x;.[L;();:;()]];i::j::@[-11!;L;i::-11!(-2;L)];jcounts::icounts;if[0 < type i;-2 (string L)," is a corrupt log. Truncate to length ",(string last i)," and restart";exit 1];hopen L};
 tick:{init[];if[not min(`time`sym~2#key flip value@)each t;'`timesym];@[;`sym;`g#]each t;d::.eodtime.d;if[l::count y;L::`$":",y,"/",x,10#".";l::ld d]};
 
-endofday:{end d;d+:1;icounts::()!();if[.z.p>.eodtime.nextroll:.eodtime.getroll[.z.p];system"t 0";'"next roll is in the past"];.eodtime.dailyadj:.eodtime.getdailyadjustment[];if[l;hclose l;l::0(`.u.ld;d)]};
+endofday:{end d;d+:1;icounts::(`symbol$())!`long$();if[.z.p>.eodtime.nextroll:.eodtime.getroll[.z.p];system"t 0";'"next roll is in the past"];.eodtime.dailyadj:.eodtime.getdailyadjustment[];if[l;hclose l;l::0(`.u.ld;d)]};
 ts:{if[.eodtime.nextroll < x;if[d<("d"$x)-1;system"t 0";'"more than one day?"];endofday[]]};
 
 


### PR DESCRIPTION
Change the initialisation of icounts and jcounts in tickerplant and chainedtp from an untyped empty dictionary to an empty dictionary with key type \`symbol and value type \`long. 