### PR TITLE
Fix process variable to get all processes

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -3,110 +3,110 @@
 . ./setenv.sh                                                                                       # load the environment
 
 getfield() {
-  fieldno=`awk -F, '{if(NR==1) for(i=1;i<=NF;i++){if($i=="'$2'") print i}}' $CSVPATH`               # get number for field based on headers
-  fieldval=`awk -F, '{if(NR == '$1') print $'$fieldno'}' $CSVPATH`                                  # pull one field from one line of file
-  echo $fieldval | envsubst                                                                         # substitute env vars
+  fieldno=$(awk -F, '{if(NR==1) for(i=1;i<=NF;i++){if($i=="'$2'") print i}}' "$CSVPATH")            # get number for field based on headers
+  fieldval=$(awk -F, '{if(NR == '$1') print $'$fieldno'}' "$CSVPATH")                               # pull one field from one line of file
+  echo "$fieldval" | envsubst                                                                       # substitute env vars
  }
 
 parameter() {
-  fieldval=`getfield $1 $2`
+  fieldval=$(getfield "$1" "$2")
   if [[ "" == "$fieldval" ]]; then                                                                  # check for empty string
     echo ""
   else
-    echo " -"$2 $fieldval
+    echo " -""$2" "$fieldval"
   fi
  }
 
 findproc() {
-  procno=`awk '/,'$1',/{print NR}' $CSVPATH`                                                        # get line number for file
-  pgrep -f "\-stackid ${KDBBASEPORT} \-proctype $(getfield $procno proctype) \-procname $1"         # get pid of process
+  procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")                                                     # get line number for file
+  pgrep -f "\-stackid ${KDBBASEPORT} \-proctype $(getfield "$procno" proctype) \-procname $1"       # get pid of process
  }
 
 startline() {
-  procno=`awk '/,'$1',/{print NR}' $CSVPATH`                                                        # get line number for file
-  proctype=`getfield $procno "proctype"`                                                            # get proctype for process 
+  procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")                                                     # get line number for file
+  proctype=$(getfield "$procno" "proctype")                                                         # get proctype for process 
   params="U localtime g T w load"                                                                   # list of params to read from config 
   sline="${TORQHOME}/torq.q -stackid ${KDBBASEPORT} -proctype $proctype -procname $1"               # base part of startup line
   for p in $params;                                                                                 # iterate over params
   do
-    a=`parameter $procno $p`;                                                                       # get param
+    a=$(parameter "$procno" "$p");                                                                  # get param
     sline="$sline$a";                                                                               # append to startup line
   done
-  qcmd=`getfield $procno "qcmd"`
-  sline="$qcmd $sline $(getfield $procno extras) -procfile $CSVPATH $EXTRAS"                        # append csv file and extra arguments to startup line
-  echo $sline
+  qcmd=$(getfield "$procno" "qcmd")
+  sline="$qcmd $sline $(getfield "$procno" extras) -procfile $CSVPATH $EXTRAS"                      # append csv file and extra arguments to startup line
+  echo "$sline"
  }
 
 start() {
-  if [[ -z `findproc $1` ]]; then                                                                   # check process not running
-    sline=$(startline $1)                                                                           # line to run each process
-    echo `date '+%H:%M:%S'` "| Starting $1..."
+  if [[ -z $(findproc "$1") ]]; then                                                                # check process not running
+    sline=$(startline "$1")                                                                         # line to run each process
+    echo "$(date '+%H:%M:%S') | Starting $1..."
     eval "nohup $sline </dev/null >${KDBLOG}/torq${1}.txt 2>&1 &"                                   # run in background and redirect output to log file
   else
-    echo `date '+%H:%M:%S'` "| $1 already running"
+    echo "$(date '+%H:%M:%S') | $1 already running"
   fi 
  }
 
 print() {
-  sline=$(startline $1)                                                                             # line to run each process 
+  sline=$(startline "$1")                                                                           # line to run each process 
   echo "Start line for $1:"
   echo "nohup $sline </dev/null >${KDBLOG}/torq${1}.txt 2>&1 &"                                     # echo not evaluate to print
  }
 
 debug() {
-  proc=`getprocs $0 $1`;                                                                            # check input process in csv
-  if [[ `echo $proc | grep "unavailable"` ]]; then                                                  
-    echo $proc                                                                                      # print input process unavailable 
+  proc=$(getprocs "$0" "$1");                                                                       # check input process in csv
+  if [[ $(echo "$proc" | grep "unavailable") ]]; then                                                  
+    echo "$proc"                                                                                    # print input process unavailable 
   else 
-    sline=$(startline $1)                                                                           # get start line for process
+    sline=$(startline "$1")                                                                         # get start line for process
     eval "$sline -debug"                                                                            # append flag to start in debug mode
   fi
  }
 
 summary() {
-  if [[ -z `findproc $1` ]]; then                                                                   # check process not running
-    printf "%-8s | %-14s | %-6s |\n" `date '+%H:%M:%S'` "$1" "down"                                 # summary table row for down process
+  if [[ -z $(findproc "$1") ]]; then                                                                # check process not running
+    printf "%-8s | %-14s | %-6s |\n" "$(date '+%H:%M:%S')" "$1" "down"                              # summary table row for down process
   else
-    pid=$(findproc $1)
-    port=`netstat -nlp 2>/dev/null | grep $pid | awk '{ print $4 }' | head -1 | awk -F: '{ print $2 }'`  
-    printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" `date '+%H:%M:%S'` "$1" "up" "$port" "$pid"        # summary table row for running process    
+    pid=$(findproc "$1")
+    port=$(netstat -nlp 2>/dev/null | grep "$pid" | awk '{ print $4 }' | head -1 | awk -F: '{ print $2 }')  # get port process is running on
+    printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" "$(date '+%H:%M:%S')" "$1" "up" "$port" "$pid"     # summary table row for running process    
   fi
  }
 
 stop() {
-  if [[ -z `findproc $1` ]]; then                                                                   # check process not running
-    echo `date '+%H:%M:%S'` "| $1 is not currently running"
+  if [[ -z $(findproc "$1") ]]; then                                                                # check process not running
+    echo "$(date '+%H:%M:%S') | $1 is not currently running"
   else
-    echo `date '+%H:%M:%S'` "| Shutting down $1..."
-    pid=$(findproc $1)
+    echo "$(date '+%H:%M:%S') | Shutting down $1..."
+    pid=$(findproc "$1")
     eval "kill -15 $pid"                                                                            # kill process pid
   fi
  }
 
 getall() {
-  procs=`awk -F, '{if(NR>1) print $4}' $CSVPATH`                                                    # get all processes from csv
+  procs=$(awk -F, '{if(NR>1) print $4}' "$CSVPATH")                                                 # get all processes from csv
   start=""
   for a in $procs;
   do
-    procno=`awk '/,'$a',/{print NR}' $CSVPATH`                                                      # get line number for file
-    f=`getfield $procno startwithall` 
+    procno=$(awk '/,'$a',/{print NR}' "$CSVPATH")                                                   # get line number for file
+    f=$(getfield "$procno" startwithall) 
     if [[ "1" == "$f" ]]; then                                                                      # checks csv column startwithall equals 1
       start="$start $a"
     fi
   done
-  echo $start
+  echo "$start"
  }
 
 checkinput() {
   input=$*                                                                                          # get all input process names
-  PROCS=`awk -F, '{if(NR>1) print $4}' $CSVPATH`                                                    # get all process names from csv
+  PROCS=$(awk -F, '{if(NR>1) print $4}' "$CSVPATH")                                                 # get all process names from csv
   avail=()
   for i in $input;
   do 
-    if [[ `echo "$PROCS" | grep -w "$i"` ]]; then                                                   # check input process is valid
+    if [[ $(echo "$PROCS" | grep -w "$i") ]]; then                                                  # check input process is valid
       avail+="$i "                                                                                  # get only valid processes
     else 
-      echo `date '+%H:%M:%S'` "| $i failed - unavailable processname"
+      echo "$(date '+%H:%M:%S') | $i failed - unavailable processname"
     fi
   done
   PROCS=$avail                                                                                      # assign valid processes
@@ -117,7 +117,7 @@ getprocs() {
     PROCS=$(getall)                                                                                 # get all processes
   else
     shift                                                                                           # ignore first argument
-    checkinput $@                                                                                   # check input process names
+    checkinput "$@"                                                                                 # check input process names
   fi
  }
 
@@ -125,43 +125,43 @@ flag() {
   count=0
   for i in ${BASH_ARGV[*]};
   do
-    count=$(($count+1))
+    count=$((count+1))
     if [[ $i == "-$1" ]]; then                                                                      # find flag argument in command line
-      N=$(($count-2))                                                                               # find index of flag arugment 
+      N=$((count-2))                                                                                # find index of flag arugment 
     fi
   done
  }
 
 flagextras() {
-  flag $@
+  flag "$*"
   z=$N
   while [ $z -ge 0 ]; 
   do
     EXTRAS+="${BASH_ARGV[$z]} "                                                                     # get all parameters following extras flag
-    z=$[$z-1]
+    z=$((z-1))
   done
  }
 
 flagcsv() {
-  flag $@
+  flag "$*"
   CSVPATH="${BASH_ARGV[$N]}"                                                                        # assign specifed csv file
  }
 
 getextras() {
-  if [[ `echo ${BASH_ARGV[*]} | grep -e extras` ]]; then                                            
+  if [[ $(echo ${BASH_ARGV[*]} | grep -e extras) ]]; then                                            
     eval flagextras "extras";                                                                       # get arguments following flag
-    length=$(($#-$N-2));                                                                            # number of arguments minus extras 
-    array=${@:1:$length};                                                                           # arguments without extras 
+    length=$(($#-N-2));                                                                             # number of arguments minus extras 
+    array=${*:1:$length};                                                                           # arguments without extras 
   else
-    array=$@;
+    array=$*;
   fi
  }
 
 getcsv() {
-  if [[ `echo ${BASH_ARGV[*]} | grep -e csv` ]]; then
+  if [[ $(echo ${BASH_ARGV[*]} | grep -e csv) ]]; then
     eval flagcsv "csv";                                                                             # get csv file following flag
     length=$(($#-2));                                                                               # number of arguments minus csv 
-    array=${@:1:$length};                                                                           # arguments without csv 
+    array=${*:1:$length};                                                                           # arguments without csv 
     getprocs $array;
   else
     CSVPATH=${TORQPROCESSES};                                                                       # set csv file to default
@@ -172,13 +172,13 @@ getcsv() {
 getextrascsv() {
   eval flagextras "extras";                                                                         # get arguments following flag
   eval flagcsv "csv";
-  length=$(($#-$N-2));
-  array=${@:1:$length};                                                                             # arguments without extras and csv
+  length=$(($#-N-2));
+  array=${*:1:$length};                                                                             # arguments without extras and csv
   getprocs $array;                                                                                  # get process names from the remaining arguments
  }
 
 checkextrascsv() {
-  if [[ `echo ${BASH_ARGV[*]} | grep -e extras` ]] && [[ `echo ${BASH_ARGV[*]} | grep -e csv` ]]; then
+  if [[ $(echo ${BASH_ARGV[*]} | grep -e extras) ]] && [[ $(echo ${BASH_ARGV[*]} | grep -e csv) ]]; then
     getextrascsv $@;                                                                                # gets extras and csv arguments 
   else
     getextras $@;                                                                                   # checks if extras flag present
@@ -187,7 +187,7 @@ checkextrascsv() {
  }
 
 allcsv() {
-  if [[ `echo ${BASH_ARGV[*]} | grep -e csv` ]]; then
+  if [[ $(echo ${BASH_ARGV[*]} | grep -e csv) ]]; then
     eval flagcsv "csv";                                                                             # get all procs from csv without starting 
   else
     CSVPATH=${TORQPROCESSES};                                                                            
@@ -197,14 +197,14 @@ allcsv() {
 startprocs() {
   for p in $PROCS;
   do
-    start $p;                                                                                       # start each process in variable
+    start "$p";                                                                                     # start each process in variable
   done
  }
 
 stopprocs() {
   for p in $PROCS;
   do
-    stop $p;                                                                                        # kill each process in variable 
+    stop "$p";                                                                                      # kill each process in variable 
   done
  }
 
@@ -225,34 +225,34 @@ usage() {
 
 
 if [[ "$1" == "start" ]]; then
-  if [[ `echo ${BASH_ARGV[*]} | grep -e print` ]]; then         
-    checkextrascsv ${*%${!#}};
+  if [[ $(echo ${BASH_ARGV[*]} | grep -e print) ]]; then         
+    checkextrascsv "${*%${!#}}";
     for p in $PROCS;
     do 
-      print $p;  
+      print "$p";  
     done
   else 
-    checkextrascsv $@;
-    startprocs $PROCS;
+    checkextrascsv "$*";
+    startprocs "$PROCS";
   fi
 elif [[ "$1" == "stop" ]]; then
   checkextrascsv $@;
-  stopprocs $PROCS;
+  stopprocs "$PROCS";
 elif [[ "$1" == "summary" ]]; then
-  allcsv $@;
-  PROCS=`awk -F, '{if(NR>1) print $4}' $CSVPATH`;
+  allcsv "$*";
+  PROCS=$(awk -F, '{if(NR>1) print $4}' "$CSVPATH");
   printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" "TIME" "PROCESS" "STATUS" "PORT" "PID"
   for p in $PROCS;
   do
-    summary $p;
+    summary "$p";
   done
 elif [[ "$1" == "procs" ]]; then
-  allcsv $@;
-  echo `awk -F, '{if(NR>1) print $4}' $CSVPATH` | tr " " "\n";
+  allcsv "$*";
+  awk -F, '{if(NR>1) print $4}' "$CSVPATH" | tr " " "\n"
 elif [[ "$2" == "-debug" ]]; then
-  allcsv $@;
-  debug $1;
-elif [[ $# -eq 0 ]]; then                                                                             
+  allcsv "$*";
+  debug "$1";
+elif [[ "$#" -eq 0 ]]; then                                                                             
   usage
 else
   echo "Invalid argument(s)"

--- a/torq.sh
+++ b/torq.sh
@@ -68,7 +68,7 @@ summary() {
     printf "%-8s | %-14s | %-6s |\n" `date '+%H:%M:%S'` "$1" "down"                                 # summary table row for down process
   else
     pid=$(findproc $1)
-    port=`netstat -pl 2>/dev/null | grep $pid | awk '{ print $4 }' | head -1 | cut -c 3-`           # get port process is running on 
+    port=`netstat -nlp 2>/dev/null | grep $pid | awk '{ print $4 }' | head -1 | awk -F: '{ print $2 }'`  
     printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" `date '+%H:%M:%S'` "$1" "up" "$port" "$pid"        # summary table row for running process    
   fi
  }


### PR DESCRIPTION
This PR will fix the problem of not being able to access processes with `startwithall` set to 0 in `process.csv`.  

I have made the following changes:

- `getall`  is a function that gets all processes with `startwithall` set to 1. I have replaced some of these with `awk -F, '{if(NR>1) print $4}' $CSVPATH` which will get all the processes. I have only changed this for the `PROCS` variables that are used to check the process exists. 
- the debug flag was echoing the wrong start line before evaluating the correct line. I have modified this so that it doesn't echo the line it doesn't use.
- small change to the port variable in the summary function. Additional `-n` flag to `netstat` to get port numbers where there were occasionally names. 