### PR TITLE
Add absolute path to bash scripts

### DIFF
--- a/monit/bin/monit.sh
+++ b/monit/bin/monit.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 #FUNCTION DECLARATION ###############################################################################
 
- cd ../.. && export BASEDIR="${PWD}" && cd - > /dev/null;                                           # set BASEDIR to the root of the torq directory
- mkdir -p ../logs  
+if [ "-bash" = $0 ]; then
+  BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+  BASEDIR="$(cd "$(dirname "$0")" && pwd)"
+fi
+BASEDIR=$(dirname $(dirname $BASEDIR))                                                              # set BASEDIR to root of TorQ directory
+mkdir -p ${BASEDIR}/monit/logs                                                                      # create directory for monit logs
 
 checkst(){
 #function to check if file exists 

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,12 +1,14 @@
+#!/bin/bash
+
 if [ "-bash" = $0 ]; then
-    dirpath="${BASH_SOURCE[0]}"
+  dirpath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 else
-    dirpath="$0"
+  dirpath="$(cd "$(dirname "$0")" && pwd)"
 fi
 
-export TORQHOME=$(dirname $dirpath)                                                                 # if running the kdb+tick example, change these to full paths
-export TORQDATA=$(dirname $dirpath)                                                                 # some of the kdb+tick processes will change directory, and these will no longer be valid
-export TORQAPPHOME=$(dirname $dirpath)
+export TORQHOME=$dirpath                                                                            # if running the kdb+tick example, change these to full paths
+export TORQDATA=$dirpath                                                                            # some of the kdb+tick processes will change directory, and these will no longer be valid
+export TORQAPPHOME=$dirpath
 
 export KDBLOG=${TORQDATA}/logs
 export KDBHTML=${TORQHOME}/html
@@ -24,4 +26,4 @@ export TORQPROCESSES=${KDBAPPCONFIG}/process.csv                                
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KDBLIB/l32
 
-export TORQMONIT=${TORQHOME}/logs/monit                                                             # set the folder for monit outputs  
+export TORQMONIT=${TORQHOME}/logs/monit                                                             # set the folder for monit outputs

--- a/torq.sh
+++ b/torq.sh
@@ -1,4 +1,22 @@
-#!/bin/bash 
+#!/bin/bash
+
+if [ "-bash" = $0 ]; then
+  dirpath="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+  dirpath="$(cd "$(dirname "$0")" && pwd)"
+fi
+
+if [ -z $SETENV ]; then
+  SETENV=${dirpath}/setenv.sh                                                                       # set the environment if not predefined
+fi
+
+if [ -f $SETENV ]; then                                                                             # check script exists
+  . $SETENV                                                                                         # load the environment
+else
+  echo "ERROR: Failed to load environment - $SETENV: No such file or directory"                     # show input file error
+  exit 1
+fi
+
 
 getfield() {
   fieldno=$(awk -F, '{if(NR==1) for(i=1;i<=NF;i++){if($i=="'$2'") print i}}' "$CSVPATH")            # get number for field based on headers
@@ -214,22 +232,6 @@ usage() {
   exit 1
  }
 
-if [ "-bash" = $0 ]; then
-    dirpath="${BASH_SOURCE[0]}"
-else
-    dirpath="$0"
-fi
-
-if [[ -z $SETENV ]]; then
-  SETENV=$(dirname $dirpath)/setenv.sh;                                                             # set the environment if not predefined
-fi
-
-if [ -f $SETENV ]; then                                                                             # check script exists 
-  . $SETENV                                                                                         # load the environment
-else
-  echo "ERROR: Failed to load environment - $SETENV: No such file or directory"                     # show input file error
-  exit 1
-fi
 
 case $1 in
   start)


### PR DESCRIPTION
A few of the bash scripts are using relative paths instead of absolute paths, I've updated 3 of them for a start to ensure absolute paths are used. I've also made some minor modifications to the layout of the bash scripts in accordance to this [style guide](https://google.github.io/styleguide/shell.xml) (although I'm, sure I haven't got everything it says).

I've rearranged `torq.sh` so the check for missing `setenv.sh` occurs near the start of the file.

It also looks like this monit addition is a little fragile, I'm going to add some comments later on to highlight a couple of the issues I think exist with it.