### PR TITLE
Improve .proc.init functionality

### DIFF
--- a/torq.q
+++ b/torq.q
@@ -614,26 +614,22 @@ if[@[value;`.servers.STARTUP;0b]; .servers.startup[]]
 // function to execute functions in .proc.initlist
 .proc.try:{[id;a]
   .lg.o[id;"attempting to run: ",.Q.s1 a];
-  success:@[value;a;{[id;a;x].lg.e[id;x," error - failed to run: ",.Q.s1 a];:1b}[id;a]];
-  if[-1h=type success;:()];
+  success:@[{value x;1b};a;{[id;a;x].lg.e[id;x," error - failed to run: ",.Q.s1 a];0b}[id;a]];
+  if[not success;:()];
   .proc.initexecuted,:a;
   .lg.o[id;"run successful: ",.Q.s1 a];
  }
 
 .proc.initcmd:{
   // command line functions executed first
-  $[`initlist in key .proc.params;
-    {.proc.try[`init;(x;`)]}each .proc.params`initlist;
-    .lg.o[`init;"no initialisation functions found in cmd line args"]
-   ];
+  if[not`initlist in key .proc.params;:.lg.o[`init;"no initialisation functions found in cmd line args"]];
+  {.proc.try[`init;(x;`)]}each .proc.params`initlist;
  }
 
 .proc.init:{
   .proc.initcmd[];
-  $[count .proc.initlist;
-    .proc.try[`init]each .proc.initlist;
-    .lg.o[`init;"no initialisation functions found"]
-   ];
+  if[0=count .proc.initlist;:.lg.o[`init;"no initialisation functions found"]];
+  .proc.try[`init]each .proc.initlist;
   .proc.initlist:();
  }
 

--- a/torq.q
+++ b/torq.q
@@ -611,16 +611,29 @@ if[@[value;`.ps.loaded;0b]; .ps.initialise[]]
 // initialise connections
 if[@[value;`.servers.STARTUP;0b]; .servers.startup[]]
 
+// function to execute functions in .proc.initlist
 .proc.try:{[id;a]
-  .lg.o[id;"attemping to run: ",.Q.s1 a];
-  @[value;a;{[id;a;x].lg.e[id;x," error - failed to run: ",.Q.s1 a]}[id;a]];
+  .lg.o[id;"attempting to run: ",.Q.s1 a];
+  success:@[value;a;{[id;a;x].lg.e[id;x," error - failed to run: ",.Q.s1 a];:1b}[id;a]];
+  if[-1h=type success;:()];
+  .proc.initexecuted,:a;
+  .lg.o[id;"run successful: ",.Q.s1 a];
  }
 
-// function to execute functions in .proc.initlist
+.proc.initcmd:{
+  // command line functions executed first
+  $[`initlist in key .proc.params;
+    {.proc.try[`init;(x;`)]}each .proc.params`initlist;
+    .lg.o[`init;"no initialisation functions found in cmd line args"]
+   ];
+ }
+
 .proc.init:{
-  if[0=count .proc.initlist;:.lg.o[`init;"no initialisation functions found"]];
-  .proc.try[`init]each .proc.initlist;
-  .proc.initexecuted,:.proc.initlist;
+  .proc.initcmd[];
+  $[count .proc.initlist;
+    .proc.try[`init]each .proc.initlist;
+    .lg.o[`init;"no initialisation functions found"]
+   ];
   .proc.initlist:();
  }
 


### PR DESCRIPTION
# Improve .proc.init functionality! :computer:

### PR general description
This pull request adds a function to take command line functions from -initlist and run the new function .proc.initcmd prior to the current .proc.initlist as called by .proc.init[]. It has updated .proc.init and .proc.try to also wipe .proc.initlist, update .init.initexectued and to print success log messages.

### Why is this PR necessary?
To keep track of additional functions being executed.
 
### Final Checklist
- [x] My code follows the code style of this project
- [x] My code is commented appropriately and concisely
- [x] If necessary, I have added new appropriate labels to this PR
- [x] I have assigned the appropriate users to this PR