### PR TITLE
Remove logging for 0D keepquerytime

### DIFF
--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -145,8 +145,7 @@ canberun:{
 
 // Manage client queries
 addquerytimeout:{[query;servertype;queryattributes;join;postback;timeout;sync]
-  if[.gw.querykeeptime<>0D;
-    `.gw.queryqueue upsert (nextqueryid[];.proc.cp[];.z.w;query;servertype;queryattributes;join;postback;timeout;0Np;0Np;0b;0<count queryattributes;sync)]
+  `.gw.queryqueue upsert (nextqueryid[];.proc.cp[];.z.w;query;servertype;queryattributes;join;postback;timeout;0Np;0Np;0b;0<count queryattributes;sync);
  };
 
 removeclienthandle:{
@@ -179,8 +178,9 @@ getnextquery:{
 finishquery:{[qid;err;serverh] 
  deleteresult[qid];
  update error:err,returntime:.proc.cp[] from `.gw.queryqueue where queryid in qid;
+ if[.gw.querykeeptime=0D; .gw.removequeries[.gw.querykeeptime]];
  setserverstate[serverh;0b];
- }  
+ } 
 
 // Get a list of pending and running queries
 getqueue:{select queryid,time,clienth,query,servertype,status:?[null submittime;`pending;`running],submittime from .gw.queryqueue where null returntime}

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -145,8 +145,10 @@ canberun:{
 
 // Manage client queries
 addquerytimeout:{[query;servertype;queryattributes;join;postback;timeout;sync]
-  `.gw.queryqueue upsert (nextqueryid[];.proc.cp[];.z.w;query;servertype;queryattributes;join;postback;timeout;0Np;0Np;0b;0<count queryattributes;sync)
+  if[.gw.querykeeptime<>0D;
+    `.gw.queryqueue upsert (nextqueryid[];.proc.cp[];.z.w;query;servertype;queryattributes;join;postback;timeout;0Np;0Np;0b;0<count queryattributes;sync)]
  };
+
 removeclienthandle:{
  update submittime:2000.01.01D0^submittime,returntime:2000.01.01D0^returntime from `.gw.queryqueue where clienth=x;
  deleteresult exec queryid from .gw.queryqueue where clienth=x;}


### PR DESCRIPTION
# Improve Gateway Logging! :computer:

### PR general description
Adding a check to only log calls when the variable keepquery time is not set to 0D to avoid over-filling tables.

### Why is this PR necessary?
In relation to: http://smithers.aquaq.co.uk/issues/2085
 
### Final Checklist
- [x] My code follows the code style of this project
- [x] My code is commented appropriately and concisely
- [x] If necessary, I have added new appropriate labels to this PR
- [x] I have assigned the appropriate users to this PR