### PR TITLE
Fix to summary (print out multiple PIDs per process)

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -82,7 +82,7 @@ summary() {
   if [[ -z $(findproc "$1") ]]; then                                                                # check process not running
     printf "%-8s | %-14s | %-6s |\n" "$(date '+%H:%M:%S')" "$1" "down"                              # summary table row for down process
   else
-    pid=$(findproc "$1")
+    pid=$((findproc "$1")|awk 'END{print}')
     port=$(netstat -nlp 2>/dev/null | grep "$pid" | awk '{ print $4 }' | head -1 | awk -F: '{ print $2 }')  # get port process is running on
     printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" "$(date '+%H:%M:%S')" "$1" "up" "$port" "$pid"     # summary table row for running process    
   fi


### PR DESCRIPTION
This fix is for the ` ./torq.sh summary ` function of torq. In the case where a process such as the rdb or hdb is started as a child process, the `findproc` function inside torq.sh is returning both PIDs for this process, for example, if the process was defined as such in process.csv for the rdb and hdb:

```
localhost,{KDBBASEPORT}+2,rdb,rdb1,${KDBAPPCONFIG}/passwords/accesslist.txt,1,1,3,,${KDBCODE}/processes/rdb.q ${KDBAPPCODE}/common,1,-discovery ::$((KDBBASEPORT+1)):rdb:pass -.rdb.savetables 0b,$KDBBIN/tasksetq.sh l64 0 -20 0
localhost,{KDBBASEPORT}+3,hdb,hdb1,${KDBAPPCONFIG}/passwords/accesslist.txt,1,1,60,4000,${KDBHDB} ${KDBAPPCODE}/processes/fxcm_analytics.q ,1,,$KDBBIN/tasksetq.sh l64 0 -20 01
```

where tasksetq.sh is implemented - these procnames would be assigned two separate PIDs.

The fix for this in the summary function of torq is to implement the following line when defining the `pid` variable:

```
pid=$((findproc "$1")|awk 'END{print}')
```

This will take only the last PID from the list of two PIDs and use that in the summary (this PID is also used to define the port number). As this change is only within the summary function - nothing else should be affected.
