### PR TITLE
Fix default .z.pi to allow qcon

### DIFF
--- a/torq.q
+++ b/torq.q
@@ -604,7 +604,7 @@ if[`load in key .proc.params; .proc.loadf each .proc.params`load]
 
 if[any`debug`nopi in key .proc.params;
 	.lg.o[`init;"Resetting .z.pi to kdb+ default value"];
-	.z.pi:show@value@;]
+	.z.pi:{.Q.s value x};]
 
 // initialise pubsub
 if[@[value;`.ps.loaded;0b]; .ps.initialise[]]


### PR DESCRIPTION
### PR general description
This PR is in relation to redmine issue:http://smithers.aquaq.co.uk/issues/2095
This allows a TorQ process with the debug flag to be qconned in to without the previous type errors.

### Why is this PR necessary?
To allow qcon on debug processes.
 
### Final Checklist
Go over all the following points, and put an `x` in all the boxes that apply. You may wish to extend this list to inform the reviewers of any additional information regarding your PR.
 
- [x] My code follows the code style of this project
- [x] My code is commented appropriately and concisely
- [x] If necessary, I have added new appropriate labels to this PR
- [x] I have assigned the appropriate users to this PR