### PR TITLE
Gateway Null Hang

### DIFF
--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -103,7 +103,6 @@ clients:([]time:`timestamp$(); clienth:`g#`int$(); user:`symbol$(); ip:`int$(); 
 //Function to generate random placeholder
 genrand:{system ("S ",string `int$.z.T);-1?0Ng}
 
-
 //Generate random placeholder
 placehold:.gw.genrand[]
 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -151,7 +151,7 @@ canberun:{
 
 // Manage client queries
 addquerytimeout:{[query;servertype;queryattributes;join;postback;timeout;sync]
-  `.gw.queryqueue upsert (nextqueryid[];.proc.cp[];.z.w;query;servertype;queryattributes;join;postback;timeout;0Np;0Np;0b;0<count queryattributes;sync)
+  `.gw.queryqueue upsert (nextqueryid[];.proc.cp[];.z.w;query;servertype;queryattributes;join;postback;timeout;0Np;0Np;0b;0<count queryattributes;sync);
  };
 removeclienthandle:{
  update submittime:2000.01.01D0^submittime,returntime:2000.01.01D0^returntime from `.gw.queryqueue where clienth=x;
@@ -184,7 +184,7 @@ finishquery:{[qid;err;serverh]
  deleteresult[qid];
  update error:err,returntime:.proc.cp[] from `.gw.queryqueue where queryid in qid;
  setserverstate[serverh;0b];
- }  
+ }
 
 // Get a list of pending and running queries
 getqueue:{select queryid,time,clienth,query,servertype,status:?[null submittime;`pending;`running],submittime from .gw.queryqueue where null returntime}
@@ -212,7 +212,7 @@ addservererror:{[queryid;error]
  }
 // check if all results are in.  If so, send the results to the client
 checkresults:{[queryid]
- if[not any (.gw.placehold)~/: value (r:.gw.results[queryid])[1;;1];
+ if[not any .gw.placehold~/: value (r:.gw.results[queryid])[1;;1];
   // get the rest of the detail from the query table
   querydetails:queryqueue[queryid];
   // apply the join function to the results
@@ -258,7 +258,7 @@ removeserverhandle:{[serverh]
  // get the list of effected query ids
 
  // 1) queries sent to this server but no reply back yet
- qids:where {[res;id] any (.gw.placehold)~/:res[1;where id=res[1;;0];1]}[;serverid] each results;
+ qids:where {[res;id] any .gw.placehold~/:res[1;where id=res[1;;0];1]}[;serverid] each results;
  // propagate an error back to each client
  sendclientreply[;.gw.errorprefix,"backend ",string[servertype]," server handling query closed the connection";0b] each qids;
  finishquery[qids;1b;serverh]; 
@@ -268,7 +268,7 @@ removeserverhandle:{[serverh]
  activeServerTypes:distinct exec servertype from .gw.servers where active, handle<>serverh;
 
  qids2:where {[res;id;aIDs;aTypes] 
-  s:where (.gw.placehold)~/:res[1;;1]; 
+  s:where .gw.placehold~/:res[1;;1]; 
   $[11h=type s; not all s in aTypes; not all any each s in\: aIDs] 
   }[;serverid;activeServerIDs;activeServerTypes] each results _ 0Ni;
  sendclientreply[;.gw.errorprefix,"backend ",string[servertype]," server for running query closed the connection";0b] each qids2;
@@ -507,9 +507,9 @@ syncexecjpre36:{[query;servertype;joinfunction]
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush
- (neg handles)@\:(.gw.placehold);
+ (neg handles)@\:.gw.placehold;
  // block and wait for the results
- res:handles@\:(.gw.placehold);
+ res:handles@\:.gw.placehold;
  // update the usage data
  update inuse:0b,usage:usage+(handles!res[;1] - start)[handle] from `.gw.servers where handle in handles;
  // check if there are any errors in the returned results

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -101,7 +101,7 @@ queryqueue:([queryid:`u#`long$()] time:`timestamp$(); clienth:`g#`int$(); query:
 clients:([]time:`timestamp$(); clienth:`g#`int$(); user:`symbol$(); ip:`int$(); host:`symbol$())
 
 //Function to generate random placeholder
-genrand:{system "S ",string `int$.z.T;rand 0Ng}
+genrand:{system"S ",string `int$.z.T;rand 0Ng}
 
 //Generate random placeholder
 placehold:.gw.genrand[]

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -101,7 +101,7 @@ queryqueue:([queryid:`u#`long$()] time:`timestamp$(); clienth:`g#`int$(); query:
 clients:([]time:`timestamp$(); clienth:`g#`int$(); user:`symbol$(); ip:`int$(); host:`symbol$())
 
 //Function to generate random placeholder
-genrand:{system ("S ",string `int$.z.T);-1?0Ng}
+genrand:{system "S ",string `int$.z.T;-1?0Ng}
 
 //Generate random placeholder
 placehold:.gw.genrand[]

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -101,7 +101,7 @@ queryqueue:([queryid:`u#`long$()] time:`timestamp$(); clienth:`g#`int$(); query:
 clients:([]time:`timestamp$(); clienth:`g#`int$(); user:`symbol$(); ip:`int$(); host:`symbol$())
 
 //Function to generate random placeholder
-genrand:{system "S ",string `int$.z.T;-1?0Ng}
+genrand:{system "S ",string `int$.z.T;rand 0Ng}
 
 //Generate random placeholder
 placehold:.gw.genrand[]

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -100,10 +100,16 @@ queryqueue:([queryid:`u#`long$()] time:`timestamp$(); clienth:`g#`int$(); query:
 // client details
 clients:([]time:`timestamp$(); clienth:`g#`int$(); user:`symbol$(); ip:`int$(); host:`symbol$())
 
+//Function to generate random placeholder for query comparisons
+genrand:{system "S";-1?0Ng}
+
+//Generate Random placeholder GUID
+placehold:.gw.genrand[]
+
 // structure to store query results from back end servers
 // structure is queryid!(clienthandle;servertype!(handle;results))
 // structure is queryid!(clienthandle;(servertype or serverIDs)!(serverID;results))
-results:(enlist 0Nj)!enlist(0Ni;(enlist `)!enlist(0Ni;::))  
+results:(enlist 0Nj)!enlist(0Ni;(enlist `)!enlist(0Ni;.gw.placehold))  
 
 // server handles - whether the server is currently running a query
 servers:([serverid:`u#`int$()]handle:`int$(); servertype:`symbol$(); inuse:`boolean$();active:`boolean$();querycount:`int$();lastquery:`timestamp$();usage:`timespan$();attributes:();disconnecttime:`timestamp$())

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -101,7 +101,8 @@ queryqueue:([queryid:`u#`long$()] time:`timestamp$(); clienth:`g#`int$(); query:
 clients:([]time:`timestamp$(); clienth:`g#`int$(); user:`symbol$(); ip:`int$(); host:`symbol$())
 
 //Function to generate random placeholder
-genrand:{system "S";-1?0Ng}
+genrand:{system ("S ",string `int$.z.T);-1?0Ng}
+
 
 //Generate random placeholder
 placehold:.gw.genrand[]

--- a/torq.q
+++ b/torq.q
@@ -604,7 +604,7 @@ if[`load in key .proc.params; .proc.loadf each .proc.params`load]
 
 if[any`debug`nopi in key .proc.params;
 	.lg.o[`init;"Resetting .z.pi to kdb+ default value"];
-	.z.pi:show@value@;]
+	.z.pi:{.Q.s value x};]
 
 // initialise pubsub
 if[@[value;`.ps.loaded;0b]; .ps.initialise[]]


### PR DESCRIPTION
There's a bug in the gateway that makes it hang if a request is sent async and returns a null (::) result. Basically, the GW uses null as a placeholder for results and the request then hangs and doesn't get returned to the client. To fix this, it's probably more suitable to replace the null and use a random GUID as the placeholder value.