### PR TITLE
edit debug arg check to allow extra flags

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -247,7 +247,7 @@ runprint() {
 
 rundebug() {
   checkextrascsv "$*";                                                                              # checks if extra flags/csv included
-  if [[ $(echo $PROCS | wc -w) -gt 1 ]] || [[ $# -ne 2 ]]; then
+  if [[ $(echo $PROCS | wc -w) -gt 1 ]] || [[ $(echo $input|wc -w) -ne 1 ]]; then
     echo "ERROR: Cannot debug more than one process at a time"
   else
     for p in $PROCS; do


### PR DESCRIPTION
The argument constraint in the function rundebug in torq.sh stops from flags being able to use. Without this argument if two (or more) arguments are given to the debug flag and one of them is a process while the others aren't then the process that exists successfully goes into debug mode.

Have replaced the argument constraint with a count of the specific debug flag args for now so additional flags can be used