### PR TITLE
lg.o Format Bug

### DIFF
--- a/torq.q
+++ b/torq.q
@@ -185,7 +185,7 @@ getapplication:{$[0 = count a:@[{read0 x};hsym last getconfigfile"application.tx
 // Logging functions live in here
 
 // Format a log message
-format:{[loglevel;proctype;proc;id;message] "|" sv (string .proc.cp[];string .z.h;string proctype;string proc;string loglevel;string id;$[1=count message;enlist message; message])}
+format:{[loglevel;proctype;proc;id;message] "|"sv string[(.proc.cp[];.z.h;proctype;proc;loglevel;id)],enlist(),message}
 
 publish:{[loglevel;proctype;proc;id;message]
  if[0<0^pubmap[loglevel];

--- a/torq.q
+++ b/torq.q
@@ -185,7 +185,7 @@ getapplication:{$[0 = count a:@[{read0 x};hsym last getconfigfile"application.tx
 // Logging functions live in here
 
 // Format a log message
-format:{[loglevel;proctype;proc;id;message] "|" sv (string .proc.cp[];string .z.h;string proctype;string proc;string loglevel;string id;message)}
+format:{[loglevel;proctype;proc;id;message] "|" sv (string .proc.cp[];string .z.h;string proctype;string proc;string loglevel;string id;$[1=count message;enlist message; message])}
 
 publish:{[loglevel;proctype;proc;id;message]
  if[0<0^pubmap[loglevel];


### PR DESCRIPTION
A client raised an issue where the` .lg.o` function returned a 'type error if the `message` variable was only a single character. The `.lg.format` function in `torq.q` has been edited to check if `message` is a single character. If it is, it is enlisted. If not, it is passed as normal.