### PR TITLE
Update .clients.clients and .servers.SERVERS if a connection crashes

### DIFF
--- a/code/handlers/trackclients.q
+++ b/code/handlers/trackclients.q
@@ -27,13 +27,14 @@ hit:{update lastp:.proc.cp[],hits:hits+1i,sz:sz+-22!x from`.clients.clients wher
 hite:{update lastp:.proc.cp[],hits:hits+1i,errs:errs+1i from`.clients.clients where w=.z.w;'x}
 po:{[result;W]
     cleanup[];
-    update w:0Ni,endp:.proc.cp[] from`.servers.SERVERS where w=W;
     `.clients.clients upsert(W;.dotz.ipa .z.a;.z.u;.z.a;0Nd;0n;0Ni;0Ni;(`);(`);0Ni;0Ni;zp;0Np;zp:.proc.cp[];0i;0i;0j);
     if[INTRUSIVE;
         neg[W]"neg[.z.w]\"update k:\",(string .z.k),\",K:\",(-3!.z.K),\",c:\",(-3!.z.c),\",s:\",(-3!system\"s\"),\",o:\",(-3!.z.o),\",f:\",(-3!.z.f),\",pid:\",(-3!.z.i),\",port:\",(-3!system\"p\"),\" from`.clients.clients where w=.z.w\""];
     result}
 addw:{po[x;x]} / manually add a client
 pc:{[result;W] update w:0Ni,endp:.proc.cp[] from`.clients.clients where w=W;cleanup[];result}
+
+.z.pc:{.clients.pc[x y;y]}.z.pc;
 
 wo:{[result;W]
     cleanup[];
@@ -42,7 +43,6 @@ wo:{[result;W]
 
 if[enabled;
 	.z.po:{.clients.po[x y;y]}.z.po;
-        .z.pc:{.clients.pc[x y;y]}.z.pc;
         .z.wo:{.clients.wo[x y;y]}.z.wo;
 	.z.wc:{.clients.pc[x y;y]}.z.wc;
 

--- a/code/handlers/trackclients.q
+++ b/code/handlers/trackclients.q
@@ -27,6 +27,7 @@ hit:{update lastp:.proc.cp[],hits:hits+1i,sz:sz+-22!x from`.clients.clients wher
 hite:{update lastp:.proc.cp[],hits:hits+1i,errs:errs+1i from`.clients.clients where w=.z.w;'x}
 po:{[result;W]
     cleanup[];
+    update w:0Ni,endp:.proc.cp[] from`.servers.SERVERS where w=W;
     `.clients.clients upsert(W;.dotz.ipa .z.a;.z.u;.z.a;0Nd;0n;0Ni;0Ni;(`);(`);0Ni;0Ni;zp;0Np;zp:.proc.cp[];0i;0i;0j);
     if[INTRUSIVE;
         neg[W]"neg[.z.w]\"update k:\",(string .z.k),\",K:\",(-3!.z.K),\",c:\",(-3!.z.c),\",s:\",(-3!system\"s\"),\",o:\",(-3!.z.o),\",f:\",(-3!.z.f),\",pid:\",(-3!.z.i),\",port:\",(-3!system\"p\"),\" from`.clients.clients where w=.z.w\""];

--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -106,9 +106,7 @@ gethandlebytype:getserverbytype[;`w;]
 gethpbytype:getserverbytype[;`hpup;]
 
 // Update the server stats
-updatestats:{[W]
-  update w:0Ni,endp:.proc.cp[] from`.clients.clients where w=W;
-  update lastp:.proc.cp[],hits:1+hits from`.servers.SERVERS where w=W}
+updatestats:{[W] update lastp:.proc.cp[],hits:1+hits from`.servers.SERVERS where w=W}
 
 names:{asc distinct exec procname from`.servers.SERVERS where .dotz.liveh w}
 types:{asc distinct exec proctypes from`.servers.SERVERS where .dotz.liveh w}
@@ -345,7 +343,8 @@ startupdependent:{[requiredprocs;timeintv]
 
 pc:{[result;W] update w:0Ni,endp:.proc.cp[] from`.servers.SERVERS where w=W;cleanup[];result}
 
+.z.pc:{.servers.pc[x y;y]}.z.pc;
+
 if[enabled;
-    .z.pc:{.servers.pc[x y;y]}.z.pc;
     if[DISCOVERYRETRY > 0; .timer.repeat[.proc.cp[];0Wp;DISCOVERYRETRY;(`.servers.retrydiscovery;`);"Attempt reconnections to the discovery service"]];
     if[RETRY > 0; .timer.repeat[.proc.cp[];0Wp;RETRY;(`.servers.retry;`);"Attempt reconnections to closed server handles"]]];

--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -106,7 +106,9 @@ gethandlebytype:getserverbytype[;`w;]
 gethpbytype:getserverbytype[;`hpup;]
 
 // Update the server stats
-updatestats:{[W] update lastp:.proc.cp[],hits:1+hits from`.servers.SERVERS where w=W}
+updatestats:{[W]
+  update w:0Ni,endp:.proc.cp[] from`.clients.clients where w=W;
+  update lastp:.proc.cp[],hits:1+hits from`.servers.SERVERS where w=W}
 
 names:{asc distinct exec procname from`.servers.SERVERS where .dotz.liveh w}
 types:{asc distinct exec proctypes from`.servers.SERVERS where .dotz.liveh w}


### PR DESCRIPTION
When .z.pc is altered there occurs a bug where .servers.SERVERS and .clients.clients are not updated when a connection crashes and results in handles in tables pointing to the wrong connections. Update statements have been added to avoid this