### PR TITLE
Generic Null Placeholder

### DIFF
--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -507,9 +507,9 @@ syncexecjpre36:{[query;servertype;joinfunction]
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush
- (neg handles)@\:.gw.placehold;
+ (neg handles)@\:(::);
  // block and wait for the results
- res:handles@\:.gw.placehold;
+ res:handles@\:(::);
  // update the usage data
  update inuse:0b,usage:usage+(handles!res[;1] - start)[handle] from `.gw.servers where handle in handles;
  // check if there are any errors in the returned results


### PR DESCRIPTION
The function ```gw.syncexec``` is used to query the rdb/hdb through the gateway.

A bug was discovered as a type error was being thrown on the line ```res:handles@\:.gw.placehold;```

By replacing these with ```(::)``` nulls, the function now runs with no problems.

This pull request was created to fix the aforementioned bug.