### PR TITLE
Grafana update

### DIFF
--- a/code/common/grafana.q
+++ b/code/common/grafana.q
@@ -51,10 +51,7 @@ search:{[rqt]
   tabs:tables[];
   symtabs:tabs where sym in'cols each tabs;
   timetabs:tabs where timecol in'cols each tabs;
-  func: string system "f";
   rsp:string tabs;
-  // prefixes "f" to each user defined function on the server
-  rsp,:raze prefix["f";] each (func; raze prefix[;func] each "gto");
   
   if[count timetabs;
     rsp,:s1:prefix["t";string timetabs];

--- a/code/common/grafana.q
+++ b/code/common/grafana.q
@@ -57,8 +57,8 @@ search:{[rqt]
   rsp,:raze prefix["f";] each (func; raze prefix[;func] each "gto");
   
   if[count timetabs;
-	rsp,:s1:prefix["t";string timetabs];
-	rsp,:s2:prefix["g";string timetabs];
+    rsp,:s1:prefix["t";string timetabs];
+    rsp,:s2:prefix["g";string timetabs];
     rsp,:raze(s2,'del),/:'c1:string {cols[x] where`number=types (0!meta x)`t}each timetabs;
     rsp,:raze(prefix["o";string timetabs],'del),/:'c1;
     if[count symtabs;

--- a/code/common/grafana.q
+++ b/code/common/grafana.q
@@ -29,7 +29,7 @@ epoch:946684800000;
 zpp:{
   // get API url from request
   // cuts at first whitespace char to avoid splitting function params
-  r: (0;n?" ") cut n:first x;
+  r:(0;n?" ")cut n:first x;
   // convert grafana message to q
   rqt:.j.k r 1;
   $["query"~r 0;query[rqt];"search"~r 0;search rqt;`$"Annotation url nyi"]
@@ -59,7 +59,7 @@ search:{[rqt]
   if[count timetabs;
 	rsp,:s1:prefix["t";string timetabs];
 	rsp,:s2:prefix["g";string timetabs];
-    rsp,:raze(s2,'del),/:'c1:string {(cols x) where`number=types (0!meta x)`t}each timetabs;
+    rsp,:raze(s2,'del),/:'c1:string {cols[x] where`number=types (0!meta x)`t}each timetabs;
     rsp,:raze(prefix["o";string timetabs],'del),/:'c1;
     if[count symtabs;
       rsp,:raze(s1,'del),/:'c2:string each finddistinctsyms'[timetabs];
@@ -100,8 +100,8 @@ tbfunc:{[rqt]
 tsfunc:{[x]	
   targ: raze x[`targets]`target;
   / split arguments
-  $[isfunc[targ]; numargs:count args:(0;1+targ?del) cut targ:2_targ; numargs:count args:`$del vs targ];
-  $[10h=abs type args 0; tyargs: `$1#args 0; tyargs: args 0];
+  numargs:count args:$[isfunc targ;(0;1+targ?del)cut targ:2_targ;`$del vs targ];
+  tyargs:$[10h=abs type args 0;`$1#;]args 0;
   // manipulate queried table
   coln:cols rqt:0!value args 1;
   // function to convert time to milliseconds, takes timestamp

--- a/code/common/grafana.q
+++ b/code/common/grafana.q
@@ -28,8 +28,9 @@ epoch:946684800000;
 // retrieve and convert Grafana HTTP POST request then process as either timeseries or table
 zpp:{
   // get API url from request
-  r:" " vs first x;
-  // convert grafana mesage to q
+  // cuts at first whitespace char to avoid splitting function params
+  r: (0;n?" ") cut n:first x;
+  // convert grafana message to q
   rqt:.j.k r 1;
   $["query"~r 0;query[rqt];"search"~r 0;search rqt;`$"Annotation url nyi"]
  };
@@ -42,20 +43,27 @@ query:{[rqt]
 
 finddistinctsyms:{?[x;enlist(>;timecol;(-;.z.p;timebackdate));1b;{x!x}enlist sym]sym};
 
+// prefixes string c to each string s, seperated by del
+prefix:{[c;s] (c,del),/:s};
+
 search:{[rqt]
   // build drop down case options from tables in port
   tabs:tables[];
   symtabs:tabs where sym in'cols each tabs;
   timetabs:tabs where timecol in'cols each tabs;
+  func: string system "f";
   rsp:string tabs;
+  // prefixes "f" to each user defined function on the server
+  rsp,:raze prefix["f";] each (func; raze prefix[;func] each "gto");
+  
   if[count timetabs;
-    rsp,:s1:("t",del),/:string timetabs;
-    rsp,:s2:("g",del),/:string timetabs; 
+	rsp,:s1:prefix["t";string timetabs];
+	rsp,:s2:prefix["g";string timetabs];
     rsp,:raze(s2,'del),/:'c1:string {(cols x) where`number=types (0!meta x)`t}each timetabs;
-    rsp,:raze((("o",del),/:string timetabs),'del),/:'c1;
+    rsp,:raze(prefix["o";string timetabs],'del),/:'c1;
     if[count symtabs;
       rsp,:raze(s1,'del),/:'c2:string each finddistinctsyms'[timetabs];
-      rsp,:raze((("o",del),/:string timetabs),'del),/:'{x[0] cross del,'string finddistinctsyms x 1}each (enlist each c1),'timetabs;
+      rsp,:raze(prefix["o";string timetabs],'del),/:'{x[0] cross del,'string finddistinctsyms x 1}each (enlist each c1),'timetabs;
      ];
    ];
   :.h.hy[`json].j.j rsp;
@@ -65,23 +73,41 @@ diskvals:{c:(count[x]-ticks)+til ticks;get'[.Q.ind[x;c]]};
 memvals:{get'[?[x;enlist(within;`i;count[x]-ticks,0);0b;()]]};
 catchvals:{@[diskvals;x;{[x;y]memvals x}[x]]};
 
+istype:{[targ;char] (char,del)~2#targ};
+isfunc:istype[;"f"]; istab:istype[;"t"];
+
+// builds body of table response in Json adaptor schema
+tabresponse:{[colname;coltype;rqt] .j.j enlist`columns`rows`type!(flip`text`type!(colname;coltype);catchvals rqt;`table)};
+
 // process a table request and return in JSON format
 tbfunc:{[rqt]
-  rqt:value raze rqt[`targets]`target;
+  rqt: raze rqt[`targets]`target;
+  symname:0b;
+  // if f.t.func, drop first 4 chars
+  $[isfunc[rqt] & istab[2_rqt]; rqt:4_rqt; 
+	// if f.func drop first 2
+	$[isfunc[rqt]; rqt:2_rqt;
+		// if t.tab or t.tab.sym 
+		if[istab[rqt];rqt: `$del vs rqt; if[2<count rqt; symname: rqt 2]; rqt: rqt 1]
+	 ]
+	];
+  rqt:0!value rqt;
   // get column names and associated types to fit format
   colname:cols rqt;
   coltype:types (0!meta rqt)`t;
-  // build body of response in Json adaptor schema
-  :.j.j enlist`columns`rows`type!(flip`text`type!(colname;coltype);catchvals rqt;`table);
+  // search rqt for sym if symname was set
+  if[-11h=type symname; rqt:?[rqt;enlist(=;sym;enlist symname);0b;()]];
+  :tabresponse[colname;coltype;rqt];
  };
 
 // process a timeseries request and return in Json format, takes in query and information dictionary
-tsfunc:{[x]
+tsfunc:{[x]	
+  targ: raze x[`targets]`target;
   / split arguments
-  numargs:count args:`$del vs raze x[`targets]`target;
-  tyargs:args 0;
+  $[isfunc[targ]; numargs:count args:(0;1+targ?del) cut targ:2_targ; numargs:count args:`$del vs targ];
+  $[10h=abs type args 0; tyargs: `$1#args 0; tyargs: args 0];
   // manipulate queried table
-  coln:cols rqt:value args 1;
+  coln:cols rqt:0!value args 1;
   // function to convert time to milliseconds, takes timestamp
   mil:{floor epoch+(`long$x)%1000000};
   // ensure time column is a timestamp
@@ -123,7 +149,7 @@ graphnosym:{[coln;rqt]
 // timeserie request on table panel w/ no preference on sym seperation
 tablenosym:{[coln;rqt]
   coltype:types -1_(0!meta rqt)`t;
-  :.j.j enlist`columns`rows`type!(flip`text`type!(coln;coltype);catchvals rqt;`table);
+  :tabresponse[coln;coltype;rqt];
  };
 
 // timeserie request on non-specific panel w/ data for one sym returned
@@ -149,6 +175,6 @@ tablesym:{[coln;rqt;symname]
   coltype:types -1_(0!meta rqt)`t;
   // select data for requested sym only
   rqt:?[rqt;enlist(=;sym;enlist symname);0b;()];
-  :.j.j enlist`columns`rows`type!(flip`text`type!(coln;coltype);catchvals rqt;`table);
+  :tabresponse[coln;coltype;rqt];
  };
 

--- a/code/common/grafana.q
+++ b/code/common/grafana.q
@@ -28,9 +28,8 @@ epoch:946684800000;
 // retrieve and convert Grafana HTTP POST request then process as either timeseries or table
 zpp:{
   // get API url from request
-  // cuts at first whitespace char to avoid splitting function params
-  r: (0;n?" ") cut n:first x;
-  // convert grafana message to q
+  r:" " vs first x;
+  // convert grafana mesage to q
   rqt:.j.k r 1;
   $["query"~r 0;query[rqt];"search"~r 0;search rqt;`$"Annotation url nyi"]
  };
@@ -43,27 +42,20 @@ query:{[rqt]
 
 finddistinctsyms:{?[x;enlist(>;timecol;(-;.z.p;timebackdate));1b;{x!x}enlist sym]sym};
 
-// prefixes string c to each string s, seperated by del
-prefix:{[c;s] (c,del),/:s};
-
 search:{[rqt]
   // build drop down case options from tables in port
   tabs:tables[];
   symtabs:tabs where sym in'cols each tabs;
   timetabs:tabs where timecol in'cols each tabs;
-  func: string system "f";
   rsp:string tabs;
-  // prefixes "f" to each user defined function on the server
-  rsp,:raze prefix["f";] each (func; raze prefix[;func] each "gto");
-  
   if[count timetabs;
-	rsp,:s1:prefix["t";string timetabs];
-	rsp,:s2:prefix["g";string timetabs];
+    rsp,:s1:("t",del),/:string timetabs;
+    rsp,:s2:("g",del),/:string timetabs; 
     rsp,:raze(s2,'del),/:'c1:string {(cols x) where`number=types (0!meta x)`t}each timetabs;
-    rsp,:raze(prefix["o";string timetabs],'del),/:'c1;
+    rsp,:raze((("o",del),/:string timetabs),'del),/:'c1;
     if[count symtabs;
       rsp,:raze(s1,'del),/:'c2:string each finddistinctsyms'[timetabs];
-      rsp,:raze(prefix["o";string timetabs],'del),/:'{x[0] cross del,'string finddistinctsyms x 1}each (enlist each c1),'timetabs;
+      rsp,:raze((("o",del),/:string timetabs),'del),/:'{x[0] cross del,'string finddistinctsyms x 1}each (enlist each c1),'timetabs;
      ];
    ];
   :.h.hy[`json].j.j rsp;
@@ -73,41 +65,23 @@ diskvals:{c:(count[x]-ticks)+til ticks;get'[.Q.ind[x;c]]};
 memvals:{get'[?[x;enlist(within;`i;count[x]-ticks,0);0b;()]]};
 catchvals:{@[diskvals;x;{[x;y]memvals x}[x]]};
 
-istype:{[targ;char] (char,del)~2#targ};
-isfunc:istype[;"f"]; istab:istype[;"t"];
-
-// builds body of table response in Json adaptor schema
-tabresponse:{[colname;coltype;rqt] .j.j enlist`columns`rows`type!(flip`text`type!(colname;coltype);catchvals rqt;`table)};
-
 // process a table request and return in JSON format
 tbfunc:{[rqt]
-  rqt: raze rqt[`targets]`target;
-  symname:0b;
-  // if f.t.func, drop first 4 chars
-  $[isfunc[rqt] & istab[2_rqt]; rqt:4_rqt; 
-	// if f.func drop first 2
-	$[isfunc[rqt]; rqt:2_rqt;
-		// if t.tab or t.tab.sym 
-		if[istab[rqt];rqt: `$del vs rqt; if[2<count rqt; symname: rqt 2]; rqt: rqt 1]
-	 ]
-	];
-  rqt:0!value rqt;
+  rqt:value raze rqt[`targets]`target;
   // get column names and associated types to fit format
   colname:cols rqt;
   coltype:types (0!meta rqt)`t;
-  // search rqt for sym if symname was set
-  if[-11h=type symname; rqt:?[rqt;enlist(=;sym;enlist symname);0b;()]];
-  :tabresponse[colname;coltype;rqt];
+  // build body of response in Json adaptor schema
+  :.j.j enlist`columns`rows`type!(flip`text`type!(colname;coltype);catchvals rqt;`table);
  };
 
 // process a timeseries request and return in Json format, takes in query and information dictionary
-tsfunc:{[x]	
-  targ: raze x[`targets]`target;
+tsfunc:{[x]
   / split arguments
-  $[isfunc[targ]; numargs:count args:(0;1+targ?del) cut targ:2_targ; numargs:count args:`$del vs targ];
-  $[10h=abs type args 0; tyargs: `$1#args 0; tyargs: args 0];
+  numargs:count args:`$del vs raze x[`targets]`target;
+  tyargs:args 0;
   // manipulate queried table
-  coln:cols rqt:0!value args 1;
+  coln:cols rqt:value args 1;
   // function to convert time to milliseconds, takes timestamp
   mil:{floor epoch+(`long$x)%1000000};
   // ensure time column is a timestamp
@@ -149,7 +123,7 @@ graphnosym:{[coln;rqt]
 // timeserie request on table panel w/ no preference on sym seperation
 tablenosym:{[coln;rqt]
   coltype:types -1_(0!meta rqt)`t;
-  :tabresponse[coln;coltype;rqt];
+  :.j.j enlist`columns`rows`type!(flip`text`type!(coln;coltype);catchvals rqt;`table);
  };
 
 // timeserie request on non-specific panel w/ data for one sym returned
@@ -175,6 +149,6 @@ tablesym:{[coln;rqt;symname]
   coltype:types -1_(0!meta rqt)`t;
   // select data for requested sym only
   rqt:?[rqt;enlist(=;sym;enlist symname);0b;()];
-  :tabresponse[coln;coltype;rqt];
+  :.j.j enlist`columns`rows`type!(flip`text`type!(coln;coltype);catchvals rqt;`table);
  };
 

--- a/code/common/grafana.q
+++ b/code/common/grafana.q
@@ -59,9 +59,11 @@ search:{[rqt]
   if[count timetabs;
     rsp,:s1:prefix["t";string timetabs];
     rsp,:s2:prefix["g";string timetabs];
+    // suffix names of number columns to graph and other panel options
     rsp,:raze(s2,'del),/:'c1:string {cols[x] where`number=types (0!meta x)`t}each timetabs;
     rsp,:raze(prefix["o";string timetabs],'del),/:'c1;
     if[count symtabs;
+      // suffix distinct syms to timeseries table and other panel options
       rsp,:raze(s1,'del),/:'c2:string each finddistinctsyms'[timetabs];
       rsp,:raze(prefix["o";string timetabs],'del),/:'{x[0] cross del,'string finddistinctsyms x 1}each (enlist each c1),'timetabs;
      ];
@@ -84,9 +86,9 @@ tbfunc:{[rqt]
   rqt: raze rqt[`targets]`target;
   symname:0b;
   // if f.t.func, drop first 4 chars
-  rqt:0!value $[isfunc[rqt] & istab[2_rqt]; 4_rqt; 
-                isfunc[rqt]; 2_rqt;
-                istab[rqt]; [rqt: `$del vs rqt; if[2<count rqt; symname: rqt 2]; rqt 1];
+  rqt:0!value $[isfunc[rqt] & istab 2_rqt; 4_rqt; 
+                isfunc rqt; 2_rqt;
+                istab rqt; [rqt: `$del vs rqt; if[2<count rqt; symname: rqt 2]; rqt 1];
                 rqt];
   // get column names and associated types to fit format
   colname:cols rqt;
@@ -126,21 +128,23 @@ tsfunc:{[x]
     `$"Wrong input"]
  };
 
+// build JSON response for graph & other panels with no sym seperation
+buildnosym:{y,`target`datapoints!(z 0;value each ?[x;();0b;z!z])};
+nosymresponse:{[rqt;colname] .j.j buildnosym[rqt]\[();colname]};
+
 // timeserie request on non-specific panel w/ no preference on sym seperation
 othernosym:{[coln;rqt]
   // return columns with json number type only
   colname:coln cross`msec;
-  build:{y,`target`datapoints!(z 0;value each ?[x;();0b;z!z])};
-  :.j.j build[rqt]\[();colname];
+  :nosymresponse[rqt;colname];
  };
 
-// timeserie request on grqph panel w/ no preference on sym seperation
+// timeserie request on graph panel w/ no preference on sym seperation
 graphnosym:{[coln;rqt]
   // return columns with json number type only
   coln:-1_coln where`number=types (0!meta rqt)`t;
   colname:coln cross`msec;
-  build:{y,`target`datapoints!(z 0;value each ?[x;();0b;z!z])};
-  :.j.j build[rqt]\[();colname];
+  :nosymresponse[rqt;colname];
  };
 
 // timeserie request on table panel w/ no preference on sym seperation

--- a/code/common/grafana.q
+++ b/code/common/grafana.q
@@ -84,14 +84,10 @@ tbfunc:{[rqt]
   rqt: raze rqt[`targets]`target;
   symname:0b;
   // if f.t.func, drop first 4 chars
-  $[isfunc[rqt] & istab[2_rqt]; rqt:4_rqt; 
-	// if f.func drop first 2
-	$[isfunc[rqt]; rqt:2_rqt;
-		// if t.tab or t.tab.sym, 
-		if[istab[rqt];rqt: `$del vs rqt; if[2<count rqt; symname: rqt 2]; rqt: rqt 1]
-	 ]
-	];
-  rqt:0!value rqt;
+  rqt:0!value $[isfunc[rqt] & istab[2_rqt]; 4_rqt; 
+                isfunc[rqt]; 2_rqt;
+                istab[rqt]; [rqt: `$del vs rqt; if[2<count rqt; symname: rqt 2]; rqt 1];
+                rqt];
   // get column names and associated types to fit format
   colname:cols rqt;
   coltype:types (0!meta rqt)`t;
@@ -126,6 +122,7 @@ tsfunc:{[x]
     (2=numargs)and`t~tyargs;tablenosym[coln;rqt];
     (4=numargs)and`o~tyargs;othersym[args;rqt];
     (3=numargs)and`o~tyargs;othernosym[args 2;rqt]; 
+    (2=numargs)and`o~tyargs;othernosym[coln except timecol;rqt];
     `$"Wrong input"]
  };
 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -507,9 +507,9 @@ syncexecjpre36:{[query;servertype;joinfunction]
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush
- (neg handles)@\:(::);
+ (neg handles)@\:.gw.placehold;
  // block and wait for the results
- res:handles@\:(::);
+ res:handles@\:.gw.placehold;
  // update the usage data
  update inuse:0b,usage:usage+(handles!res[;1] - start)[handle] from `.gw.servers where handle in handles;
  // check if there are any errors in the returned results

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -507,9 +507,9 @@ syncexecjpre36:{[query;servertype;joinfunction]
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush
- (neg handles)@\:.gw.placehold;
+ (neg handles)@\:(::);
  // block and wait for the results
- res:handles@\:.gw.placehold;
+ res:handles@\:(::);
  // update the usage data
  update inuse:0b,usage:usage+(handles!res[;1] - start)[handle] from `.gw.servers where handle in handles;
  // check if there are any errors in the returned results


### PR DESCRIPTION
To summarize additions to the adapter:

1. functions can be applied to create table panels for timeseries and non timeseries data
2. functions can be applied to create graph panels for timeseries data only
3. Previously if you selected "t.trades" or "t.trades.MSFT" for your query in a table panel, this would only work if you had also selected timeserie from the response dropdown; now, if you select table, this will create a table as expected
4. Keyed tables can now be displayed.

Things that are not yet working/implemented:

1. Creating a graph from non-timeseries data is not yet implemented. Further modification of tbfunc will be needed to return the right grafana response.

For review by @FionaMorgan & @Joe-Griffiths 