### PR TITLE
Changes made to <stop> function to accommodate a child/parent pair of PIDs

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -93,8 +93,9 @@ stop() {
     echo "$(date '+%H:%M:%S') | $1 is not currently running"
   else
     echo "$(date '+%H:%M:%S') | Shutting down $1..."
-    pid=$(findproc "$1")
-    eval "kill -15 $pid"                                                                            # kill process pid
+    procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")
+    port=$(eval echo \$"$(getfield "$procno" port)" | bc)
+    eval "kill -15 `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
   fi
  }
 


### PR DESCRIPTION
Issue:
Any torq processes that consisted of a child/parent pair of PIDs would need `./torq stop` to be run twice in order to kill the process properly

Fix:
The `stop` function in `torq.sh` has been altered to do the following
- pull the port number from the `process.csv` (determined by the process name argument as standard)
- use lsof to return only the child PID using the port number provided
- kill the process using the the child PID 