### PR TITLE
torq.sh stop updated to use $(( )) instead of bc

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -94,7 +94,7 @@ stop() {
   else
     echo "$(date '+%H:%M:%S') | Shutting down $1..."
     procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")
-    port=$(eval echo \$"$(getfield "$procno" port)" | bc)
+    port=$(($(eval echo \$"$(getfield "$procno" port)")))
     eval "kill -15 `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
   fi
  }


### PR DESCRIPTION
No change to previous PR for altering the `./torq.sh stop` function - only difference is that `bc` is not implemented, as servers are not guaranteed to have it installed - now using `$(( ))` to evaluate the `{baseport}+offset` instead 

Note* `expr` could be used, but would require spaces to work and so would mean adding more logic to insert spaces