### PR TITLE
Summary now prints all ports that are listening, not just a single port

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -102,8 +102,8 @@ summary() {
     printf "%-8s | %-14s | %-6s |\n" "$(date '+%H:%M:%S')" "$1" "down"                              # summary table row for down process
   else
     pid=$((findproc "$1")|awk 'END{print}')
-    port=$(netstat -nlp 2>/dev/null | grep "$pid" | awk '{ print $4 }' | head -1 | awk -F: '{ print $2 }')  # get port process is running on
-    printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" "$(date '+%H:%M:%S')" "$1" "up" "$port" "$pid"     # summary table row for running process    
+    port=$(echo $(netstat -nlp 2>/dev/null | grep "$pid" | awk '{ print $4 }' | awk -F: '{ print $2 }'))  # get port process is running on
+    printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" "$(date '+%H:%M:%S')" "$1" "up" "$pid" "$port"     # summary table row for running process
   fi
  }
 
@@ -260,7 +260,7 @@ rundebug() {
 runsummary() {
   allcsv "$*";
   PROCS=$(awk -F, '{if(NR>1) print $4}' "$CSVPATH");
-  printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" "TIME" "PROCESS" "STATUS" "PORT" "PID"
+  printf "%-8s | %-14s | %-6s | %-6s | %-6s\n" "TIME" "PROCESS" "STATUS" "PID" "PORT"
   for p in $PROCS; do
     summary "$p";
   done


### PR DESCRIPTION
This change is to cover scenarios where a single TorQ process has multiple ports listening

The solution is to swap the position of `PID` and `PORT` in the summary table, so that the `PORT` column can now print out multiple ports separated by spaces

Changes:
swapping `$port` and `$pid` in the summary `printf`
swapping the headers `PORT` and `PID` in the summary printf
changing `$port` variable to a list of PIDs rather than pulling only one using `netstat`