### PR TITLE
loaddir added to startline params

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -52,7 +52,7 @@ findproc() {
 startline() {
   procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")                                                     # get line number for file
   proctype=$(getfield "$procno" "proctype")                                                         # get proctype for process 
-  params="U localtime g T w load"                                                                   # list of params to read from config 
+  params="U localtime g T w loaddir load"                                                           # list of params to read from config 
   sline="${TORQHOME}/torq.q -stackid ${KDBBASEPORT} -proctype $proctype -procname $1"               # base part of startup line
   for p in $params; do                                                                              # iterate over params
     a=$(parameter "$procno" "$p");                                                                  # get param


### PR DESCRIPTION
This change is extending the functionality of a previous commit that enabled `loaddir` to be added manually to the startline for TorQ processes.

Adding the <loaddir> param to the <startline> function in <torq.sh> means that a start line containing a <loaddir> parameter can be output from the function, pulling from the process.csv file, rather than having to add `-loaddir` to a printed start line manually
