### PR TITLE
execute torq.q with q

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -59,6 +59,9 @@ startline() {
     sline="$sline$a";                                                                               # append to startup line
   done
   qcmd=$(getfield "$procno" "qcmd")
+  if [ -z $qcmd ]; then
+  qcmd="q"
+  fi
   sline="$qcmd $sline $(getfield "$procno" extras) -procfile $CSVPATH $EXTRAS"                      # append csv file and extra arguments to startup line
   echo "$sline"
  }

--- a/torq.sh
+++ b/torq.sh
@@ -59,8 +59,8 @@ startline() {
     sline="$sline$a";                                                                               # append to startup line
   done
   qcmd=$(getfield "$procno" "qcmd")
-  if [ -z $qcmd ]; then
-  qcmd="q"
+  if [ -z $qcmd ]; then                                                                             # if qcmd is undefined then default to q
+    qcmd="q"
   fi
   sline="$qcmd $sline $(getfield "$procno" extras) -procfile $CSVPATH $EXTRAS"                      # append csv file and extra arguments to startup line
   echo "$sline"


### PR DESCRIPTION
I needed this fix to make it start from my Linux install. I don't see how launching a nonexecutable script could work anywhere, but I'm probably missing something.