### PR TITLE
Disable email if trying to run on win 64

### DIFF
--- a/code/common/email.q
+++ b/code/common/email.q
@@ -21,9 +21,9 @@ lib:`$getenv[`KDBLIB],"/",string[.z.o],"/torQemail";
 connected:@[value;`connected;0b]
 
 if[enabled and .z.o~`w64;
-    .lg.w[`email;"Email is not supported for Windows 64bit. Disabling email fucntionality"];
-    enabled:0b
-    ];
+  .lg.w[`email;"Email is not supported for Windows 64bit. Disabling email fucntionality"];
+  enabled:0b
+  ];
 
 if[.email.enabled;
 

--- a/code/common/email.q
+++ b/code/common/email.q
@@ -20,6 +20,11 @@ img:@[value;`img;`$getenv[`KDBHTML],"/img/AquaQ-TorQ-symbol-small.png"]	// defau
 lib:`$getenv[`KDBLIB],"/",string[.z.o],"/torQemail";
 connected:@[value;`connected;0b]
 
+if[enabled and .z.o~`w64;
+    .lg.w[`email;"Email is not supported for Windows 64bit. Disabling email fucntionality"];
+    enabled:0b
+    ];
+
 if[.email.enabled;
 
   libfile:hsym ` sv lib,$[.z.o like "w*"; `dll; `so];


### PR DESCRIPTION
I tried unsuccessfully to compile the email libraries to w64. (I am no expert on C or dll though so this might still be possible to do)

Instead, if user tries to run email on w64 throw a warning and disable the email.enabled flag. 


