### PR TITLE
Fix for windows housekeeping inconsistency

### DIFF
--- a/code/processes/housekeeping.q
+++ b/code/processes/housekeeping.q
@@ -122,7 +122,7 @@ find:{[path;match;age;agemin]
 //defines full list of files based on Windows OS version
 winfilelist:{[path;match]
 	$[version in `w7`w8`w10;-2_(5_system "dir ",path,match);-5_(5_system "dir ",path,match, " /s")]
-}
+ }
 
 
 //removes files

--- a/code/processes/housekeeping.q
+++ b/code/processes/housekeeping.q
@@ -96,6 +96,12 @@ zip:{[FILE]
 
 //-locates files with path, matching string and age
 find:{[path;match;age;agemin]
+	//returns empty list for files if match is an empty string
+        if[""~match;
+          .lg.o[`housekeeping;"No matching files located"];
+          :();
+        ];
+
 	//renames the path to a windows readable format
 	PATH:ssr[path;"/";"\\"];
 	//searches for files and refines return to usable format

--- a/code/processes/housekeeping.q
+++ b/code/processes/housekeeping.q
@@ -108,15 +108,21 @@ find:{[path;match;age;agemin]
         //searches for files and refines return to usable format
 	$[0=agemin;
 	files:.[{[PATH;match;age].lg.o[`housekeeping;"Searching for: ", match];
-		system "z 1";fulllist:-2_(5_system "dir ",PATH,match);
+		system "z 1";fulllist:winfilelist[PATH;match];
 		removelist:fulllist where ("D"${10#x} each fulllist)<.proc.cd[]-age; system "z 0";
 		{[path;x]path,last " " vs x} [PATH;] each removelist};(PATH;match;age);err];
 	files:.[{[PATH;match;age].lg.o[`housekeeping;"Searching for: ", match];
-		system "z 1";fulllist:-2_(5_system "dir ",PATH,match);
+		system "z 1";fulllist:winfilelist[PATH;match];
 		removelist:fulllist where ({ts:("  " vs 17#x);("D"$ts[0]) + value ts[1]} each fulllist)<.proc.cp[]-`minute$age; system "z 0";
 		{[path;x]path,last " " vs x} [PATH;] each removelist};(PATH;match;age);err]];
 	$[(count files)=0;
 	[.lg.o[`housekeeping;"No matching files located"];files]; files]}
+
+//defines full list of files based on Windows OS version
+winfilelist:{[path;match]
+	$[.windows.version in `w7`w8`w10;-2_(5_system "dir ",PATH,match);-5_(5_system "dir ",PATH,match, " /s")]
+}
+
 
 //removes files
 rm: {[FILE]

--- a/code/processes/housekeeping.q
+++ b/code/processes/housekeeping.q
@@ -101,21 +101,20 @@ find:{[path;match;age;agemin]
           .lg.o[`housekeeping;"No matching files located"];
           :();
         ];
-
 	//renames the path to a windows readable format
 	PATH:ssr[path;"/";"\\"];
-	//searches for files and refines return to usable format
+	//error and info for find function 
+	err:{.lg.e[`housekeeping;"Find function failed: ", x]; ()};
+        //searches for files and refines return to usable format
 	$[0=agemin;
 	files:.[{[PATH;match;age].lg.o[`housekeeping;"Searching for: ", match];
-		system "z 1";fulllist:-5_(5_system "dir ",PATH,match, " /s");
+		system "z 1";fulllist:-2_(5_system "dir ",PATH,match);
 		removelist:fulllist where ("D"${10#x} each fulllist)<.proc.cd[]-age; system "z 0";
-		{[path;x]path,last " " vs x} [PATH;] each removelist};(PATH;match;age)];
+		{[path;x]path,last " " vs x} [PATH;] each removelist};(PATH;match;age);err];
 	files:.[{[PATH;match;age].lg.o[`housekeeping;"Searching for: ", match];
-		system "z 1";fulllist:-5_(5_system "dir ",PATH,match, " /s");
+		system "z 1";fulllist:-2_(5_system "dir ",PATH,match);
 		removelist:fulllist where ({ts:("  " vs 17#x);("D"$ts[0]) + value ts[1]} each fulllist)<.proc.cp[]-`minute$age; system "z 0";
-		{[path;x]path,last " " vs x} [PATH;] each removelist};(PATH;match;age)]];
-	//error and info for find function 
-	{.lg.e[`housekeeping;"Find function failed: ", x]; ()};
+		{[path;x]path,last " " vs x} [PATH;] each removelist};(PATH;match;age);err]];
 	$[(count files)=0;
 	[.lg.o[`housekeeping;"No matching files located"];files]; files]}
 

--- a/code/processes/housekeeping.q
+++ b/code/processes/housekeeping.q
@@ -6,6 +6,7 @@
 inputcsv:@[value;`.hk.inputcsv;.proc.getconfigfile["housekeeping.csv"]]
 runtimes:@[value;`.hk.runtimes;12:00]
 runnow:@[value;`.hk.runnow;0b]
+.win.version:@[value;`.win.version;`w10]
 
 inputcsv:string inputcsv
 
@@ -120,7 +121,7 @@ find:{[path;match;age;agemin]
 
 //defines full list of files based on Windows OS version
 winfilelist:{[path;match]
-	$[.windows.version in `w7`w8`w10;-2_(5_system "dir ",PATH,match);-5_(5_system "dir ",PATH,match, " /s")]
+	$[version in `w7`w8`w10;-2_(5_system "dir ",path,match);-5_(5_system "dir ",path,match, " /s")]
 }
 
 

--- a/config/settings/housekeeping.q
+++ b/config/settings/housekeeping.q
@@ -5,6 +5,6 @@ inputcsv:first .proc.getconfigfile["housekeeping.csv"]
 runtimes:02:00:00
 runnow:0b
 
-\d .windows
+\d .win
 
 version:`w10

--- a/config/settings/housekeeping.q
+++ b/config/settings/housekeeping.q
@@ -4,3 +4,7 @@
 inputcsv:first .proc.getconfigfile["housekeeping.csv"]
 runtimes:02:00:00
 runnow:0b
+
+\d .windows
+
+version:`w10


### PR DESCRIPTION
Attempted fix for housekeeping for Win OS - following up on issue #163 

Now the windows find function follows the unix find logic.

added an early exit to return files as an empty list if match is empty (targeting the issue from 163)