### PR TITLE
introduce reval for gw func calls

### DIFF
--- a/code/common/execas.q
+++ b/code/common/execas.q
@@ -1,4 +1,4 @@
 \d .pm
 
-execas:{[f;u;g]
- $[`.pm.requ ~ key `.pm.requ;.pm.requ[u;f];`.pm.valp ~ key `.pm.valp;.pm.valp f; g f]}
+execas:{[f;u]
+ $[`.pm.requ ~ key `.pm.requ;.pm.requ[u;f]; value f]}

--- a/code/common/execas.q
+++ b/code/common/execas.q
@@ -1,4 +1,4 @@
 \d .pm
 
 execas:{[f;u]
- $[`.pm.requ ~ key `.pm.requ;.pm.requ[u;f]; value f]}
+ $[`.pm.requ ~ key `.pm.requ;.pm.requ[u;f]; valp f]}

--- a/code/common/execas.q
+++ b/code/common/execas.q
@@ -1,4 +1,4 @@
 \d .pm
 
 execas:{[f;u]
- $[`.pm.requ ~ key `.pm.requ;.pm.requ[u;f]; valp f]}
+ $[`.pm.requ ~ key `.pm.requ;.pm.requ[u;f];`.pm.valp ~ key `.pm.valp;.pm.valp f; value f]}

--- a/code/common/execas.q
+++ b/code/common/execas.q
@@ -1,4 +1,4 @@
 \d .pm
 
-execas:{[f;u]
- $[`.pm.requ ~ key `.pm.requ;.pm.requ[u;f];`.pm.valp ~ key `.pm.valp;.pm.valp f; value f]}
+execas:{[f;u;g]
+ $[`.pm.requ ~ key `.pm.requ;.pm.requ[u;f];`.pm.valp ~ key `.pm.valp;.pm.valp f; g f]}

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -4,6 +4,10 @@
 if[@[1b; `.access.enabled;0b]; ('"controlaccess.q already active";exit 1) ]
 enabled:@[value;`enabled;0b]            // whether permissions are enabled
 maxsize:@[value;`maxsize;200000000]     // the maximum size of any returned result set
+readonly:@[value;`.readonly.enabled;0b]
+val:$[readonly;reval;eval]
+valp:$[readonly;{reval parse x};value]
+
 
 / constants
 ALL:`$"*";  / used to indicate wildcard/superuser access to functions/data
@@ -113,9 +117,9 @@ query:{[u;q;b;pr]
   $[b; :qexe q; :1b]}
 
 dotqd:enlist[`]!enlist{[u;e;b;pr]if[not (fchk[u;ALL;()] or fchk[u;`$string(first e);()]);$[b;'err[`expr][]];:0b];$[b;exe e;1b]};
-dotqd[`lj`ij`pj`uj]:{[u;e;b;pr] $[b;eval @[e;1 2;expr[u]];1b]}
-dotqd[`aj`ej]:{[u;e;b;pr] $[b;eval @[e;2 3;expr[u]];1b]}
-dotqd[`wj`wj1]:{[u;e;b;pr] $[b;eval @[e;2;expr[u]];1b]}
+dotqd[`lj`ij`pj`uj]:{[u;e;b;pr] $[b;val @[e;1 2;expr[u]];1b]}
+dotqd[`aj`ej]:{[u;e;b;pr] $[b;val @[e;2 3;expr[u]];1b]}
+dotqd[`wj`wj1]:{[u;e;b;pr] $[b;val @[e;2;expr[u]];1b]}
 
 dotqf:{[u;q;b;pr]
   qf:.q?(q[0]);
@@ -130,10 +134,10 @@ lamq:{[u;e;l;b;pr]
   if[count prohibited;'" | " sv .pm.err[`selt] each prohibited];
   $[b; :exe e; :1b]}
 
-exe:{if[(100<abs type first x); v:eval x]; v:value x;
+exe:{if[(100<abs type first x); v:val x]; v:valp x;
   if[maxsize<-22!v; 'err[`size][]]; v} 
 
-qexe:{v:eval x; if[maxsize<-22!v; 'err[`size][]]; v}
+qexe:{v:val x; if[maxsize<-22!v; 'err[`size][]]; v}
 
 mainexpr:{[u;e;b;pr]
   / store initial expression to use with value
@@ -166,7 +170,7 @@ allowed:mainexpr[;;0b;0b]
 parsequery:{[q]q:$[10=type q;q;10h=abs type f:first q;destringf[f],1_ q;q]}
 destringf:{$[(x:`$x)in key`.q;.q x;x~`insert;insert;x]}
 cando:{[u;q]q:parsequery[q]; $[enabled;allowed[u;q];1b]};
-requ:{[u;q]q:parsequery[q]; $[enabled; expr[u;q]; value q]};
+requ:{[u;q]q:parsequery[q]; $[enabled; expr[u;q]; valp q]};
 req:{$[.z.w = 0 ; value x; requ[.z.u;x]]}   / entry point - replace .z.pg/.zps
 
 / authentication

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -84,9 +84,6 @@ errorprefix:@[value;`.gw.errorprefix; "error: "]                 // the prefix f
 permissioned:@[value;`.gw.permissioned; 0b]                      // should the gateway permission queries before the permissions script does 
 clearinactivetime:@[value;`.gw.clearinactivetime; 0D01:00]       // the time to store data on inactive handles
 
-readonly:@[value;`.readonly.enabled;0b]                          // default read-only to off
-valp:$[readonly;{reval parse x};value]
-
 eod:0b
 seteod:{[b] .lg.o[`eod;".gw.eod set to ",string b]; eod::b;}    // called by wdb.q during EOD
 checkeod:{[IDS].gw.eod&1<count distinct$[11h=type ids:raze IDS;ids;exec servertype from .gw.servers where any serverid in/:ids]}    // check if eod reload affects query
@@ -449,7 +446,7 @@ asyncexecjpts:{[query;servertype;joinfunction;postback;timeout;sync]
    :();
    ];
   ];
- query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);valp q]}; .z.u; query);
+ query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; value q]}; .z.u; query);
  /- if sync calls are allowed disable async calls to avoid query conflicts
  $[.gw.synccallsallowed and .z.K<3.6;
    errStr:.gw.errorprefix,"only synchronous calls are allowed";
@@ -506,7 +503,7 @@ syncexecjpre36:{[query;servertype;joinfunction]
  handles:(exec serverid!handle from tab)first each (exec serverid from tab) inter/: serverids;
  setserverstate[handles;1b];
  start:.z.p;
- query:({[u;q]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u);valp q]}; .z.u; query);
+ query:({[u;q]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; value q]}; .z.u; query);
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -84,6 +84,9 @@ errorprefix:@[value;`.gw.errorprefix; "error: "]                 // the prefix f
 permissioned:@[value;`.gw.permissioned; 0b]                      // should the gateway permission queries before the permissions script does 
 clearinactivetime:@[value;`.gw.clearinactivetime; 0D01:00]       // the time to store data on inactive handles
 
+readonly:@[value;`.readonly.enabled;0b]                          // default read-only to off
+valp:$[readonly;{reval parse x};value]
+
 eod:0b
 seteod:{[b] .lg.o[`eod;".gw.eod set to ",string b]; eod::b;}    // called by wdb.q during EOD
 checkeod:{[IDS].gw.eod&1<count distinct$[11h=type ids:raze IDS;ids;exec servertype from .gw.servers where any serverid in/:ids]}    // check if eod reload affects query
@@ -446,7 +449,7 @@ asyncexecjpts:{[query;servertype;joinfunction;postback;timeout;sync]
    :();
    ];
   ];
- query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);value q]}; .z.u; query);
+ query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);valp q]}; .z.u; query);
  /- if sync calls are allowed disable async calls to avoid query conflicts
  $[.gw.synccallsallowed and .z.K<3.6;
    errStr:.gw.errorprefix,"only synchronous calls are allowed";
@@ -503,7 +506,7 @@ syncexecjpre36:{[query;servertype;joinfunction]
  handles:(exec serverid!handle from tab)first each (exec serverid from tab) inter/: serverids;
  setserverstate[handles;1b];
  start:.z.p;
- query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);value q]}; .z.u; query);
+ query:({[u;q]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u);valp q]}; .z.u; query);
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -450,7 +450,7 @@ asyncexecjpts:{[query;servertype;joinfunction;postback;timeout;sync]
    :();
    ];
   ];
- query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; @[value;q;{.lg.e[`gw;"Failed to execute query."]}]]}; .z.u; query;.gw.valp);
+ query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; value q]}; .z.u; query);
  /- if sync calls are allowed disable async calls to avoid query conflicts
  $[.gw.synccallsallowed and .z.K<3.6;
    errStr:.gw.errorprefix,"only synchronous calls are allowed";
@@ -507,7 +507,7 @@ syncexecjpre36:{[query;servertype;joinfunction]
  handles:(exec serverid!handle from tab)first each (exec serverid from tab) inter/: serverids;
  setserverstate[handles;1b];
  start:.z.p;
- query:({[u;q]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; @[value;q;{.lg.e[`gw;"Failed to execute query."]}]]}; .z.u; query;.gw.valp);
+ query:({[u;q]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; value q]}; .z.u; query);
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -84,6 +84,10 @@ errorprefix:@[value;`.gw.errorprefix; "error: "]                 // the prefix f
 permissioned:@[value;`.gw.permissioned; 0b]                      // should the gateway permission queries before the permissions script does 
 clearinactivetime:@[value;`.gw.clearinactivetime; 0D01:00]       // the time to store data on inactive handles
 
+readonly:@[value;`.readonly.enabled;0b]
+valp:$[`.pm.valp ~ key `.pm.valp;.pm.valp;.gw.readonly;{value parse x};value]
+val:$[`.pm.val ~ key `.pm.val;.pm.val;.gw.readonly;reval;eval]
+
 eod:0b
 seteod:{[b] .lg.o[`eod;".gw.eod set to ",string b]; eod::b;}    // called by wdb.q during EOD
 checkeod:{[IDS].gw.eod&1<count distinct$[11h=type ids:raze IDS;ids;exec servertype from .gw.servers where any serverid in/:ids]}    // check if eod reload affects query
@@ -446,7 +450,7 @@ asyncexecjpts:{[query;servertype;joinfunction;postback;timeout;sync]
    :();
    ];
   ];
- query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; value q]}; .z.u; query);
+ query:({[u;q;g]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u; g);`.pm.valp ~ key `.pm.valp; .pm.valp q; g q]}; .z.u; query;.gw.valp);
  /- if sync calls are allowed disable async calls to avoid query conflicts
  $[.gw.synccallsallowed and .z.K<3.6;
    errStr:.gw.errorprefix,"only synchronous calls are allowed";
@@ -503,7 +507,7 @@ syncexecjpre36:{[query;servertype;joinfunction]
  handles:(exec serverid!handle from tab)first each (exec serverid from tab) inter/: serverids;
  setserverstate[handles;1b];
  start:.z.p;
- query:({[u;q]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; value q]}; .z.u; query);
+ query:({[u;q;g]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u; g);`.pm.valp ~ key `.pm.valp; .pm.valp q; g q]}; .z.u; query;.gw.valp);
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -450,7 +450,7 @@ asyncexecjpts:{[query;servertype;joinfunction;postback;timeout;sync]
    :();
    ];
   ];
- query:({[u;q;g]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u; g);`.pm.valp ~ key `.pm.valp; .pm.valp q; g q]}; .z.u; query;.gw.valp);
+ query:({[u;q]$[`.pm.execas ~ key `.pm.execas;value (`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; @[value;q;{.lg.e[`gw;"Failed to execute query."]}]]}; .z.u; query;.gw.valp);
  /- if sync calls are allowed disable async calls to avoid query conflicts
  $[.gw.synccallsallowed and .z.K<3.6;
    errStr:.gw.errorprefix,"only synchronous calls are allowed";
@@ -507,7 +507,7 @@ syncexecjpre36:{[query;servertype;joinfunction]
  handles:(exec serverid!handle from tab)first each (exec serverid from tab) inter/: serverids;
  setserverstate[handles;1b];
  start:.z.p;
- query:({[u;q;g]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u; g);`.pm.valp ~ key `.pm.valp; .pm.valp q; g q]}; .z.u; query;.gw.valp);
+ query:({[u;q]$[`.pm.execas ~ key `.pm.execas; value(`.pm.execas; q; u);`.pm.valp ~ key `.pm.valp; .pm.valp q; @[value;q;{.lg.e[`gw;"Failed to execute query."]}]]}; .z.u; query;.gw.valp);
  // to allow parallel execution, send an async query up each handle, then block and wait for the results
  (neg handles)@\:({@[neg .z.w;@[{(1b;.z.p;value x)};x;{(0b;.z.p;x)}];{@[neg .z.w;(0b;.z.p;x);()]}]};query);
  // flush


### PR DESCRIPTION
Fixes #162 
Added new eval/value functions for both .pm and .gw namespaces which prevent the readonly function being violated by calling a .gw function.