### PR TITLE
Store TP logs and HDB in separate location

### DIFF
--- a/setenv.sh
+++ b/setenv.sh
@@ -17,8 +17,9 @@ export KDBCONFIG=${TORQHOME}/config
 export KDBCODE=${TORQHOME}/code
 export KDBAPPCONFIG=${TORQAPPHOME}/appconfig                                                        # sets the application specific configuration directory
 export KDBAPPCODE=${TORQAPPHOME}/code
-export KDBHDB=${TORQDATA}/hdb/database
+export KDBHDB=${TORQDATA}/hdb
 export KDBWDB=${TORQDATA}/wdbhdb
+export KDBTPLOG=${TORQDATA}/tplogs
 
 export KDBBASEPORT=6000                                                                             # set KDBBASEPORT to the default value for a TorQ Installation
 export KDBSTACKID="-stackid ${KDBBASEPORT}"


### PR DESCRIPTION
Aimed to address the issue of TP logs and HDB data stored in the same directory. now TP logs will be saved in /tplogs and hdb saved in /hdb