### PR TITLE
call extended logging functionality on log messages

### DIFF
--- a/torq.q
+++ b/torq.q
@@ -202,9 +202,9 @@ pubmap:@[value;`pubmap;`ERROR`ERR`INF`WARN!1 1 0 1]
 // Log a message
 l:{[loglevel;proctype;proc;id;message;dict]
 	if[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
-		neg[redir] .lg.format[loglevel;proctype;proc;id;message];
-		ext[loglevel;proctype;proc;id;message;dict]];
-        publish[loglevel;proctype;proc;id;message];	
+		neg[redir] .lg.format[loglevel;proctype;proc;id;message]];
+	ext[loglevel;proctype;proc;id;message;dict];
+	publish[loglevel;proctype;proc;id;message];	
 	}
 
 // Log an error.  

--- a/torq.q
+++ b/torq.q
@@ -201,7 +201,7 @@ pubmap:@[value;`pubmap;`ERROR`ERR`INF`WARN!1 1 0 1]
 
 // Log a message
 l:{[loglevel;proctype;proc;id;message;dict]
-	$[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
+	if[0 < redir:`int$(0w 1 `onelog in key .proc.params)&0^outmap[loglevel];
 		neg[redir] .lg.format[loglevel;proctype;proc;id;message];
 		ext[loglevel;proctype;proc;id;message;dict]];
         publish[loglevel;proctype;proc;id;message];	


### PR DESCRIPTION
Any extended logging functionality defined in .lg.ext should be executed as part of logging