### PR TITLE
Checks for correct attribute parameter types

### DIFF
--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -313,7 +313,7 @@ getserversinitial:{[req;att]
  att:(where all each (key req) in/: key each att)#att;
 
  if[not count att;'"getservers: no servers report all requested attributes"];
-
+ 
  /- calculate where each of the requirements is in each of the attribute sets
  s:update serverid:key att from value req in'/: (key req)#/:att;
 
@@ -388,6 +388,10 @@ getserverscross:{[req;att;besteffort]
 getserverids:{[att]
   if[99h<>type att;
    // its a list of servertypes e.g. `rdb`hdb
+   // check if user attributes are a symbol list
+   if[11h<>type att;
+   '" Servertype should be given as either a dictionary(type 99h) or a symbol list (11h)"
+   ];
    servertype:distinct att,();
    //list of active servers
    activeservers:exec distinct servertype from .gw.servers where active;
@@ -409,6 +413,12 @@ getserverids:{[att]
   ];
 
   // its a dictionary of attributes
+  // check if attribute types are correct types
+  correctAttTypes:`dates`servertypes`tables!(14h;11h;11h);
+  w:(correctAttTypes [key att]=type each att);
+  if[not all{[x;y] y each key x}[att;w];
+  '("Wrong function parameter types provided.", " ",(raze " " sv string (where not w))," parameter(s) need type(s) ",raze " " sv string correctAttTypes where not w),"h"
+  ];
 
   serverids:$[`servertype in key att; 
   raze getserveridstype[delete servertype from att] each (),att`servertype; 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -313,7 +313,7 @@ getserversinitial:{[req;att]
  att:(where all each (key req) in/: key each att)#att;
 
  if[not count att;'"getservers: no servers report all requested attributes"];
- 
+
  /- calculate where each of the requirements is in each of the attribute sets
  s:update serverid:key att from value req in'/: (key req)#/:att;
 
@@ -413,12 +413,12 @@ getserverids:{[att]
   ];
 
   // its a dictionary of attributes
-  // check if attribute types are correct types
-  correctAttTypes:`dates`servertypes`tables!(14h;11h;11h);
-  w:(correctAttTypes [key att]=type each att);
-  if[not all{[x;y] y each key x}[att;w];
-  '("Wrong function parameter types provided.", " ",(raze " " sv string (where not w))," parameter(s) need type(s) ",raze " " sv string correctAttTypes where not w),"h"
-  ];
+    // check if attribute types are correct types
+    correctAttTypes:`dates`servertypes`tables!14 11 11h;
+    w:correctAttTypes[key att]=type each att;
+    if[not all{[x;y] y each key x}[att;w];
+    '("Wrong function parameter types provided.", " ",(raze " " sv string (where not w))," parameter(s) need type(s) ",raze " " sv string correctAttTypes where not w),"h"
+    ];
 
   serverids:$[`servertype in key att; 
   raze getserveridstype[delete servertype from att] each (),att`servertype; 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -388,10 +388,10 @@ getserverscross:{[req;att;besteffort]
 getserverids:{[att]
   if[99h<>type att;
    // its a list of servertypes e.g. `rdb`hdb
-     // check if user attributes are a symbol list
-     if[not type[att]in 99 11h;
+   // check if user attributes are a symbol list
+   if[not type[att]in 99 11h;
      '" Servertype should be given as either a dictionary(type 99h) or a symbol list (11h)"
-     ];
+   ];
    servertype:distinct att,();
    //list of active servers
    activeservers:exec distinct servertype from .gw.servers where active;
@@ -413,15 +413,15 @@ getserverids:{[att]
   ];
 
   // its a dictionary of attributes
-    // check if attribute types are correct types
-    correctAttTypes:`date`servertype`tables!14 11 11h;
-    w:correctAttTypes[key att]=abs type each att;
-    if[not all w key att;
-    '"Wrong function parameter types provided.", " ",(" "sv string where not w)," parameter(s) need type(s) ",.Q.s1 correctAttTypes where not w
-    ];
+  // check if attribute types are correct types
+  correctAttTypes:`date`servertype`tables!14 11 11h;
+  w:correctAttTypes[key att]=abs type each att;
+  if[not all w key att;
+    '"Wrong function parameter types provided.", " ",(" "sv string where not w)," parameter(s) need type(s) ",.Q.s1 correctAttTypes where not
+  ];
 
-  serverids:$[`servertype in key att; 
-  raze getserveridstype[delete servertype from att] each (),att`servertype; 
+  serverids:$[`servertype in key att;
+  raze getserveridstype[delete servertype from att] each (),att`servertype;
   getserveridstype[att;`all]];
 
   if[all 0=count each serverids;'"no servers match requested attributes"];

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -388,10 +388,10 @@ getserverscross:{[req;att;besteffort]
 getserverids:{[att]
   if[99h<>type att;
    // its a list of servertypes e.g. `rdb`hdb
-   // check if user attributes are a symbol list
-   if[11h<>type att;
-   '" Servertype should be given as either a dictionary(type 99h) or a symbol list (11h)"
-   ];
+     // check if user attributes are a symbol list
+     if[11h<>type att;
+     '" Servertype should be given as either a dictionary(type 99h) or a symbol list (11h)"
+     ];
    servertype:distinct att,();
    //list of active servers
    activeservers:exec distinct servertype from .gw.servers where active;

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -389,7 +389,7 @@ getserverids:{[att]
   if[99h<>type att;
    // its a list of servertypes e.g. `rdb`hdb
      // check if user attributes are a symbol list
-     if[11h<>type att;
+     if[not type[att]in 99 11h;
      '" Servertype should be given as either a dictionary(type 99h) or a symbol list (11h)"
      ];
    servertype:distinct att,();
@@ -414,10 +414,10 @@ getserverids:{[att]
 
   // its a dictionary of attributes
     // check if attribute types are correct types
-    correctAttTypes:`dates`servertypes`tables!14 11 11h;
-    w:correctAttTypes[key att]=type each att;
-    if[not all{[x;y] y each key x}[att;w];
-    '("Wrong function parameter types provided.", " ",(raze " " sv string (where not w))," parameter(s) need type(s) ",raze " " sv string correctAttTypes where not w),"h"
+    correctAttTypes:`date`servertype`tables!14 11 11h;
+    w:correctAttTypes[key att]=abs type each att;
+    if[not all w key att;
+    '"Wrong function parameter types provided.", " ",(" "sv string where not w)," parameter(s) need type(s) ",.Q.s1 correctAttTypes where not w
     ];
 
   serverids:$[`servertype in key att; 

--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -389,7 +389,7 @@ getserverids:{[att]
   if[99h<>type att;
    // its a list of servertypes e.g. `rdb`hdb
    // check if user attributes are a symbol list
-   if[not type[att]in 99 11h;
+   if[not type[att]=11h;
      '" Servertype should be given as either a dictionary(type 99h) or a symbol list (11h)"
    ];
    servertype:distinct att,();


### PR DESCRIPTION
Inform user of the correct parameter types if a wrong type is passed in.
Checks are placed in the `getserverids` function and include checks for:
- If servertype is given as a symbol list 
- If servertype attributes are of the correct types compared to a correctAttTypes dictionary