### PR TITLE
Added kill -9 to stop function to ensure processes are stopped

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -119,6 +119,13 @@ stop() {
     port=$(($(eval echo \$"$(getfield "$procno" port)")))
     eval "kill -15 `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
   fi
+  if [[ ! -z $(findproc "$1") ]]; then                                                              # check process still running
+    sleep 1
+    if [[ ! -z $(findproc "$1") ]]; then
+      echo "$(date '+%H:%M:%S') | $1 did not shut down correctly. Killing process with -9..."
+      eval "kill -9 `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
+    fi
+  fi
  }
 
 getall() {


### PR DESCRIPTION
Improve the stop function in torq.sh to ensure that a process stops. Check if the function is still up after kill -15, if it is sleep, check again and perform kill -9 on active process.