### PR TITLE
Set testing variable in dqe for use with unit tests

### DIFF
--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -3,6 +3,8 @@
 configcsv:@[value;`.dqe.configcsv;first .proc.getconfigfile["dqeconfig.csv"]];
 detailcsv:@[value;`.dqe.detailcsv;first .proc.getconfigfile["dqedetailtab.csv"]];
 
+testing:@[value;`.dqe.testing;0b];                                                                              /- testing varible for unit tests
+
 init:{
   .lg.o[`init;"searching for servers"];
   .servers.startup[];                                                                                           /- Open connection to discovery
@@ -95,4 +97,4 @@ update endtime:?[0W=endtime;0Wp;.z.d+endtime] from `.dqe.configtable
 / Sample runcheck:
 / show .dqe.results
 / Load up timers
-.dqe.loadtimer '[.dqe.configtable]
+if[not .dqe.testing;.dqe.loadtimer '[.dqe.configtable]]


### PR DESCRIPTION
Set `.dqe.testing` up to be used for stopping timers when running unit tests