### PR TITLE
Ensure correct sub information is returned

### DIFF
--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -11,7 +11,7 @@ SUBSCRIPTIONS:([]procname:`symbol$();proctype:`symbol$();w:`int$();table:();inst
 getsubscriptionhandles:{[proctype;procname;attributes]
 	/-grab data from .serves.SERVERS, add handling for passing in () as an argument
 	data:{select procname,proctype,w from x}each .servers.getservers[;;attributes;1b;0b]'[`proctype`procname;(proctype;procname)];
-	$[0h in type each (proctype;procname);:distinct raze data;:inter/[data]]
+	$[0h in type each (proctype;procname);distinct raze data;inter/[data]]
 	}
 
 updatesubscriptions:{[proc;tab;instrs]

--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -9,7 +9,9 @@ checksubscriptionperiod:(not @[value;`.proc.lowpowermode;0b]) * @[value;`checksu
 SUBSCRIPTIONS:([]procname:`symbol$();proctype:`symbol$();w:`int$();table:();instruments:();createdtime:`timestamp$();active:`boolean$());
 
 getsubscriptionhandles:{[proctype;procname;attributes]
-	distinct raze {select procname,proctype,w from x}each .servers.getservers[;;attributes;1b;0b]'[`proctype`procname;(proctype;procname)]
+	/-grab data from .serves.SERVERS, add handling for passing in () as an argument
+	data:{select procname,proctype,w from x}each .servers.getservers[;;attributes;1b;0b]'[`proctype`procname;(proctype;procname)];
+	$[0h in type each (proctype;procname);:distinct raze data;:inter/[data]]
 	}
 
 updatesubscriptions:{[proc;tab;instrs]


### PR DESCRIPTION
## Overview
Change the way that `.sub.getsubscriptionhandles` handles the data pulled from `.servers.SERVERS`. Add handling for `()` argument for process name/type.

Fixes #212 

## Tasks
- [x] Update to have null sym return all procnames matching the current proctype
- [x] Identify if () case should be kept; potentially this is being used in production code
- [ ] Update documentation to reflect changes