### PR TITLE
Allow tickerplant to start with no tplogdir

### DIFF
--- a/code/processes/tickerplant.q
+++ b/code/processes/tickerplant.q
@@ -80,7 +80,7 @@ if[not system"t";system"t 1000";
 
 \d .
 src:$["/" in src;(1 + last src ss "/") _ src; src];  / if src contains directory path, remove it
-.u.tick[src;ssr[raze .proc.params`tplogdir;"\\";"/"]];
+.u.tick[src;ssr[$[count .proc.params`tplogdir;raze .proc.params`tplogdir;""];"\\";"/"]];
 
 
 \


### PR DESCRIPTION
Small change to allow case where tickerplant is started like so:

```
q torq.q -procname tickerplant1 ... -tplogdir -procfile ...
```

i.e. `-tplogdir` is specified in cmd line but no value given.

This allows disabling TP logging by unsetting the relevant env var (i.e. `KDBTPLOG`)

I believe this was already the intended behaviour, but it threw a `'type` error on the `ssr` if ``.proc.params`tplogdir`` was an empty list rather than a string.