### PR TITLE
Improve k4unit TorQ integration

### DIFF
--- a/config/settings/default.q
+++ b/config/settings/default.q
@@ -173,3 +173,10 @@ del:".";
 \d .dg
 enabled:0b;		//whether .lg.ext is overwritten to send errors to datadog. Default is 0b meaning errors will not be sent to datadog.
 
+// k4unit tests
+\d .KU
+VERBOSE:1;              // 0 - no logging to console, 1 - log filenames, >1 - log tests
+DEBUG:0;                // 0 - trap errors, 1 - suspend if errors (except action=`fail)
+DELIM:",";              // csv delimiter
+SAVEFILE:`:KUTR.csv;    // test results savefile
+

--- a/setenv.sh
+++ b/setenv.sh
@@ -15,6 +15,7 @@ export KDBHTML=${TORQHOME}/html
 export KDBLIB=${TORQHOME}/lib
 export KDBCONFIG=${TORQHOME}/config
 export KDBCODE=${TORQHOME}/code
+export KDBTESTS=${TORQHOME}/tests
 export KDBAPPCONFIG=${TORQAPPHOME}/appconfig                                                        # sets the application specific configuration directory
 export KDBAPPCODE=${TORQAPPHOME}/code
 export KDBHDB=${TORQDATA}/hdb

--- a/tests/k4unit.q
+++ b/tests/k4unit.q
@@ -2,6 +2,14 @@
 / csv columns: action,ms,bytes,lang,code (csv with colheaders)
 / if your code contains commas enclose the whole code in "quotes"
 / usage: q k4unit.q -p 5001
+
+\d .KU
+VERBOSE:@[value;`.KU.VERBOSE;1];                // 0 - no logging to console, 1 - log filenames, >1 - log tests
+DEBUG:@[value;`.KU.DEBUG;0];                    // 0 - trap errors, 1 - suspend if errors (except action=`fail)
+DELIM:@[value;`.KU.DELIM;","];                  // csv delimiter
+SAVEFILE:@[value;`.KU.SAVEFILE;`:KUTR.csv];     // test results savefile
+\d .
+
 / KUT <-> KUnit Tests
 KUT:([]action:`symbol$();ms:`int$();bytes:`long$();lang:`symbol$();code:`symbol$();repeat:`int$();minver:`float$();file:`symbol$();comment:())
 / KUltd `:dirname and/or KUltf `:filename.csv
@@ -43,7 +51,6 @@ KUTR:([]action:`symbol$();ms:`int$();bytes:`long$();lang:`symbol$();code:`symbol
 / timestamp: when test was run
 / comment: description of the test if it's obscure..
 
-\c 10000 10000
 KUstr:{.KU.SAVEFILE 0:.KU.DELIM 0:update code:string code from KUTR} / save test results
 KUltr:{`KUTR upsert("SIJSSIJSIBBBBZ";enlist .KU.DELIM)0:.KU.SAVEFILE} / reload previously saved test results
 
@@ -61,12 +68,11 @@ KUltd:{ / (load test dir) - load all *.csv files in directory <x> into KUT
 
 KUrt:{ / (run tests) - run contents of KUT, save results to KUTR
 	before:count KUTR;uf:exec asc distinct file from KUT;i:0;
-	if[.KU.VERBOSE;-1(string .z.Z)," start"];
+	if[.KU.VERBOSE;.lg.o[`k4unit;"start"]];
 	exec KUexec'[lang;code;repeat] from KUT where action=`beforeany;
 	do[count uf;
 		ufi:uf[i];KUTI:select from KUT where file=ufi;
-		if[.KU.VERBOSE;
-			-1(string .z.Z)," ",(string ufi)," ",(string exec count i from KUTI where action in `run`true`fail)," test(s)"];
+		if[.KU.VERBOSE;.lg.o[`k4unit;(string ufi)," ",(string exec count i from KUTI where action in `run`true`fail)," test(s)"]];
 		exec KUexec'[lang;code;repeat] from KUT where action=`beforeeach;
 		exec KUexec'[lang;code;repeat] from KUTI where action=`before;
 		/ preserve run,true,fail order
@@ -75,12 +81,12 @@ KUrt:{ / (run tests) - run contents of KUT, save results to KUTR
 		exec KUexec'[lang;code;repeat] from KUT where action=`aftereach;
 		i+:1];
 	exec KUexec'[lang;code;repeat] from KUT where action=`afterall;
-	if[.KU.VERBOSE;-1(string .z.Z)," end"];
+	if[.KU.VERBOSE;.lg.o[`k4unit;"end"]];
 	neg before-count KUTR}
 
 KUpexec:{[prefix;lang;code;repeat;allowfail]
 	s:prefix,(string lang),")",$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"];
-	if[1<.KU.VERBOSE;-1 s];$[.KU.DEBUG&allowfail;value s;@[value;s;`FA1L]]}
+	if[1<.KU.VERBOSE;.lg.o[`k4unit;s]];$[.KU.DEBUG&allowfail;value s;@[value;s;`FA1L]]}
 
 KUfailed:{`FA1L~x}
 
@@ -121,21 +127,6 @@ KUerr::delete ok from select from KUTR where not ok
 KUerrf::distinct exec file from KUerr
 KUinvalid::delete ok,valid from select from KUTR where not valid
 KUinvalidf::distinct exec file from KUinvalid
-
-\d .KU
-/ VERBOSE:
-/ 0 - no logging to console
-/ 1 - log filenames
-/>1 - log tests
-VERBOSE:1
-/ DEBUG:
-/0 - trap errors, press on regardless
-/1 - suspend if errors (except if action=`fail of course)
-DEBUG:0
-/ DELIM, csv delimiter
-DELIM:","
-/ Test Results SAVEFILE
-SAVEFILE:`:KUTR.csv
 
 \d .
 @[value;"\\l k4unit.custom.q";::];

--- a/tests/runtests.q
+++ b/tests/runtests.q
@@ -1,6 +1,6 @@
-KUltd each hsym`$.proc.params[`test]
+KUltd each hsym`$.proc.params[`test];
 
-KUrt[]
+KUrt[];
 
 show "k4unit Test Results"
 show KUTR


### PR DESCRIPTION
Couple of tweaks to make k4unit more integrated in TorQ

* Use TorQ logging functions
* Move `.KU` config variables to top of `k4unit.q` & add to config
  * Allows to overwrite config on cmd line e.g. `-.KU.DEBUG 1` etc.
* Add `KDBTESTS` env var to default `setenv.sh`
* Remove console resizing
* Suppress return when loading & running tests