### PR TITLE
Allow subscription when TP logs disabled

### DIFF
--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -55,9 +55,8 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 	/-if replaylog is false,dont try to get the log file details - they may not exist
 	/-set the function to send to the server based on this
 	.lg.o[`subscribe;"getting details from the server"];
-	df:$[replaylog;{(.u.sub\:[x;y];(.u.i;.u.L);(.u `icounts);(.u `d))};{(.u.sub\:[x;y];(.u `i;`);(.u `icounts);(.u `d))}];
-	details:@[proc`w;(df;subtabs;instrs);
-		{.lg.e[`subscribe;"failed to get the required details from server : ",x];()}];
+    df:{(.u.sub\:[x;y];(.u`i`L);(.u `icounts);(.u `d))};
+    details:@[proc`w;(df;subtabs;instrs);{.lg.e[`subscribe;"subscribe failed : ",x];()}];
 	/-to be returned at end of function (null if there is no log)
 	logdate: 0Nd;
 	if[count details;
@@ -66,7 +65,7 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 			/-the first element of details is a list of pairs (tablename; schema)
 			/-this is the same as (tablename set schema)each table subscribed to
 			(@[`.;;:;].)each details[0] where not nulldetail:0=count each details 0;];
-		if[replaylog;
+		if[replaylog&not null details[1;1];
 			.lg.o[`subscribe;"replaying the log file"];
 			/-store the orig version of upd
 			origupd:@[value;`..upd;{{[x;y]}}];
@@ -82,6 +81,8 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 			@[{-11!x;};details 1;{.lg.e[`subscribe;"could not replay the log file: ", x]}];
 			/-reset the upd function back to original upd
 			@[`.;`upd;:;origupd]];
+		if[replaylog&null details[1;1];
+			.lg.w[`subscribe;"replaylog set to true but TP not using log file"]];
 		/-insert the details into the SUBSCRIPTIONS table
 		.lg.o[`subscribe;"subscription successful"];
 		updatesubscriptions[proc;;instrs]each subtabs];

--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -55,8 +55,8 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 	/-if replaylog is false,dont try to get the log file details - they may not exist
 	/-set the function to send to the server based on this
 	.lg.o[`subscribe;"getting details from the server"];
-    df:{(.u.sub\:[x;y];(.u`i`L);(.u `icounts);(.u `d))};
-    details:@[proc`w;(df;subtabs;instrs);{.lg.e[`subscribe;"subscribe failed : ",x];()}];
+	df:{(.u.sub\:[x;y];(.u`i`L);(.u `icounts);(.u `d))};
+	details:@[proc`w;(df;subtabs;instrs);{.lg.e[`subscribe;"subscribe failed : ",x];()}];
 	/-to be returned at end of function (null if there is no log)
 	logdate: 0Nd;
 	if[count details;

--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -82,7 +82,7 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 			/-reset the upd function back to original upd
 			@[`.;`upd;:;origupd]];
 		if[replaylog&null details[1;1];
-			.lg.w[`subscribe;"replaylog set to true but TP not using log file"]];
+			.lg.e[`subscribe;"replaylog set to true but TP not using log file"]];
 		/-insert the details into the SUBSCRIPTIONS table
 		.lg.o[`subscribe;"subscription successful"];
 		updatesubscriptions[proc;;instrs]each subtabs];

--- a/code/processes/chainedtp.q
+++ b/code/processes/chainedtp.q
@@ -123,12 +123,13 @@ refreshtp:{[d]
   /- reset log and publish count
   .u.i:.u.j:0;
   .u.icounts::.u.jcounts::(`symbol$())!0#0,();
-  /- create new logfile name
-  .u.L:createlogfilename[d];
+  /- create log file if required
+  if[createlogfile;
+    .u.L:createlogfilename[d];
+    if[clearlogonsubscription;clearlog .u.L];
+  ];
   /- log file handle
-  .u.l:$[createlogfile;
-    [if[clearlogonsubscription;clearlog .u.L];
-    openlog .u.L];1i];
+  .u.l:$[createlogfile;openlog .u.L;1i];
   /- set date
   .u.d:d;
   }


### PR DESCRIPTION
In #215 ability to start tickerplant without TP logs was added

When subscriber connects (including rdb, wdb etc.) & attempts to replay log, this fails because `.u.L` can't be retrieved from tickerplant.

This PR changes this so that `.u.L` is always taken from tickerplant by indexing into `.u` (which gives generic null if variable is not defined) & displays a warning if `replaylog` was set to true but there is no log file provided by tickerplant.

Additionally, CTP defined `.u.L` regards of setting of `.ctp.createlog`; this meant that subscribing & replaying log while CTP log is disabled would still be broken - change to define `.u.L` only if log is being created.