### PR TITLE
Update CTP subscribe function

### DIFF
--- a/code/processes/chainedtp.q
+++ b/code/processes/chainedtp.q
@@ -55,7 +55,7 @@ openlog:{[lgfile]
 
 /- subscribe to tickerplant and refresh tickerplant settings
 subscribe:{[]
-  s:.sub.getsubscriptionhandles[`procname;.ctp.tickerplantname;()!()];
+  s:.sub.getsubscriptionhandles[`;.ctp.tickerplantname;()!()];
   if[count s;
       subproc:first s;
       .ctp.tph:subproc`w;


### PR DESCRIPTION
The `.sub.getsubscriptionhandles` function was updated to ensure that it returned correct subscriber information and also to handle `()` as a function argument. The CTP was using a dummy parameter when calling this function to return any handle with the correct process name, and the new function behaviour would cause this not to work and in fact return nothing. 

Instead, the dummy process type should be replaced with a null symbol or `()` to return processes of any type with the given process name, and that is what has been done with this change.