### PR TITLE
Change how the Engine process stores results

### DIFF
--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -8,32 +8,22 @@ getpartition:@[value;`getpartition;
     (`date^partitiontype)$(.z.D,.z.d)gmttime]}}];
 
 configcsv:@[value;`.dqe.configcsv;first .proc.getconfigfile["dqengineconfig.csv"]];
-resultstab:([procs:`$();tab:`$()]tablecount:`long$();nullcount:`long$();anomcount:`long$());
+resultstab:([]funct:`$();params:`$();procs:`$();resvalue:`long$());
 
 init:{
   .lg.o[`init;"searching for servers"];
   .servers.startup[];                                                                                           /- Open connection to discovery
   }
 
-updresultstab:{[proc;col;table;tabinput]                                                                        /- upadate results table with results
-  .lg.o[`updresultstab;"Updating results table for ",(string table)," table from proc ",string proc];
-  colfix:`$5_string col;                                                                                        /- remove namespace from query name
-  ![`.dqe.resultstab;((=;`procs;enlist proc);(=;`tab;enlist table));0b;(enlist colfix)!enlist tabinput]         /- Update query results into table
+updresultstab:{[proc;fn;params;resinput]                                                                        /- upadate results table with results
+  .lg.o[`updresultstab;"Updating results for ",(string fn)," from proc ",string proc];
+  `.dqe.resultstab insert (`$5_string fn;`$"," sv string params;proc;resinput)
   }
 
-chkinresults:{[proc;table]                                                                                      /- check if record already exists for proc,table pair
-  .lg.o[`chkresults;"Checking if ",(string proc),",",(string table)," is in resultstab"];
-  if[not (proc;table) in key resultstab;
-    .lg.o[`chkinresults;"adding null row for ",(string table)," table from proc ",string proc];
-    colcount:-2+count cols resultstab;                                                                          /- get count of unkeyed columns from results table
-    `.dqe.resultstab insert raze(proc;table,colcount#0N)]                                                       /- insert proc,table pair with nulls into other columns
-  }
-
-qpostback:{[proc;query;result]
+qpostback:{[proc;query;params;querytype;result]
   .lg.o[`qpostback;"Postback sucessful for ",string first proc];
-  tab:key result;                                                                                               /- get table names from dictionary
-  .dqe.chkinresults[first proc]'[tab];
-  .dqe.updresultstab[first proc;query]'[tab;value result];
+  if[`table=querytype;params:(key result),\:params];                                                            /- get table names from dictionary and attach other parameters
+  .dqe.updresultstab[first proc;query]'[params;value result];
   }
 
 runquery:{[query;params;querytype;rs]
@@ -42,7 +32,7 @@ runquery:{[query;params;querytype;rs]
   if[not rs in exec procname from .servers.SERVERS;.lg.e[`runquery;"error: remote service must be a proctype";:()]];
 
   h:.dqe.gethandles[(),rs];
-  .async.postback[h`w;((value query),params);.dqe.qpostback[h`procname;query]];
+  .async.postback[h`w;((value query),params);.dqe.qpostback[h`procname;query;params;querytype]];
   }
 
 loadtimer:{[d]


### PR DESCRIPTION
- Changed the results tab in Engine to store as rows rather than columns
- Removed chkinresults function as it is no longer needed
- Change resultstab schema to allow other types of check result returns, instead of just table related