### PR TITLE
DQE engine distinct symbols count

### DIFF
--- a/code/dqe/symcount.q
+++ b/code/dqe/symcount.q
@@ -1,4 +1,4 @@
 \d .dqe
-symcount:{[t;col]
-  (enlist t)!(enlist count {?[x; enlist(=;.Q.pf;last .Q.PV); 1b; (enlist y)!(enlist y)]}[t;col])
+symcount:{[t;col]                                                                                        /distinct symbols count in a table t and a column col. Works on partitioned tables in an hdb
+  (enlist t)!(enlist count ?[t; enlist(=;.Q.pf;last .Q.PV); 1b; {x!x}enlist col])
   }

--- a/code/dqe/symcount.q
+++ b/code/dqe/symcount.q
@@ -1,5 +1,4 @@
 \d .dqe
-symcount:{[t;colname]
-  /count {?[x; enlist(=;.Q.pf;last .Q.PV); 1b; (enlist y)!(enlist y)]}[t;colname]
-  (enlist t)!(enlist count {?[x; (); 1b; (enlist y)!(enlist y)]}[t;colname])
+symcount:{[t;col]
+  (enlist t)!(enlist count {?[x; enlist(=;.Q.pf;last .Q.PV); 1b; (enlist y)!(enlist y)]}[t;col])
   }

--- a/code/dqe/symcount.q
+++ b/code/dqe/symcount.q
@@ -1,4 +1,4 @@
 \d .dqe
 symcount:{[t;colname]
-  count {?[x; (); 1b; (enlist y)!(enlist y)]}[t;colname]
+  count {?[x; enlist(=;.Q.pf;last .Q.PV); 1b; (enlist y)!(enlist y)]}[t;colname]
   }

--- a/code/dqe/symcount.q
+++ b/code/dqe/symcount.q
@@ -1,0 +1,4 @@
+\d .dqe
+symcount:{[t;colname]
+  count {?[x; (); 1b; (enlist y)!(enlist y)]}[t;colname]
+  }

--- a/code/dqe/symcount.q
+++ b/code/dqe/symcount.q
@@ -1,4 +1,5 @@
 \d .dqe
 symcount:{[t;colname]
-  count {?[x; enlist(=;.Q.pf;last .Q.PV); 1b; (enlist y)!(enlist y)]}[t;colname]
+  /count {?[x; enlist(=;.Q.pf;last .Q.PV); 1b; (enlist y)!(enlist y)]}[t;colname]
+  (enlist t)!(enlist count {?[x; (); 1b; (enlist y)!(enlist y)]}[t;colname])
   }

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -8,7 +8,7 @@ getpartition:@[value;`getpartition;
     (`date^partitiontype)$(.z.D,.z.d)gmttime]}}];
 
 configcsv:@[value;`.dqe.configcsv;first .proc.getconfigfile["dqengineconfig.csv"]];
-resultstab:([procs:`$();tab:`$()]tablecount:`long$();nullcount:`long$();anomcount:`long$());
+resultstab:([procs:`$();tab:`$()]tablecount:`long$();nullcount:`long$();anomcount:`long$();symcount:`long$());
 
 init:{
   .lg.o[`init;"searching for servers"];

--- a/config/dqengineconfig.csv
+++ b/config/dqengineconfig.csv
@@ -1,2 +1,3 @@
 query,params,proc,querytype,starttime
 tablecount,.z.d-1,`hdb1,table,09:00:00.000000000
+symcount,(`quote;`sym),`hdb1,table,09:00:00.000000000


### PR DESCRIPTION
DQE side distinct symbols - a function on the Engine side that outputs the count of distinct symbols in a pre-specified column and a pre-specified table 
