### PR TITLE
Add .save.manipulate functionality to partbyattr mode

### DIFF
--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -162,7 +162,7 @@ savetablesbypart:{[dir;pt;forcesave;tablename]
 		/- get list of distinct combiniations for partition directories
 		extrapartitions:.merge.getextrapartitions[tablename;extrapartitiontype];
 		/- enumerate data to be upserted
-		enumdata:.Q.en[hdbsettings[`hdbdir];r:0!.save.manipulate[tablename;`. tablename]];
+		enumdata:.Q.en[hdbsettings[`hdbdir];0!.save.manipulate[tablename;`. tablename]];
 		.lg.o[`save;"enumerated ",(string tablename)," table"];		
 		/- upsert data to specific partition directory 
 		upserttopartition[dir;tablename;enumdata;pt;extrapartitiontype] each extrapartitions;				

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -162,7 +162,7 @@ savetablesbypart:{[dir;pt;forcesave;tablename]
 		/- get list of distinct combiniations for partition directories
 		extrapartitions:.merge.getextrapartitions[tablename;extrapartitiontype];
 		/- enumerate data to be upserted
-		enumdata:.Q.en[hdbsettings[`hdbdir];value tablename];
+		enumdata:.Q.en[hdbsettings[`hdbdir];r:0!.save.manipulate[tablename;`. tablename]];
 		.lg.o[`save;"enumerated ",(string tablename)," table"];		
 		/- upsert data to specific partition directory 
 		upserttopartition[dir;tablename;enumdata;pt;extrapartitiontype] each extrapartitions;				


### PR DESCRIPTION
## .save.manipulate addition to partbyattr mode
This addition allows the partbyattr mode to have the save-down manipulation functionality that already exists in standard mode.

Addresses issue #239 

## Checklist
- [x] Replace `value tabname` with `.save.manipulate` to manipulate table as defined by dictionary `savedownmanipulation`.
- [x] Test 