### PR TITLE
RDB timeout change to 0 before EOD write-down

### DIFF
--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -98,7 +98,7 @@ endofday:{[date]
 	/-save and wipe the tables
 	writedown[hdbdir;date];
 	/-reset timeout to original timeout
-    restoretimeout[];
+        restoretimeout[];
 	/-reapply the attributes
 	/-functional update is equivalent of {update col:`att#col from tab}each tables
 	(![;();0b;].)each a where 0<count each a[;1];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -112,8 +112,6 @@ endofday:{[date]
 	
 reload:{[date]
 	.lg.o[`reload;"reload command has been called remotely"];
-	/-set timeout to be 0 before tables are wiped
-	system"T 0";
 	/-get all attributes from all tables before they are wiped
 	/-get a list of pairs (tablename;columnname!attributes)
 	a:{(x;raze exec {(enlist x)!enlist((#);enlist y;x)}'[c;a] from meta x where not null a)}each tabs:subtables except ignorelist;
@@ -174,7 +172,7 @@ notpconnected:{[]
 
 /-resets timeout to 0 before EOD writedown
 timeoutreset:{.rdb.timeout:system"T";system"T 0"};
-restoretimeout:{system["T ", string timeout]};
+restoretimeout:{system["T ", string .rdb.timeout]};
 \d .
 
 /- make sure that the process will make a connection to each of the tickerplant and hdb types

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -205,6 +205,5 @@ reload:.rdb.reload
 
 /-change timeout to zero before eod flush
 .rdb.timeoutreset[]
-.timer.repeat[.eodtime.nextroll-1000000000*60;0W;1D00:00:00.000000000;
+.timer.repeat[.eodtime.nextroll-00:01;0W;1D;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];
-

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -18,7 +18,6 @@ ignorelist:@[value;`ignorelist;`heartbeat`logmsg];          //list of tables to 
 subscribesyms:@[value;`subscribesyms;`];                    //a list of syms to subscribe for, (`) means all syms
 tpconnsleepintv:@[value;`tpconnsleepintv;10];               //number of seconds between attempts to connect to the tp											
 
-timeout:@[value;`timeout;system"T"];						//get timeout for rdb
 onlyclearsaved:@[value;`onlyclearsaved;0b];                 //if true, eod writedown will only clear tables which have been successfully saved to disk
 savetables:@[value;`savetables;1b];                         //if true tables will be saved at end of day, if false tables wil not be saved, only wiped
 gc:@[value;`gc;1b];                                         //if true .Q.gc will be called after each writedown - tradeoff: latency vs memory usage
@@ -171,7 +170,7 @@ notpconnected:{[]
 	0 = count select from .sub.SUBSCRIPTIONS where proctype in .rdb.tickerplanttypes, active}
 
 /-resets timeout to 0 before EOD writedown
-timeoutreset:{if[not reloadenabled; system"T 0"]};
+timeoutreset:{if[not reloadenabled; .rdb.timeout:system"T";system"T 0"]};
 
 \d .
 
@@ -203,6 +202,5 @@ reload:.rdb.reload
 .rdb.setpartition[]
 
 /-change timeout to zero before eod flush
-.rdb.timeoutreset[]
 .timer.repeat[.eodtime.nextroll-00:01;0W;1D;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -3,7 +3,6 @@
 /-changes added 
 /-Can specify the hdb directory rather than relying on the tickerplant
 
-
 /-default parameters
 \d .rdb
 

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -173,7 +173,7 @@ notpconnected:{[]
 	0 = count select from .sub.SUBSCRIPTIONS where proctype in .rdb.tickerplanttypes, active}
 
 /-resets timeout to 0 before EOD writedown
-timeoutreset:{if[not reloadenabled; .rdb.timeout:system"T";system"T 0"]};
+timeoutreset:{.rdb.timeout:system"T";system"T 0"};
 restoretimeout:{system["T ", string timeout]};
 \d .
 

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -97,9 +97,8 @@ endofday:{[date]
 	a:{(x;raze exec {(enlist x)!enlist((#);enlist y;x)}'[c;a] from meta x where not null a)}each tables`.;
 	/-save and wipe the tables
 	writedown[hdbdir;date];
-	/-reset timeout to original timeout if reloadenabled is 0b
-	if[not reloadenabled;
-		system["T ", string timeout]];
+	/-reset timeout to original timeout
+    restoretimeout[];
 	/-reapply the attributes
 	/-functional update is equivalent of {update col:`att#col from tab}each tables
 	(![;();0b;].)each a where 0<count each a[;1];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -113,6 +113,8 @@ endofday:{[date]
 	
 reload:{[date]
 	.lg.o[`reload;"reload command has been called remotely"];
+	/-set timeout to be 0 before tables are wiped
+	system"T 0";
 	/-get all attributes from all tables before they are wiped
 	/-get a list of pairs (tablename;columnname!attributes)
 	a:{(x;raze exec {(enlist x)!enlist((#);enlist y;x)}'[c;a] from meta x where not null a)}each tabs:subtables except ignorelist;
@@ -126,6 +128,8 @@ reload:{[date]
 	if[gc;.gc.run[]];
 	/-reset eodtabcount back to zero for each table (in case this is called more than once)
 	eodtabcount[tabs]:0;
+	/-restore original timeout back to rdb
+	restoretimeout[];
 	.lg.o[`reload;"Finished reloading RDB"];
 	};
 	
@@ -171,7 +175,7 @@ notpconnected:{[]
 
 /-resets timeout to 0 before EOD writedown
 timeoutreset:{if[not reloadenabled; .rdb.timeout:system"T";system"T 0"]};
-
+restoretimeout:{system["T ", string timeout]};
 \d .
 
 /- make sure that the process will make a connection to each of the tickerplant and hdb types

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -98,7 +98,7 @@ endofday:{[date]
 	/-save and wipe the tables
 	writedown[hdbdir;date];
 	/-reset timeout to original timeout
-        restoretimeout[];
+	restoretimeout[];
 	/-reapply the attributes
 	/-functional update is equivalent of {update col:`att#col from tab}each tables
 	(![;();0b;].)each a where 0<count each a[;1];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -4,7 +4,6 @@
 /-Can specify the hdb directory rather than relying on the tickerplant
 
 
-
 /-default parameters
 \d .rdb
 
@@ -206,5 +205,6 @@ reload:.rdb.reload
 
 /-change timeout to zero before eod flush
 .rdb.timeoutreset[]
-.timer.repeat[.eodtime.nextroll-1000000000*60;0W;1D00:00:00.000000000;(`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];
+.timer.repeat[.eodtime.nextroll-1000000000*60;0W;1D00:00:00.000000000;
+  (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];
 

--- a/config/settings/rdb.q
+++ b/config/settings/rdb.q
@@ -26,8 +26,6 @@ parvaluesrc:`log		//where to source the rdb partition value, can be log (from tp
 				//anything else will return a null date which is will be filled by pardefault                                             
 pardefault:.z.D			//if the src defined in parvaluesrc returns null, use this default date instead
 tpcheckcycles:0W                //specify the number of times the process will check for an available tickerplant
-timeout:system"T"
-
 
 \d .proc
 loadprocesscode:1b              // whether to load the process specific code defined at ${KDBCODE}/{process type}

--- a/config/settings/rdb.q
+++ b/config/settings/rdb.q
@@ -26,6 +26,8 @@ parvaluesrc:`log		//where to source the rdb partition value, can be log (from tp
 				//anything else will return a null date which is will be filled by pardefault                                             
 pardefault:.z.D			//if the src defined in parvaluesrc returns null, use this default date instead
 tpcheckcycles:0W                //specify the number of times the process will check for an available tickerplant
+timeout:system"T"
+
 
 \d .proc
 loadprocesscode:1b              // whether to load the process specific code defined at ${KDBCODE}/{process type}


### PR DESCRIPTION
## RDB EOD Timeout adjustment
If `reloadenabled` is `0b`, the RDB will do the EOD writedown and will not use the WDB.  In this case, the timeout command line parameter will be set to 0 one minute before EOD write-down each day, so that if the writedown takes longer than the original -T parameter set in process.csv, it will not run into a 'stop error and write-down will complete successfully.

If `reloadenabled` is `1b`, then the RDB will offload the save-down to the WDB.  Wiping memory from RDB at EOD can take time so should set the timeout to be zero in this case too.  This can be done in the `reload` function in the RDB which is called by the WDB.

This PR addresses issue #238 

## Checklist
- [x] Add ` timeoutreset` function in RDB process which sets -T to be 0 if `reloadenabled` is false
- [x] Set a timer function for `timeoutreset` to be called one minute before EOD writedown
- [x] Add functionality to when RDB offloads the save-down to the WDB
- [x] Test case when `reloadenabled` is false
- [x] Test case when `reloadenabled` is true