### PR TITLE
Add web request functionality to datadog send functions

### DIFF
--- a/code/common/datadog.q
+++ b/code/common/datadog.q
@@ -4,10 +4,20 @@
 \d .dg
 
 //default to disabled - .lg.ext will not be overwritten
-enabled:@[value;`enabled;0b] 
+enabled:@[value;`enabled;0b]
+
+//default to disabled - datadog agent used
+webreq:@[value;`webreq;0b] 
 
 //define dogstatsd_port
 dogstatsd_port:@[value;`dogstatsd_port;getenv[`DOGSTATSD_PORT]]
+
+//define dogstatsd_apikey
+dogstatsd_apikey:@[value;`dogstatsd_apikey;getenv[`DOGSTATSD_APIKEY]]
+
+//define dogstatsd_url
+dogstatsd_url:@[value;`dogstatsd__url;getenv[`DOGSTATSD_URL]]
+
 
 //Functions are set to return 1b or 0b based on the health of the process
 //Default check (isok) returns 1b from each process to indicate process is up and can be queried.
@@ -16,7 +26,7 @@ handlers:(`$())!()
 
 isok:{$[.proc.proctype in key .dg.handlers;.dg.handlers .proc.proctype;1b]}
 
-//define sendmetric and sendevent functions
+//define sendmetric and sendevent functions using datadog agent
 .dg.sendevent:{[event_title;event_text;tags;alert_type] 
   $[.z.o like "l*";
     system"event_title=",event_title,"; event_text=","\"",event_text,"\"","; tags=","\"#",$[0h=type tags;","sv tags;tags],"\"",";alert_type=",alert_type,"; ","echo \"_e{${#event_title},${#event_text}}:$event_title|$event_text|#$tags|t:$alert_type\" |nc -4u -w0 127.0.0.1 ",dogstatsd_port;
@@ -29,6 +39,20 @@ isok:{$[.proc.proctype in key .dg.handlers;.dg.handlers .proc.proctype;1b]}
     .lg.w[`sendmetric;"Currently only linux operating systems are supported to send metrics"]]
   }
 
+//define sendmetric and sendevent functions using web request
+.dg.sendevent_webreq:{[event_title;event_text;tags;alert_type]
+  url:`$(dogstatsd_url,"events?api_key=",dogstatsd_apikey);
+  .Q.hp[url;.h.ty`json]
+  .j.j (`title;`text;`priority;`tags;`alert_type)!(event_title;event_text;"normal";$[0h=type tags;","sv tags;tags];alert_type)
+  }
+
+.dg.sendmetric_webreq:{[metric_name;metric_value]
+  url:`$(dogstatsd_url,"series?api_key=",dogstatsd_apikey);
+  unix_time:floor((`long$.z.p)-`long$1970.01.01D00:00)%1e9;
+  .Q.hp[url;.h.ty`json]
+  .j.j (enlist `series)!enlist(enlist (`metric`points`host`tags!(metric_name;enlist (unix_time;metric_value);.z.h;"shell")))
+  }
+
 //Option to override default .lg.ext functionality to send error and warning events to datadog
 enablelogging:{[]
   .lg.ext:{[olddef;loglevel;proctype;proc;id;message;dict]
@@ -39,3 +63,5 @@ enablelogging:{[]
 \d .
 
 if[.dg.enabled;.dg.enablelogging[]]
+
+if[.dg.webreq;(.dg.sendevent:.dg.sendevent_webreq;.dg.sendmetric:.dg.sendmetric_webreq)]

--- a/code/common/datadog.q
+++ b/code/common/datadog.q
@@ -16,7 +16,7 @@ dogstatsd_port:@[value;`dogstatsd_port;getenv[`DOGSTATSD_PORT]]
 dogstatsd_apikey:@[value;`dogstatsd_apikey;getenv[`DOGSTATSD_APIKEY]]
 
 //define dogstatsd_url
-dogstatsd_url:@[value;`dogstatsd__url;getenv[`DOGSTATSD_URL]]
+dogstatsd_url:@[value;`dogstatsd_url;getenv[`DOGSTATSD_URL]]
 
 
 //Functions are set to return 1b or 0b based on the health of the process
@@ -41,16 +41,16 @@ isok:{$[.proc.proctype in key .dg.handlers;.dg.handlers .proc.proctype;1b]}
 
 //define sendmetric and sendevent functions using web request
 .dg.sendevent_webreq:{[event_title;event_text;tags;alert_type]
-  url:`$(dogstatsd_url,"events?api_key=",dogstatsd_apikey);
+  url:`$dogstatsd_url,"events?api_key=",dogstatsd_apikey;
   .Q.hp[url;.h.ty`json]
-  .j.j (`title;`text;`priority;`tags;`alert_type)!(event_title;event_text;"normal";$[0h=type tags;","sv tags;tags];alert_type)
+    .j.j`title`text`priority`tags`alert_type!(event_title;event_text;"normal";$[0h=type tags;","sv tags;tags];alert_type)
   }
 
 .dg.sendmetric_webreq:{[metric_name;metric_value]
-  url:`$(dogstatsd_url,"series?api_key=",dogstatsd_apikey);
-  unix_time:floor((`long$.z.p)-`long$1970.01.01D00:00)%1e9;
+  url:`$dogstatsd_url,"series?api_key=",dogstatsd_apikey;
+  unix_time:floor((`long$.z.p)-1970.01.01D00:00)%1e9;
   .Q.hp[url;.h.ty`json]
-  .j.j (enlist `series)!enlist(enlist (`metric`points`host`tags!(metric_name;enlist (unix_time;metric_value);.z.h;"shell")))
+    .j.j (enlist `series)!enlist(enlist (`metric`points`host`tags!(metric_name;enlist (unix_time;metric_value);.z.h;"shell")))
   }
 
 //Option to override default .lg.ext functionality to send error and warning events to datadog
@@ -64,4 +64,4 @@ enablelogging:{[]
 
 if[.dg.enabled;.dg.enablelogging[]]
 
-if[.dg.webreq;(.dg.sendevent:.dg.sendevent_webreq;.dg.sendmetric:.dg.sendmetric_webreq)]
+if[.dg.webreq;.dg.sendevent:.dg.sendevent_webreq;.dg.sendmetric:.dg.sendmetric_webreq]

--- a/code/common/datadog.q
+++ b/code/common/datadog.q
@@ -16,7 +16,7 @@ dogstatsd_port:@[value;`dogstatsd_port;getenv[`DOGSTATSD_PORT]]
 dogstatsd_apikey:@[value;`dogstatsd_apikey;getenv[`DOGSTATSD_APIKEY]]
 
 //define dogstatsd_url
-dogstatsd_url:@[value;`dogstatsd_url;getenv[`DOGSTATSD_URL]]
+dogstatsd_url:":https://api.datadoghq.com/api/v1/"
 
 
 //Functions are set to return 1b or 0b based on the health of the process

--- a/config/settings/default.q
+++ b/config/settings/default.q
@@ -172,6 +172,7 @@ del:".";
 //Datadog configuration
 \d .dg
 enabled:0b;		//whether .lg.ext is overwritten to send errors to datadog. Default is 0b meaning errors will not be sent to datadog.
+webreq:0b;		//whether datadog agent or web request function is used. Default is 0b which means datadog agent is used.
 
 // k4unit tests
 \d .KU

--- a/setenv.sh
+++ b/setenv.sh
@@ -30,7 +30,6 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KDBLIB/l32
 
 export DOGSTATSD_PORT=8125                                                                          # set DOGSTATSD_PORT to the default value for datadog daemon
 export DOGSTATSD_APIKEY=4f8c4802645g2d21t38622e76w5f4905					    # set DGSTATSD_APIKEY to default value
-export DOGSTATSD_URL=":https://api.datadoghq.com/api/v1/"					    # set DOGSTATSD_EVENT_URL to the default value
 
 export TORQMONIT=${TORQHOME}/logs/monit                                                             # set the folder for monit outputs
 

--- a/setenv.sh
+++ b/setenv.sh
@@ -29,7 +29,7 @@ export TORQPROCESSES=${KDBAPPCONFIG}/process.csv                                
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KDBLIB/l32
 
 export DOGSTATSD_PORT=8125                                                                          # set DOGSTATSD_PORT to the default value for datadog daemon
-export DOGSTATSD_APIKEY=1b3b2816915f9c21b67073c48a1f5861					    # set DGSTATSD_APIKEY to default value
+export DOGSTATSD_APIKEY=4f8c4802645g2d21t38622e76w5f4905					    # set DGSTATSD_APIKEY to default value
 export DOGSTATSD_URL=":https://api.datadoghq.com/api/v1/"					    # set DOGSTATSD_EVENT_URL to the default value
 
 export TORQMONIT=${TORQHOME}/logs/monit                                                             # set the folder for monit outputs

--- a/setenv.sh
+++ b/setenv.sh
@@ -28,7 +28,9 @@ export TORQPROCESSES=${KDBAPPCONFIG}/process.csv                                
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KDBLIB/l32
 
-export DOGSTATSD_PORT=8125                                                                          # set DOGSTATSD_PORT to the default value for datadog daemon 
+export DOGSTATSD_PORT=8125                                                                          # set DOGSTATSD_PORT to the default value for datadog daemon
+export DOGSTATSD_APIKEY=1b3b2816915f9c21b67073c48a1f5861					    # set DGSTATSD_APIKEY to default value
+export DOGSTATSD_URL=":https://api.datadoghq.com/api/v1/"					    # set DOGSTATSD_EVENT_URL to the default value
 
 export TORQMONIT=${TORQHOME}/logs/monit                                                             # set the folder for monit outputs
 


### PR DESCRIPTION
Insert web request functions analogous to sendevent and sendmetric

Provide the user with option between using port (datadog agent) or web
request functions

Create the api key and datadog url environment variables

Closes #254 