### PR TITLE
Add symdir optional parameter to loadparams

### DIFF
--- a/code/common/dataloader.q
+++ b/code/common/dataloader.q
@@ -115,7 +115,7 @@ loadallfiles:{[loadparams;dir]
  loadparams:(`dataprocessfunc`chunksize`partitioncol`partitiontype`compression`gc!({[x;y] y};`int$100*2 xexp 20;`time;`date;();0b)),loadparams;
 
  // required types
- reqtypes:`headers`types`tablename`dbdir`chunksize`partitioncol`partitiontype`gc!`short$(11;10;-11;-11;-6;-11;-11;-1);
+ reqtypes:`headers`types`tablename`dbdir`symdir`chunksize`partitioncol`partitiontype`gc!`short$(11;10;-11;-11;-11;-6;-11;-11;-1);
  
  // check the types
  if[count w:where not (type each loadparams key reqtypes)=reqtypes;

--- a/code/common/dataloader.q
+++ b/code/common/dataloader.q
@@ -10,6 +10,7 @@
 // separator = separator field.  enlist it if the first row in the file is header data (same as standard q way) e.g. enlist","
 // tablename = name of table to load to, e.g. `trade
 // dbdir = database directory to write to e.g. `:hdb
+// symdir [optional] = directory to enumerate against; default is to enumerate against dbdir
 // dataprocessfunc [optional] = diadic function to use to further process data before saving. 
 // Parameters passed in are loadparams dict and data to be modified.  Default is {[x;y] y}
 // partitiontype [optional] = the partition type - one of `date`month`year`int.  Default is `date
@@ -55,7 +56,9 @@ loaddata:{[loadparams;rawdata]
 
  // enumerate the table - best to do this once
  .lg.o[`dataloader;"Enumerating"];
- data:.Q.en[loadparams[`dbdir];data]; 
+ data:$[`symdir in key loadparams;
+  .Q.en[loadparams[`symdir];data];
+  .Q.en[loadparams[`dbdir];data]]; 
 
  writedatapartition[loadparams[`dbdir];;loadparams[`partitiontype];loadparams[`partitioncol];loadparams[`tablename];data] each distinct loadparams[`partitiontype]$data[loadparams`partitioncol];
  

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -586,6 +586,7 @@ dictionary should/can have the following fields:
 |    separator    |  Y   | char\[list\] | Delimiting character. Enlist it if first line of file is header data |
 |    tablename    |  Y   |    symbol    |      Name of table to write data to      |
 |      dbdir      |  Y   |    symbol    |        Directory to write data to        |
+|     symdir      |  N   |    symbol    |      Directory to enumerate against      |
 |  partitiontype  |  N   |    symbol    | Partitioning to use. Must be one of \`date\`month\`year\`int. Default is \`date |
 |  partitioncol   |  N   |    symbol    | Column to use to extract partition information.Default is `time |
 | dataprocessfunc |  N   |   function   | Diadic function to process data after it has been read in. First argument is load parameters dictionary, second argument is data which has been read in. Default is {[x;y] y} |


### PR DESCRIPTION
## Add symdir optional parameter to loadparams

The `symdir` parameter will allow you to specify a single location for the data to be enumerated against.  At the moment data will always be enumerated to the `dbdir` parameter, and you may want to specify a single directory to enumerate against while loading in multiple files that belong to the same data set.

# Checklist:
- [x] Add logic for if `symdir` is included in `loadparams` to determine where to enumerate
- [x] Add `symdir` to the list `reqtypes` for type checking
- [x] Testing