### PR TITLE
Edited torq.sh to fix port truncation issue

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -132,25 +132,21 @@ stop() {
   host=$(getfield "$procno" "host")
   if [[ $host == "localhost" || $host == `hostname -i`  ||
         ${hostips[@]}  =~ $host || ${hostnames[@]} =~ $host ]]; then
-    if [[ -z $(findproc "$1") ]]; then                                                              # check process not running
-      echo "$(date '+%H:%M:%S') | $1 is not currently running"
-    else
-      echo "$(date '+%H:%M:%S') | Shutting down $1..."
-      procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")
-      port=$(($(eval echo \$"$(getfield "$procno" port)")))
-      eval "kill -15 `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
-    fi
+    kcmd="kill -15"
   else
-    if [[ -z $(findproc "$1") ]]; then
-    echo "$(date '+%H:%M:%S') | $1 is not currently running"
-    else
-      echo "$(date '+%H:%M:%S') | Shutting down $1..."
-      procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")
-      port=$(($(eval echo \$"$(getfield "$procno" port)")))
-      eval "$cmd `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
-    fi
+    kcmd="$cmd"
   fi
-  
+  if [[ -z $(findproc "$1") ]]; then
+    echo "$(date '+%H:%M:%S') | $1 is not currently running"
+  else
+    echo "$(date '+%H:%M:%S') | Shutting down $1..."
+    procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")
+    port=$(getfield "$procno" port)
+    if [[ ! $port =~ ^[0-9]+$ ]]; then
+      port=$(($(eval echo \$$port)))
+    fi
+    eval "$kcmd `lsof -i :$port -sTCP:LISTEN | awk '{if(NR>1)print $2}'`"
+  fi
  }
 
 getall() {

--- a/torq.sh
+++ b/torq.sh
@@ -142,6 +142,7 @@ stop() {
     echo "$(date '+%H:%M:%S') | Shutting down $1..."
     procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")
     port=$(getfield "$procno" port)
+    # check if port is numerical, if not it is an expression that needs evaluated
     if [[ ! $port =~ ^[0-9]+$ ]]; then
       port=$(($(eval echo \$$port)))
     fi


### PR DESCRIPTION
In regards to ./torq.sh stop all - kill command fails #257 
Upon looking into the issue these are the steps I took to try and fix the problem.

Original process.csv
![image](https://user-images.githubusercontent.com/61872480/80720994-9767bc00-8af5-11ea-92fa-26db70d53a7f.png)


Error replication
![err rep](https://user-images.githubusercontent.com/61872480/80721100-bcf4c580-8af5-11ea-9dd7-5efd91a7bd81.png)

The first thing I investigated was the default process.csv upon cloning TorQ and it was interesting that the ports were inputted via the {KDBBASEPORT} variable set in setenv.sh

Default process.csv
![image](https://user-images.githubusercontent.com/61872480/80720838-67b8b400-8af5-11ea-8aa4-b1a04cec0ea5.png)

After reformatting the custom process.csv and defining the host to be localhost and the desired base port to 9998 in setenv.sh and upon running ./torq.sh start all, ./torq.sh summary and ./torq.sh stop all it can be seen that they execute fine and with no truncation of the ports occuring.

Changing the custom process.csv
![image](https://user-images.githubusercontent.com/61872480/80721652-63d96180-8af6-11ea-9828-067fe0e9bad7.png)

Setting the KDBBASEPORT in setenv.sh
![image](https://user-images.githubusercontent.com/61872480/80721260-edd4fa80-8af5-11ea-96f7-019ebd2e86a6.png)
Running the ./torq.sh scripts
![var fix](https://user-images.githubusercontent.com/61872480/80721853-a1d68580-8af6-11ea-909c-b5c09c109e8a.png)

Next I tried to find what exactly was causing the truncation of the port if it was hard coded in e.g. 9998.. etc
It turns out the **port=$(($(eval echo \$"$(getfield "$procno" port)")))** at line 140 (was line 142 in older version) of the torq.sh script the eval echo section was truncating the port number.

![image](https://user-images.githubusercontent.com/61872480/80725772-7013ed80-8afb-11ea-9b30-4fae59bd678d.png)

So to get around this I just simplified the port variable from **port=$(($(eval echo \$"$(getfield "$procno" port)")))** to **port=$(getfield "$procno" port)** and this just outputs the full hard coded port unchanged.

However now the ./torq.sh start all and ./torq.sh stop all only works for hard coded ports and not for the default {KDBBASEPORT} method so for this to handle both formats I needed to alter the stop () function section of the torq.sh script.
After some tinkering I was able to successfully refactor the stop () function in the torq.sh script and it seems to be working perfectly now with no errors. The main part that helped fix the issue was the following:

![image](https://user-images.githubusercontent.com/61872480/80725871-8f127f80-8afb-11ea-863e-7a7e04040c2c.png)

This first set the port to the full unchanged port entered in the process.csv file, it then checked to see if the port entered was not made up of numbers i.e in the {KDBBASEPORT} format. 

If it was found to be in the {KDBBASEPORT} format then to eval echo the port and this is capable of handling the port in variable form ({KDBBASEPORT}) and continues on to shutdown/kill the processes associated with the {KDBBASEPORT} variable. 

If not then the port remained in it's full unchanged hard coded form and the script then continues on and successfully shutdowns/kills the processes on their respective ports. 

Can now work with both hard coded ports and {KDBBASEPORT}'s
![fix hc](https://user-images.githubusercontent.com/61872480/80726118-e6185480-8afb-11ea-9822-5ad1de580d37.png)

This closes #257 