### PR TITLE
Change k4unit.q so that it works across all versions of kdb

### DIFF
--- a/tests/k4unit.q
+++ b/tests/k4unit.q
@@ -85,13 +85,13 @@ KUrt:{ / (run tests) - run contents of KUT, save results to KUTR
 	neg before-count KUTR}
 
 KUpexec:{[prefix;lang;code;repeat;allowfail]
-	s:prefix,(string lang),")",$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"];
+	s:prefix,$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"];
 	if[1<.KU.VERBOSE;.lg.o[`k4unit;s]];$[.KU.DEBUG&allowfail;value s;@[value;s;`FA1L]]}
 
 KUfailed:{`FA1L~x}
 
 KUexec:{[lang;code;repeat]
-	value $[1=repeat;string code;"do[",(string repeat),";",(string code),"]"]}
+	value$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"]}
 
 KUact:{[action;lang;code;repeat;ms;bytes;file]
 	msx:0;bytesx:0j;ok:okms:okbytes:valid:0b;

--- a/tests/k4unit.q
+++ b/tests/k4unit.q
@@ -85,7 +85,7 @@ KUrt:{ / (run tests) - run contents of KUT, save results to KUTR
 	neg before-count KUTR}
 
 KUpexec:{[prefix;lang;code;repeat;allowfail]
-	s:prefix,(string lang),")",$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"];
+	s:(string lang),")",prefix,$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"];
 	if[1<.KU.VERBOSE;.lg.o[`k4unit;s]];$[.KU.DEBUG&allowfail;value s;@[value;s;`FA1L]]}
 
 KUfailed:{`FA1L~x}

--- a/tests/k4unit.q
+++ b/tests/k4unit.q
@@ -85,7 +85,7 @@ KUrt:{ / (run tests) - run contents of KUT, save results to KUTR
 	neg before-count KUTR}
 
 KUpexec:{[prefix;lang;code;repeat;allowfail]
-	s:prefix,$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"];
+	s:prefix,(string lang),")",$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"];
 	if[1<.KU.VERBOSE;.lg.o[`k4unit;s]];$[.KU.DEBUG&allowfail;value s;@[value;s;`FA1L]]}
 
 KUfailed:{`FA1L~x}

--- a/tests/k4unit.q
+++ b/tests/k4unit.q
@@ -91,7 +91,7 @@ KUpexec:{[prefix;lang;code;repeat;allowfail]
 KUfailed:{`FA1L~x}
 
 KUexec:{[lang;code;repeat]
-	value(string lang),")",$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"]}
+	value $[1=repeat;string code;"do[",(string repeat),";",(string code),"]"]}
 
 KUact:{[action;lang;code;repeat;ms;bytes;file]
 	msx:0;bytesx:0j;ok:okms:okbytes:valid:0b;

--- a/tests/k4unit.q
+++ b/tests/k4unit.q
@@ -91,7 +91,7 @@ KUpexec:{[prefix;lang;code;repeat;allowfail]
 KUfailed:{`FA1L~x}
 
 KUexec:{[lang;code;repeat]
-	value$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"]}
+	value(string lang),")",$[1=repeat;string code;"do[",(string repeat),";",(string code),"]"]}
 
 KUact:{[action;lang;code;repeat;ms;bytes;file]
 	msx:0;bytesx:0j;ok:okms:okbytes:valid:0b;


### PR DESCRIPTION
k4unit.q currently uses 
```
\ts *lang*)*code*
```
to run q and k code, but this no longer works in kdb 4.0. To fix this, we have changed it to 
```
*lang*)\ts *code*
```