### PR TITLE
Allow quote escaping in k4unit

### DIFF
--- a/tests/k4unit.q
+++ b/tests/k4unit.q
@@ -56,7 +56,7 @@ KUltr:{`KUTR upsert("SIJSSIJSIBBBBZ";enlist .KU.DELIM)0:.KU.SAVEFILE} / reload p
 
 KUltf:{ / (load test file) - load tests in csv file <x> into KUT
 	before:count KUT;
-	this:update file:x,action:lower action,lang:`q^lower lang,ms:0^ms,bytes:0j^bytes,repeat:1|repeat,minver:0^minver from `action`ms`bytes`lang`code`repeat`minver`comment xcol("SIJSSIF*";enlist .KU.DELIM)0:x:hsym x;
+	this:update file:x,action:lower action,lang:`q^lower lang,code:`$code,ms:0^ms,bytes:0j^bytes,repeat:1|repeat,minver:0^minver from `action`ms`bytes`lang`code`repeat`minver`comment xcol("SIJS*IF*";enlist .KU.DELIM)0:x:hsym x;
 	KUT,:select from this where minver<=.z.K;
 	/KUT,:update file:x,action:lower action,lang:`q^lower lang,ms:0^ms,bytes:0j,repeat:1|repeat from `action`ms`lang`code`repeat`comment xcol("SISSI*";enlist .KU.DELIM)0:x:hsym x;
 	neg before-count KUT}

--- a/tests/k4unit/tests.csv
+++ b/tests/k4unit/tests.csv
@@ -1,0 +1,2 @@
+action,ms,bytes,lang,code,repeat,minver,comment
+true,0,0,q,"(""a,b"")~"",""sv 1#'""ab""",,,test quote escaping


### PR DESCRIPTION
Currently, k4unit reads the `code` field from test CSVs as a symbol. When kdb reads CSV fields as symbol, it does not apply escaping for quotation marks e.g.

```
(base) jonny@kodiak ~ $ more test.csv 
col1
"""a,b,c"""
(base) jonny@kodiak ~ $ q
KDB+ 3.6 2018.12.24 Copyright (C) 1993-2018 Kx Systems
l64/ 4(16)core 7360MB jonny kodiak 127.0.1.1 EXPIRE 2020.06.04 jonathon.mcmurray@aquaq.co.uk KOD #4165225

q)(1#"S";1#",")0:`:test.csv
col1     
---------
""a,b,c""
q)(1#"*";1#",")0:`:test.csv
col1       
-----------
"\"a,b,c\""
q)
```

i.e. when reading as symbol, `""` is taken as two literal `"` instead of one (and putting only one breaks wrapping the whole field in `"`).

For this reason, this change instead reads as a string (which correctly interprets `""` as a single `"`) & then casts to a symbol. A unit test for this is also added.

It may be a "better" change to modify k4unit to use strings for this column throughout instead of symbols; one possible reason it uses symbols currently is so that code "looks right" when inspecting the tables manually (e.g. not having `\"` as in strings).