### PR TITLE
Make output from schemacheck more descriptive

### DIFF
--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -9,5 +9,5 @@ schemacheck:{[tab;colname;types;forkeys;attribute]
   f: {@[x;where 0=count each string x;{`$"_"}]};
   $[all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
-    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv("columnname";"types";"foreignkeys";"attribute")where not c) ,". Expected schema: ",(", "sv raze each string f each checkschema b),". Actual schema: ",", "sv raze each string f each origschema b:`c`t`f`a where not c)]
+    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv("columnname";"types";"foreignkeys";"attribute")where not c),". Expected schema: ",(", "sv raze each string f each checkschema b),". Actual schema: ",", "sv raze each string f each origschema b:`c`t`f`a where not c)]
   }

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -9,5 +9,5 @@ schemacheck:{[tab;colname;types;forkeys;attribute]
   f: {@[x;where 0=count each string x;{`$"_"}]};
   $[all c:checkschema~'origschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
-    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv string origschema[`c][where not c]),". Expected schema from the columns: ",(", "sv raze each string f each checkschema[where not c][`t`f`a]),". Actaul Schema: ",", "sv raze each string f each origschema[where not c][`t`f`a])]
+    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv string origschema[`c][where not c]),". Expected schema from the columns: ",(", "sv raze each string f each checkschema[where not c][`t`f`a]),". Actual Schema: ",", "sv raze each string f each origschema[where not c][`t`f`a])]
   }

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -7,7 +7,8 @@ schemacheck:{[tab;colname;types;forkeys;attribute]
   checkschema:([]c:colname;t:types;f:forkeys;a:attribute);
   / Function to replace empty symbols with underscores in error messages.
   f: {@[x;where 0=count each string x;{`$"_"}]};
-  $[all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
+  b:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
+  $[all c:checkschema~'origschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
-    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv("columnname";"types";"foreignkeys";"attribute")where not c),". Expected schema: ",(", "sv raze each string f each checkschema b),". Actual schema: ",", "sv raze each string f each origschema b:`c`t`f`a where not c)]
+    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv string origschema[`c][where not c]),". Expected schema from the columns: ",(", "sv raze each string f each checkschema[where not c][`t`f`a]),". Actaul Schema: ",", "sv raze each string f each origschema[where not c][`t`f`a])]
   }

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -2,12 +2,11 @@
 
 /- checks that the meta of a table matches expectation
 schemacheck:{[tab;colname;types;forkeys;attribute]
-  /.lg.o[`dqc;"checking schema of table mathces expectation"];
+  .lg.o[`dqc;"checking schema of table mathces expectation"];
   origschema:0!meta tab;
   checkschema:([]c:colname;t:types;f:forkeys;a:attribute);
   / Function to replace empty symbols with underscores in error messages.
-  /f: {@[x;where 0=count each string x;{`$"_"}]};
-  a:$[all c:checkschema~'origschema;
+  $[all c:checkschema~'origschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
     (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv string origschema[`c][where not c]),". Expected schema from the columns: ",(.Q.s1`type`fkey`attr!checkschema[where not c][`t`f`a]),". Actual Schema: ",.Q.s1`type`fkey`attr!origschema[where not c][`t`f`a])]
   }

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -2,12 +2,12 @@
 
 /- checks that the meta of a table matches expectation
 schemacheck:{[tab;colname;types;forkeys;attribute]
-  .lg.o[`dqc;"checking schema of table mathces expectation"];
+  /.lg.o[`dqc;"checking schema of table mathces expectation"];
   origschema:0!meta tab;
   checkschema:([]c:colname;t:types;f:forkeys;a:attribute);
   / Function to replace empty symbols with underscores in error messages.
-  f: {@[x;where 0=count each string x;{`$"_"}]};
-  $[all c:checkschema~'origschema;
+  /f: {@[x;where 0=count each string x;{`$"_"}]};
+  a:$[all c:checkschema~'origschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
-    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv string origschema[`c][where not c]),". Expected schema from the columns: ",(", "sv raze each string f each checkschema[where not c][`t`f`a]),". Actual Schema: ",", "sv raze each string f each origschema[where not c][`t`f`a])]
+    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv string origschema[`c][where not c]),". Expected schema from the columns: ",(.Q.s1`type`fkey`attr!checkschema[where not c][`t`f`a]),". Actual Schema: ",.Q.s1`type`fkey`attr!origschema[where not c][`t`f`a])]
   }

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -7,7 +7,6 @@ schemacheck:{[tab;colname;types;forkeys;attribute]
   checkschema:([]c:colname;t:types;f:forkeys;a:attribute);
   / Function to replace empty symbols with underscores in error messages.
   f: {@[x;where 0=count each string x;{`$"_"}]};
-  b:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
   $[all c:checkschema~'origschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
     (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv string origschema[`c][where not c]),". Expected schema from the columns: ",(", "sv raze each string f each checkschema[where not c][`t`f`a]),". Actaul Schema: ",", "sv raze each string f each origschema[where not c][`t`f`a])]

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -7,7 +7,7 @@ schemacheck:{[tab;colname;types;forkeys;attribute]
   checkschema:([]c:colname;t:types;f:forkeys;a:attribute);
   / Function to replace empty symbols with underscores in error messages.
   f: {@[x;where 0=count each string x;{`$"_"}]};
-  $[b:all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
+  $[all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
     (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv("columnname";"types";"foreignkeys";"attribute")where not c) ,". Expected schema: ",(", "sv raze each string f each checkschema b),". Actual schema: ",", "sv raze each string f each origschema b:`c`t`f`a where not c)]
   }

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -5,7 +5,10 @@ schemacheck:{[tab;colname;types;forkeys;attribute]
   .lg.o[`dqc;"checking schema of table mathces expectation"];
   origschema:0!meta tab;
   checkschema:([]c:colname;t:types;f:forkeys;a:attribute);
-  $[all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
+  all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
+  / Function to replace empty symbols with underscores in error messages.
+  f: {@[x;where 0=count each string x;{`$"_"}]};
+  a:$[b:all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
-    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(","sv("columnname";"types";"foreignkeys";"attribute")where not c) ,". Expected: ",((raze/)string checkschema b),". Actual Schema: ",(raze/)string origschema b:`c`t`f`a where not c)]
+    (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv("columnname";"types";"foreignkeys";"attribute")where not c) ,". Expected schema: ",(", "sv raze each string f each checkschema b),". Actual schema: ",", "sv raze each string f each origschema b:`c`t`f`a where not c)]
   }

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -5,7 +5,6 @@ schemacheck:{[tab;colname;types;forkeys;attribute]
   .lg.o[`dqc;"checking schema of table mathces expectation"];
   origschema:0!meta tab;
   checkschema:([]c:colname;t:types;f:forkeys;a:attribute);
-  / Function to replace empty symbols with underscores in error messages.
   $[all c:checkschema~'origschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
     (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv string origschema[`c][where not c]),". Expected schema from the columns: ",(.Q.s1`type`fkey`attr!checkschema[where not c][`t`f`a]),". Actual Schema: ",.Q.s1`type`fkey`attr!origschema[where not c][`t`f`a])]

--- a/code/dqc/schemacheck.q
+++ b/code/dqc/schemacheck.q
@@ -5,10 +5,9 @@ schemacheck:{[tab;colname;types;forkeys;attribute]
   .lg.o[`dqc;"checking schema of table mathces expectation"];
   origschema:0!meta tab;
   checkschema:([]c:colname;t:types;f:forkeys;a:attribute);
-  all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
   / Function to replace empty symbols with underscores in error messages.
   f: {@[x;where 0=count each string x;{`$"_"}]};
-  a:$[b:all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
+  $[b:all c:((flip origschema)each key flip origschema)~'(flip checkschema)each key flip checkschema;
     (1b;"Schema of ",(string tab)," matched proposed schema");
     (0b;"The following columns from the schema of table ",(string tab)," did not match expectation: ",(", "sv("columnname";"types";"foreignkeys";"attribute")where not c) ,". Expected schema: ",(", "sv raze each string f each checkschema b),". Actual schema: ",", "sv raze each string f each origschema b:`c`t`f`a where not c)]
   }


### PR DESCRIPTION
We have improved the output of schemacheck so that it shows the columns whose meta does not match expectation, as well as the actual and expected schema of those columns.