### PR TITLE
Adding Nullcount query to dqe

### DIFF
--- a/code/dqc/refdatacheck.q
+++ b/code/dqc/refdatacheck.q
@@ -8,3 +8,4 @@ refdatacheck:{[tablea;tableb;cola;colb]
     "The following data did not exist in",(string colb), " of ",(string tableb),": ",string tablea[cola]where not r];
     .lg.o[`refdatacheck;"refdatacheck completed; All data from ",(string cola),$[msg;"did";"did not"]," exist in ",string colb];
     (c;msg)
+  }

--- a/code/dqe/nullcount.q
+++ b/code/dqe/nullcount.q
@@ -1,7 +1,8 @@
 \d .dqe
 
 /- Given a table name as a symbol (tn), returns the number of nulls in tn.
+/- Works on partitioned tables in an hdb
 nullcount:{[tn]
   .lg.o[`nullcount;"Getting count of nulls in ",string tn];
-  (enlist tn)!enlist sum value{sum$[0h=type x;0=count each x;null x]}each flip get tn
+  (enlist tn)!enlist sum value{sum$[0h=type x;0=count each x;null x]}each flip (?[tn; enlist(=;.Q.pf;last .Q.PV);1b;()])
   }

--- a/code/dqe/nullcount.q
+++ b/code/dqe/nullcount.q
@@ -5,5 +5,5 @@
 /- col can be set to ` for the function to work on the whole table
 nullcount:{[tn;col]
   .lg.o[`nullcount;"Getting count of nulls in",$[col~`;" ";" column: ",(string col)," of "],string tn];
-  (enlist tn)!enlist sum value{sum$[0h=type x;0=count each x;null x]}each flip (?[tn; enlist(=;.Q.pf;last .Q.PV);1b;$[col~`;();{x!x}enlist col]])
+  (enlist tn)!enlist sum value{sum$[0h=type x;0=count each x;null x]}each flip?[tn;enlist(=;.Q.pf;last .Q.PV);1b;$[col~`;();{x!x}enlist col]]
   }

--- a/code/dqe/nullcount.q
+++ b/code/dqe/nullcount.q
@@ -1,0 +1,5 @@
+\d .dqe
+nullcount:{[tab]
+  .lg.o[`nullcount;"Getting count of nulls"];
+  (enlist tab)!enlist sum value ({sum$[0h=type x;0=count@'x;null x]}each flip tab)
+  }

--- a/code/dqe/nullcount.q
+++ b/code/dqe/nullcount.q
@@ -3,5 +3,5 @@
 /- Given a table name as a symbol (tn), returns the number of nulls in tn.
 nullcount:{[tn]
   .lg.o[`nullcount;"Getting count of nulls in ",string tn];
-  (enlist tn)!enlist sum value ({sum$[0h=type x;0=count@'x;null x]}each flip get tn)
+  (enlist tn)!enlist sum value ({sum$[0h=type x;0=count each x;null x]}each flip get tn)
   }

--- a/code/dqe/nullcount.q
+++ b/code/dqe/nullcount.q
@@ -1,5 +1,7 @@
 \d .dqe
-nullcount:{[tab]
-  .lg.o[`nullcount;"Getting count of nulls"];
-  (enlist tab)!enlist sum value ({sum$[0h=type x;0=count@'x;null x]}each flip tab)
+
+/- Given a table name as a symbol (tn), returns the number of nulls in tn.
+nullcount:{[tn]
+  .lg.o[`nullcount;"Getting count of nulls in ",string tn];
+  (enlist tn)!enlist sum value ({sum$[0h=type x;0=count@'x;null x]}each flip get tn)
   }

--- a/code/dqe/nullcount.q
+++ b/code/dqe/nullcount.q
@@ -3,5 +3,5 @@
 /- Given a table name as a symbol (tn), returns the number of nulls in tn.
 nullcount:{[tn]
   .lg.o[`nullcount;"Getting count of nulls in ",string tn];
-  (enlist tn)!enlist sum value ({sum$[0h=type x;0=count each x;null x]}each flip get tn)
+  (enlist tn)!enlist sum value{sum$[0h=type x;0=count each x;null x]}each flip get tn
   }

--- a/code/dqe/nullcount.q
+++ b/code/dqe/nullcount.q
@@ -1,8 +1,9 @@
 \d .dqe
 
-/- Given a table name as a symbol (tn), returns the number of nulls in tn.
+/- Given a table name as a symbol (tn) and a column name as a symbol (col), returns the number of nulls in col of tn.
 /- Works on partitioned tables in an hdb
-nullcount:{[tn]
-  .lg.o[`nullcount;"Getting count of nulls in ",string tn];
-  (enlist tn)!enlist sum value{sum$[0h=type x;0=count each x;null x]}each flip (?[tn; enlist(=;.Q.pf;last .Q.PV);1b;()])
+/- col can be set to ` for the function to work on the whole table
+nullcount:{[tn;col]
+  .lg.o[`nullcount;"Getting count of nulls in",$[col~`;" ";" column: ",(string col)," of "],string tn];
+  (enlist tn)!enlist sum value{sum$[0h=type x;0=count each x;null x]}each flip (?[tn; enlist(=;.Q.pf;last .Q.PV);1b;$[col~`;();{x!x}enlist col]])
   }


### PR DESCRIPTION
nullcount query keeps track of the number of nulls in a table in a partitioned HDB

To add to that, wondering if I should add a column variable to the function for it to work on a specific column just like infinitycount, or to leave i to count number of nulls in a table like nullchk in the dqc.