### PR TITLE
Account for anymap type in kdb 3.6+

### DIFF
--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -169,7 +169,10 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
             [.lg.o[`compression;"File ",cmp,"compressed ","successfully; matches orginal. Deleting original."];
                 system "r ", (last ":" vs string compressedFile)," ", last ":" vs string filetoCompress;
                 / move the hash files too.
-                if[78 <= type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#"];
+                $[3.6<=.z.K;
+                    if[77 = type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#";
+                        .[{system "r ", (last ":" vs string x),"## ", (last ":" vs string y),"##"};(compressedFile;filetoCompress);.lg.o[`compression;"File does not have enumeration domain"]]];
+                    if[78 <= type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#"]];
                 /-log to the table if the algo wasn't 0
                 statstab,:$[not 0=algo;(filetoCompress;algo;(-21!filetoCompress)`compressedLength;sizeuncomp);(filetoCompress;algo;comprL;sizeuncomp)]];
             [$[not count -21!compressedFile;

--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -180,7 +180,10 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
         .lg.o[`compression; "file ", (string filetoCompress), " is already ",cmp,"compressed",". Skipping this file"]]}
 
 hashfilecheck:{[compressedFile;filetoCompress;sf]
+    / if running 3.6 or higher, account for anymap type for nested lists
+    / check for double hash file if nested data contains symbol vector/atom
     $[3.6<=.z.K;
         if[77 = type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#";
             .[{system "r ", (last ":" vs string x),"## ", (last ":" vs string y),"##"};(compressedFile;filetoCompress);.lg.o[`compression;"File does not have enumeration domain"]]];
+        / if running below 3.6, nested list types will be 77h+t and will not have double hash file    
         if[78 <= type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#"]]}

--- a/code/common/compress.q
+++ b/code/common/compress.q
@@ -169,10 +169,7 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
             [.lg.o[`compression;"File ",cmp,"compressed ","successfully; matches orginal. Deleting original."];
                 system "r ", (last ":" vs string compressedFile)," ", last ":" vs string filetoCompress;
                 / move the hash files too.
-                $[3.6<=.z.K;
-                    if[77 = type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#";
-                        .[{system "r ", (last ":" vs string x),"## ", (last ":" vs string y),"##"};(compressedFile;filetoCompress);.lg.o[`compression;"File does not have enumeration domain"]]];
-                    if[78 <= type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#"]];
+                hashfilecheck[compressedFile;filetoCompress;sf];
                 /-log to the table if the algo wasn't 0
                 statstab,:$[not 0=algo;(filetoCompress;algo;(-21!filetoCompress)`compressedLength;sizeuncomp);(filetoCompress;algo;comprL;sizeuncomp)]];
             [$[not count -21!compressedFile;
@@ -181,3 +178,9 @@ compress:{[filetoCompress;algo;blocksize;level;sizeuncomp]
         ];
         / if already compressed/decompressed, then log that and skip.
         .lg.o[`compression; "file ", (string filetoCompress), " is already ",cmp,"compressed",". Skipping this file"]]}
+
+hashfilecheck:{[compressedFile;filetoCompress;sf]
+    $[3.6<=.z.K;
+        if[77 = type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#";
+            .[{system "r ", (last ":" vs string x),"## ", (last ":" vs string y),"##"};(compressedFile;filetoCompress);.lg.o[`compression;"File does not have enumeration domain"]]];
+        if[78 <= type sf; system "r ", (last ":" vs string compressedFile),"# ", (last ":" vs string filetoCompress),"#"]]}


### PR DESCRIPTION
## Anymap type coverage in compress.q

Adjust logic to cover if data contained mapped lists or nested lists.  If data has an enumeration domain, then you have to account for the file## in addition to file#.

Anymap type docs [here](https://code.kx.com/q/releases/ChangesIn3.6/#anymap) 

PR fixes issue #284 