### PR TITLE
New Table comparison Function in the DQC

### DIFF
--- a/code/dqc/tablecomp.q
+++ b/code/dqc/tablecomp.q
@@ -1,6 +1,5 @@
-/- only meant to be used for comparison - not sure if i should create a new function
-/- also might need to modify the comparison code
+/- only meant to be used for comparison
 \d .dqc
 tablecomp:{[tab]
-  (1b;("table count of ",(string tab)," is ",count tab);count tab)
+  (1b;("table count of ",(string tab)," is ",count tab);count get tab)
   }

--- a/code/dqc/tablecomp.q
+++ b/code/dqc/tablecomp.q
@@ -1,0 +1,6 @@
+/- only meant to be used for comparison - not sure if i should create a new function
+/- also might need to modify the comparison code
+tablecomp:{[tab]
+  .lg.o["checking whether two tables from two processes have the same count"];
+  (1b;("table count of ",(string tab)," is ",count tab);count tab)
+  }

--- a/code/dqc/tablecomp.q
+++ b/code/dqc/tablecomp.q
@@ -1,5 +1,6 @@
 /- only meant to be used for comparison - not sure if i should create a new function
 /- also might need to modify the comparison code
+\d .dqc
 tablecomp:{[tab]
   .lg.o["checking whether two tables from two processes have the same count"];
   (1b;("table count of ",(string tab)," is ",count tab);count tab)

--- a/code/dqc/tablecomp.q
+++ b/code/dqc/tablecomp.q
@@ -2,6 +2,5 @@
 /- also might need to modify the comparison code
 \d .dqc
 tablecomp:{[tab]
-  .lg.o["checking whether two tables from two processes have the same count"];
   (1b;("table count of ",(string tab)," is ",count tab);count tab)
   }


### PR DESCRIPTION
The function is only meant to be used for comparison of table counts utilizing the comparing processes functionality in DQC, that is why it only returns 1b so it doesnt flag any false errors. 
Example of appconfig will be included in TorQ-FSP.