### PR TITLE
Change attrcheck so that it works on atoms

### DIFF
--- a/code/dqc/attrcheck.q
+++ b/code/dqc/attrcheck.q
@@ -4,7 +4,7 @@
 attrcheck:{[tab;attribute;col]
   .lg.o[`dqe;"checking attributes on table ",string tab];
   dictmeta:exec c!a from meta tab where c in col;
-  dictcheck:col!attribute;
+  dictcheck:(f col)!(f:{$[0>type x;enlist x;x]})attribute;
   $[dictmeta~dictcheck;
     (1b;"attribute of ",(","sv string(),col)," matched expectation");
     (0b;"Expected attribute of column ",(","sv string(),col)," was ",(","sv string(),attribute),". Attribute of column ",(","sv string(),col)," is ",(","sv string(),value dictmeta))]


### PR DESCRIPTION
attrcheck bugs out when passed column names and attributes as atoms. We check for atoms now and enlist them.