### PR TITLE
Update chained tickperplant startup

### DIFF
--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -331,6 +331,7 @@ startup:{
 
 // Check if required processes all connected
 reqprocsnotconn:{[requiredprocs;typeorname]
+    // parse of exec typeorname from .servers.SERVERS where .dotz.liveh[w]
     not all requiredprocs in ?[`.servers.SERVERS;enlist (`.dotz.liveh;`w);();typeorname]
   };
 

--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -330,15 +330,21 @@ startup:{
     retry[]}
 
 // Check if required processes all connected
-reqprocsnotconn:{[requiredprocs] 
-    not all requiredprocs in exec proctype from .servers.SERVERS where .dotz.liveh[w]
+reqprocsnotconn:{[requiredprocs;typeorname]
+    not all requiredprocs in ?[`.servers.SERVERS;enlist (`.dotz.liveh;`w);();typeorname]
   };
 
+// Check if required process types all connected
+reqproctypesnotconn:reqprocsnotconn[;`proctype];
+
+// Check if required process names all connected
+reqprocnamesnotconn:reqprocsnotconn[;`procname];
+
 // Block process until all required processes are connected
-startupdepcycles:{[requiredprocs;timeintv;cycles]
+startupdepcyclestypename:{[requiredprocs;typeornamefunc;timeintv;cycles]
   n:1;                                                                                                                  //variable used to check how many cycles have passed
   .servers.startup[];
-  while[.servers.reqprocsnotconn requiredprocs;                                                                         //check if requiredprocs are running
+  while[typeornamefunc requiredprocs;                                                                                   //check if requiredprocs are running
     if[n>cycles;
       b:((),requiredprocs)except(),exec proctype from .servers.SERVERS where .dotz.liveh w;
       .lg.e[`connectionreport;string[.proc.procname]," cannot connect to ",","sv string'[b]];                           //after "cycles" times output error and exit process.
@@ -349,7 +355,13 @@ startupdepcycles:{[requiredprocs;timeintv;cycles]
    ];
  };
 
-startupdependent:startupdepcycles[;;0W];
+// Block process until all required process types are connected
+startupdepcycles:startupdepcyclestypename[;.servers.reqproctypesnotconn;;];
+
+// Block process until all required process names are connected
+startupdepnamecycles:startupdepcyclestypename[;.servers.reqprocnamesnotconn;;];
+
+startupdependent:startupdepcyclestypename[;.servers.reqproctypesnotconn;;0W];
 
 pc:{[result;W] update w:0Ni,endp:.proc.cp[] from`.servers.SERVERS where w=W;cleanup[];result}
 

--- a/code/processes/chainedtp.q
+++ b/code/processes/chainedtp.q
@@ -4,7 +4,6 @@
 
 /- user defined variables
 tickerplantname:@[value;`tickerplantname;`tickerplant1];        /- list of tickerplant names to try and make a connection to
-tickerplanttypes:@[value;`tickerplanttypes;`tickerplant];       /- list of tickerplant types to try and make a connection to
 pubinterval:@[value;`pubinterval;0D00:00:00];                   /- publish batch updates at this interval
 tpconnsleep:@[value;`tpconnsleep;10];                           /- number of seconds between attempts to connect to the source tickerplant   
 createlogfile:@[value;`createlogfile;0b];                       /- create a log file
@@ -187,7 +186,7 @@ if[not `upd in key `.; upd:.ctp.upd];
 .ps.initialise[];                                                                   
 
 /- check if tickerplant is available and if not exit with error 
-.servers.startupdepcycles[.ctp.tickerplanttypes;.ctp.tpconnsleep;.ctp.tpcheckcycles];
+.servers.startupdepnamecycles[.ctp.tickerplantname;.ctp.tpconnsleep;.ctp.tpcheckcycles];
 
 /- subscribe to tickerplant
 .ctp.subscribe[]; 

--- a/code/processes/chainedtp.q
+++ b/code/processes/chainedtp.q
@@ -192,8 +192,7 @@ if[not `upd in key `.; upd:.ctp.upd];
 .ctp.subscribe[]; 
 
 /- add subscribed table schemas to .ctp.tableschemas, used in cleartables
-if[not .ctp.notpconnected[];
-    .ctp.tableschemas:{x!(0#)@'value@'x} (),$[any null .ctp.subscribeto;tables[`.];.ctp.subscribeto]];
+.ctp.tableschemas:{x!(0#)@'value@'x} (),$[any null .ctp.subscribeto;tables[`.];.ctp.subscribeto];
 
 /- set timer for batch update publishing
 if[.ctp.pubinterval;

--- a/code/processes/chainedtp.q
+++ b/code/processes/chainedtp.q
@@ -187,13 +187,13 @@ if[not `upd in key `.; upd:.ctp.upd];
 .ps.initialise[];                                                                   
 
 /- check if tickerplant is available and if not exit with error 
-.servers.startupdepcycles[.ctp.tickerplanttypes;.ctp.tpconnsleepintv;.ctp.tpcheckcycles];
+.servers.startupdepcycles[.ctp.tickerplanttypes;.ctp.tpconnsleep;.ctp.tpcheckcycles];
 
 /- subscribe to tickerplant
 .ctp.subscribe[]; 
 
 /- add subscribed table schemas to .ctp.tableschemas, used in cleartables
-if[not notpconnected[];
+if[not .ctp.notpconnected[];
     .ctp.tableschemas:{x!(0#)@'value@'x} (),$[any null .ctp.subscribeto;tables[`.];.ctp.subscribeto]];
 
 /- set timer for batch update publishing

--- a/config/settings/chainedtp.q
+++ b/config/settings/chainedtp.q
@@ -1,7 +1,8 @@
 / Chained Tickerplant
 
 \d .ctp
-tickerplantname:`tickerplant1;	/- list of tickerplant types to try and make a connection to
+tickerplantname:`tickerplant1;	/- list of tickerplant names to try and make a connection to
+tickerplanttypes:`tickerplant;  /- list of tickerplant types to try and make a connection to
 pubinterval:0D00:00:00;       	/- publish batch updates at this interval, 0D00:00:00 for tick by tick
 tpconnsleep:10;			/- number of seconds between attempts to connect to the source tickerplant   
 createlogfile:0b;             	/- create a log file
@@ -11,6 +12,7 @@ subscribesyms:`;              	/- list of syms to subscription to
 replay:0b;                    	/- replay the tickerplant log file
 schema:1b;                    	/- retrieve schema from tickerplant
 clearlogonsubscription:0b;	/- clear logfile on subscription
+tpcheckcycles:0W;               /- specify the number of times the process will check for an available tickerplant
 
 \d .servers
 CONNECTIONS:`tickerplant 	/- list of connections to make at start up

--- a/config/settings/chainedtp.q
+++ b/config/settings/chainedtp.q
@@ -2,7 +2,6 @@
 
 \d .ctp
 tickerplantname:`tickerplant1;	/- list of tickerplant names to try and make a connection to
-tickerplanttypes:`tickerplant;  /- list of tickerplant types to try and make a connection to
 pubinterval:0D00:00:00;       	/- publish batch updates at this interval, 0D00:00:00 for tick by tick
 tpconnsleep:10;			/- number of seconds between attempts to connect to the source tickerplant   
 createlogfile:0b;             	/- create a log file


### PR DESCRIPTION
Modify how chained tickerplant connects to tickerplant on startup to behave in a way similar to the rdb.

Fixes bug where chained tickerplant hangs on startup when using start_torq_demo_mac.sh from [TorQ-Finance-Starter-Pack](https://github.com/AquaQAnalytics/TorQ-Finance-Starter-Pack)