### PR TITLE
added timecheck on each upd; made upd/ts functions more extendible

### DIFF
--- a/code/processes/segmentedtickerplant.q
+++ b/code/processes/segmentedtickerplant.q
@@ -7,6 +7,8 @@
 // Filtered - apply filters to published data, filters defined on client side
 
 .proc.loadf[getenv[`KDBCODE],"/common/os.q"];
+.proc.loadf[getenv[`KDBCODE],"/common/timezone.q"];
+.proc.loadf[getenv[`KDBCODE],"/common/eodtime.q"];
 
 // Load schema
 $[`schemafile in key .proc.params;
@@ -20,8 +22,8 @@ $[`schemafile in key .proc.params;
 
 // updtab stores functions to add/modify columns
 // Default functions timestamp updates
-// TO DO - add function to load type-sepcified updtab funcs
-@[`.stpps.updtab;.stpps.t;:;{(enlist(count first x)#.z.p+.eodtime.dailyadj),x}];
+// Preserve any prior definitions, but default all tables if not specified
+.stplg.updtab:(.stpps.t!(count .stpps.t)#{(enlist(count first x)#y),x}),.stplg.updtab
 
 // In none or tabular mode, intraday rolling not required
 if[.stplg.multilog in `none`tabular;.stplg.multilogperiod:1D];
@@ -33,21 +35,32 @@ if[.stplg.multilog~`custom;
  ];
 
 init:{[b]
-  .u.upd:{[b;t;x]
+  if[not all b in/:(key .stplg.upd;key .stplg.zts);'"mode ",(string b)," must be defined in both .stplg.upd and .stplg.zts"];
+  .stplg.updmsg:.stplg.upd[b];
+  .u.upd:{[t;x]
+    // snap the current time and check for period end
+    .stplg.checkends now:.z.p+.eodtime.dailyadj;
     // Type check allows update messages to contain multiple tables/data
     $[0h<type t;
-      [.stplg.upd[b]'[t;x];.stplg.totalmsgcount+:count t];
-      [.stplg.upd[b][t;x];.stplg.totalmsgcount+:1]
+      [.stplg.updmsg'[t;x;now];.stplg.totalmsgcount+:count t];
+      [.stplg.updmsg[t;x;now];.stplg.totalmsgcount+:1]
     ];
+    .stplg.seqnum+:1;
     @[`.stplg.msgcount;t;+;1];
-  }[b;;];
-  .z.ts:.stplg.zts[b];
+  };
+  // set .z.ts to execute the timer func and then check for end-of-period/end-of-day
+  .stplg.ts:.stplg.zts[b];
+  .z.ts:{
+   .stplg.ts now:.z.p+.eodtime.dailyadj; 
+   .stplg.checkends now};
   // Error mode - write failed updates to separate TP log
   if[.stplg.errmode;
     .stplg.openlogerr[.stplg.dldir];
     .stp.upd:.u.upd;
     .u.upd:{[t;x] .[.stp.upd;(t;x);{.stplg.badmsg[x;y;z]}[;t;x]]}
   ];
+  // default the timer if not set
+  if[not system"t"; system"t 1000"];
  };
 
 // Initialise process

--- a/code/processes/segmentedtickerplant.q
+++ b/code/processes/segmentedtickerplant.q
@@ -12,7 +12,7 @@
 
 // Load schema
 $[`schemafile in key .proc.params;
-  .proc.loadf[raze .proc.params[`schemafile],".q"];
+  .proc.loadf[schemafile:raze .proc.params[`schemafile]];
   [.lg.e[`stp;"schema file required"];exit 1]
  ]
 
@@ -42,11 +42,10 @@ init:{[b]
     .stplg.checkends now:.z.p+.eodtime.dailyadj;
     // Type check allows update messages to contain multiple tables/data
     $[0h<type t;
-      [.stplg.updmsg'[t;x;now];.stplg.totalmsgcount+:count t];
-      [.stplg.updmsg[t;x;now];.stplg.totalmsgcount+:1]
+      .stplg.updmsg'[t;x;now];
+      .stplg.updmsg[t;x;now]
     ];
     .stplg.seqnum+:1;
-    @[`.stplg.msgcount;t;+;1];
   };
   // set .z.ts to execute the timer func and then check for end-of-period/end-of-day
   .stplg.ts:.stplg.zts[b];
@@ -60,13 +59,16 @@ init:{[b]
     .u.upd:{[t;x] .[.stp.upd;(t;x);{.stplg.badmsg[x;y;z]}[;t;x]]}
   ];
   // default the timer if not set
-  if[not system"t"; system"t 1000"];
+  if[not system"t"; 
+   .lg.o[`timer;"defaulting timer to 1000ms"];
+    system"t 1000"];
  };
 
 // Initialise process
 
 // Create log directory, open all table logs
-.stplg.init[]
+// use name of schema to create directory
+.stplg.init[dbname:-2 _ last "/" vs schemafile]
 
 // Set update and publish modes
 init[.stplg.batchmode]

--- a/code/processes/segmentedtickerplant.q
+++ b/code/processes/segmentedtickerplant.q
@@ -50,8 +50,8 @@ init:{[b]
   // set .z.ts to execute the timer func and then check for end-of-period/end-of-day
   .stplg.ts:.stplg.zts[b];
   .z.ts:{
-   .stplg.ts now:.z.p+.eodtime.dailyadj; 
-   .stplg.checkends now};
+    .stplg.ts now:.z.p+.eodtime.dailyadj; 
+    .stplg.checkends now};
   // Error mode - write failed updates to separate TP log
   if[.stplg.errmode;
     .stplg.openlogerr[.stplg.dldir];

--- a/code/segmentedtickerplant/pubsub.q
+++ b/code/segmentedtickerplant/pubsub.q
@@ -22,7 +22,7 @@ endp:{
 // Function to send end of day messages to subscribers      
 // Assumes that .u.end has been defined on the client side   
 end:{
-  (neg raze union/[value subrequestall;exec handle from .stpps.subrequestfiltered])@\:(`.u.end;x;y);
+  (neg raze union/[value subrequestall;exec handle from .stpps.subrequestfiltered])@\:(`.u.end;x);
  };
 
 suball:{

--- a/code/segmentedtickerplant/pubsub.q
+++ b/code/segmentedtickerplant/pubsub.q
@@ -58,12 +58,6 @@ selfiltered:{[x;y]
   `.stpps.subrequestfiltered upsert (x;.z.w;filts;());
  };
 
-upd:{[t;x]
-  x:updtab[t]@x;
-  t insert x;
-  :x;
- };
-
 pub:{[t;x]
   if[count x;
     if[count h:subrequestall[t];-25!(h;(`upd;t;x))];
@@ -74,8 +68,11 @@ pub:{[t;x]
   ];
  };
 
-// Functions to add columns on updates
-updtab:enlist[`]!enlist {(enlist(count first x)#.z.p),x}
+// publish and clear tables
+pubclear:{
+ .stpps.pub'[x;value each x,:()];
+ @[`.;x;:;.stpps.schemas[x]];
+ }
 
 // Remove handle from subscription meta
 delhandle:{[t;h]
@@ -92,7 +89,7 @@ closesub:{[h]
   delhandlef[;h]each t;
  };
 
-.z.pc:{[f;x] f@x; closesub x}@[value;`.z.pc;{{}}]
+.z.pc:{[f;x] @[f;x;()]; closesub x}@[value;`.z.pc;{{}}]
 
 \d .
 

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -74,7 +74,7 @@ upd[`autobatch]:{[t;x;now]
 zts[`autobatch]:{
   {[t]
     if[count value t;
-      `..loghandles[t] enlist (`upd;t;flip value t);
+      `..loghandles[t] enlist (`upd;t;value flip value t);
       @[`.stplg.msgcount;t;+;1];
       @[`.stplg.rowcount;t;+;count value t];
       .stpps.pubclear[t]];
@@ -88,8 +88,6 @@ upd[`defaultbatch]:{[t;x;now]
   // track tmp counts, and add these after publish
   @[`.stplg.tmpmsgcount;t;+;1];
   @[`.stplg.tmprowcount;t;+;count first x];
-  // reset temp counts
-  .stplg.tmpmsgcount:.stplg.tmprowcount:()!();
  };
 
 zts[`defaultbatch]:{
@@ -98,11 +96,13 @@ zts[`defaultbatch]:{
   // after data has been published, updated the counts
   .stplg.msgcount+:.stplg.tmpmsgcount;
   .stplg.rowcount+:.stplg.tmprowcount;
+  // reset temp counts
+  .stplg.tmpmsgcount:.stplg.tmprowcount:()!();
  };
 
 // Immediate mode - publish and write immediately
 upd[`immediate]:{[t;x;now]
-  x:.stpps.updtab[t] . (x;now);
+  x:updtab[t] . (x;now);
   `..loghandles[t] enlist(`upd;t;x);
   @[`.stplg.msgcount;t;+;1];
   @[`.stplg.rowcount;t;+;count first x];

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -19,12 +19,12 @@ createdld:{[name;date]
 
 // Functions to generate log names in one of five modes ///////////////////////////////
 
-logname:enlist[`]!enlist ()
+logname:@[value;`.stplg.logname;enlist[`]!enlist ()];
 
 // Default stp mode is tabperiod
 // TP log rolled periodically (default 1 hr), 1 log per table
 logname[`tabperiod]:{[dir;tab;p]
-  ` sv(hsym dir;`$string[tab],raze[string"du"$p]except".:")
+  ` sv(hsym dir;`$string[tab],raze[string"dv"$p]except".:")
  };
 
 // Standard TP mode - write all tables to single log, roll daily
@@ -34,7 +34,7 @@ logname[`none]:{[dir;tab;p]
 
 // Periodic-only mode - write all tables to single log, roll periodically intraday
 logname[`periodic]:{[dir;tab;p]
-  ` sv(hsym dir;`$"periodic",raze[string"du"$p]except".:")
+  ` sv(hsym dir;`$"periodic",raze[string"dv"$p]except".:")
  };
 
 // Tabular-only mode - write tables to separate logs, roll daily
@@ -55,57 +55,63 @@ logname[`custom]:{[dir;tab;p]
 // preserve pre-existing definitions
 upd:@[value;`.stplg.upd;enlist[`]!enlist ()];
 zts:@[value;`.stplg.zts;enlist[`]!enlist ()];
-batch:enlist[`]!enlist ()
+
+// Number of update messages received for each table
+msgcount:rowcount:tmpmsgcount:tmprowcount:enlist[`]!enlist ()
+
+// Sequence number
+seqnum:0
 
 // Functions to add columns on updates
 updtab:@[value;`.stplg.updtab;enlist[`]!enlist {(enlist(count first x)#y),x}]
 
 // If set to autobatch, publish and write to disk will be run in batches
+// insert to table in memory, on a timer flush the table to disk and publish, update counts
 upd[`autobatch]:{[t;x;now]
-  x:.stplg.updtab[t] . (x;now);
-  @[`.stplg.batch;t;,;enlist x]
+  t insert updtab[t] . (x;now);
  };
 
 zts[`autobatch]:{
   {[t]
-    x:batch[t];
-    if[count x;
-      .stpps.pub[t]'[x];
-      `..loghandles[t] (`upd;t),/:enlist each x]
+    if[count value t;
+      `..loghandles[t] enlist (`upd;t;flip value t);
+      @[`.stplg.msgcount;t;+;1];
+      @[`.stplg.rowcount;t;+;count value t];
+      .stpps.pubclear[t]];
   }each .stpps.t;
-  batch::.stpps.t!();
  };
 
-// Standard batch mode - publish in batches, write to disk immediately
+// Standard batch mode - write to disk immediately, publish in batches
 upd[`defaultbatch]:{[t;x;now]
   t insert x:.stplg.updtab[t] . (x;now);
   `..loghandles[t] enlist(`upd;t;x);
+  // track tmp counts, and add these after publish
+  @[`.stplg.tmpmsgcount;t;+;1];
+  @[`.stplg.tmprowcount;t;+;count first x];
+  // reset temp counts
+  .stplg.tmpmsgcount:.stplg.tmprowcount:()!();
  };
 
 zts[`defaultbatch]:{
-  // publish and clear all tables
+  // publish and clear all tables, increment counts
   .stpps.pubclear[.stpps.t];
+  // after data has been published, updated the counts
+  .stplg.msgcount+:.stplg.tmpmsgcount;
+  .stplg.rowcount+:.stplg.tmprowcount;
  };
 
 // Immediate mode - publish and write immediately
 upd[`immediate]:{[t;x]
   x:.stpps.updtab[t] . (x;now);
   `..loghandles[t] enlist(`upd;t;x);
+  @[`.stplg.msgcount;t;+;1];
+  @[`.stplg.rowcount;t;+;count first x];
   .stpps.pub[t;x]
  };
 
 zts[`immediate]:{}
 
 //////////////////////////////////////////////////////////////////////////////////////
-
-// Number of update messages received for each table
-msgcount:enlist[`]!enlist ()
-
-// Total messages received
-totalmsgcount:0
-
-// Sequence number
-seqnum:0
 
 // Functions to obtain logs for client replay ////////////////////////////////////////
 // replaylog called from client-side, returns nested list of logcounts and lognames
@@ -142,23 +148,25 @@ openlog:{[multilog;dir;tab;p]
   `..currlog upsert (tab;lname;h);
  };
 
+errorlogname:@[value;`.stplg.errorlogname;`err]
+
 // Error log for failed updates in error mode
 openlogerr:{[dir]
-  lname:` sv(hsym dir;`$"errdatabase_",string[.eodtime.d]except".");
+  lname:` sv(hsym dir;`$string[errorlogname],string[.eodtime.d]except".");
   if[not type key lname;.[lname;();:;()]];
   h:hopen lname;
-  `..currlog upsert (`err;lname;h);
+  `..currlog upsert (errorlogname;lname;h);
  };
 
 // Log failed message and error type in error mode
 badmsg:{[e;t;x]
   .lg.o[`upd;"Bad message received, error: ",e];
-  `..loghandles[`err] enlist(`upderr;t;x);
+  `..loghandles[errorlogname] enlist(`upderr;t;x);
  };
 
 closelog:{[tab]
   if[null h:`..currlog[tab;`handle];.lg.o[`closelog;"No open handle to log file"];:()];
-  @[hclose;h;.lg.e[`closelog;"Handle already closed"]];
+  @[hclose;h;{.lg.e[`closelog;"Handle already closed"]}];
   update handle:0N from `..currlog where tbl=tab;
  };
 
@@ -169,23 +177,24 @@ rolllog:{[multilog;dir;tabs;p]
   @[`.stplg.msgcount;tabs;:;0];
   {[m;d;t]
     .[openlog;(m;d;t;.eodtime.currperiod);
-      {.lg.e[`stp;"failed to open log for table ",string[y]]}[;t]]
+      {.lg.e[`stp;"failed to open log for table ",string[y],": ",x]}[;t]]
   }[multilog;dir;]each tabs;
   .stpm.updmeta[multilog][`open;tabs;p];
  };
 
 // Send close of period message to subscribers, update logging period times, roll logs
 endofperiod:{[p]
-  .stpps.endp . .eodtime`p`nextperiod;
+  .stpps.endp . .eodtime`currperiod`nextperiod;
   .eodtime.currperiod:.eodtime.nextperiod;
   if[p>.eodtime.nextperiod:.eodtime.getperiod[multilogperiod;.eodtime.currperiod];
     system"t 0";'"next period is in the past"];
   getnextend[];
   i+::1;
   rolllog[multilog;dldir;rolltabs;p];
-  totalmsgcount::0;
  };
 
+// send end of day to subscribers, close out current logs, roll the day, 
+// create new and directory for the next day
 endofday:{[p]
   .stpps.end .eodtime.d;
   if[p>.eodtime.nextroll:.eodtime.getroll[p];system"t 0";'"next roll is in the past"];
@@ -194,7 +203,7 @@ endofday:{[p]
   .stpm.metatable:0#.stpm.metatable;
   closelog each logtabs;
   .eodtime.d+:1;
-  init[];
+  init[`. `dbname];
  };
 
 // get the next end time to compare to
@@ -202,24 +211,26 @@ getnextend:{nextend::min(.eodtime.nextroll;.eodtime.nextperiod)}
 
 checkends:{
   // jump out early if don't have to do either 
-  if[.stplg.nextend > x; :()];
+  if[nextend > x; :()];
   if[.eodtime.nextperiod < x; endofperiod[x]];
   if[.eodtime.nextroll < x;if[.eodtime.d<("d"$x)-1;system"t 0";'"more than one day?"];endofday[x]];
  };
 
-init:{
+init:{[dbname]
   t::tables[`.]except `currlog;
-  i::0;
   @[`.stplg.msgcount;t;:;0];
-  totalmsgcount::0;
-  batch::t!();
   logtabs::$[multilog~`custom;key custommode;t];
   rolltabs::$[multilog~`custom;logtabs except where custommode in `tabular`none;t];
   .eodtime.currperiod:multilogperiod xbar .z.p+.eodtime.dailyadj;
   .eodtime.nextperiod:.eodtime.getperiod[multilogperiod;.eodtime.currperiod];
   getnextend[]; 
-  createdld[`database;.eodtime.d];
+  createdld[dbname;.eodtime.d];
   openlog[multilog;dldir;;.z.p+.eodtime.dailyadj]each logtabs;
+  // read in the meta table from disk 
+  .stpm.metatable:@[get;hsym`$string[.stplg.dldir],"/stpmeta";0#.stpm.metatable];
+  // set log sequence number to the max of what we've found
+  i::1+ -1|exec max seq from .stpm.metatable;
+  // add the info to the meta table
   .stpm.updmeta[multilog][`open;logtabs;.z.p+.eodtime.dailyadj];
  };
 

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -101,7 +101,7 @@ zts[`defaultbatch]:{
  };
 
 // Immediate mode - publish and write immediately
-upd[`immediate]:{[t;x]
+upd[`immediate]:{[t;x;now]
   x:.stpps.updtab[t] . (x;now);
   `..loghandles[t] enlist(`upd;t;x);
   @[`.stplg.msgcount;t;+;1];

--- a/config/settings/segmentedtickerplant.q
+++ b/config/settings/segmentedtickerplant.q
@@ -1,6 +1,50 @@
 // Segmented TP config
 
+\d .stplg
+  
+multilog:`tabperiod;            // [tabperiod|none|periodic|tabular|custom]
+multilogperiod:0D01;
+errmode:1b;
+batchmode:`defaultbatch;        // [autobatch|defaultbatch|immediate]
+customcsv:hsym first .proc.getconfigfile["stpcustom.csv"];
+replayperiod:`day               // [period|day|prior]
+
+\d .proc
+
+loadprocesscode:1b        
+
+\d .eodtime
+
+datatimezone:`$"GMT"
+rolltimezone:`$"GMT"
+
+  
+\d .proc
+loadcommoncode:0b               // do not load common code
+loadprocesscode:1b              // load process code
+
+logroll:0b                      // do not roll logs
+
 // Configuration used by the usage functions - logging of client interaction
 \d .usage
-enabled:0b			// switch off the usage logging
- 
+enabled:0b                      // switch off the usage logging
+
+// Client tracking configuration
+// This is the only thing we want to do
+// and only for connections being opened and closed
+\d .clients
+enabled:1b                      // whether client tracking is enabled
+opencloseonly:1b                // only log open and closing of connections
+
+// Server connection details
+\d .servers
+enabled:0b                      // disable server tracking
+
+\d .timer
+enabled:0b                      // disable the timer
+
+\d .hb
+enabled:0b                      // disable heartbeating
+
+\d .zpsignore
+enabled:0b                      // disable zpsignore - zps should be empty 


### PR DESCRIPTION
- added end-of-day/end-of-period check on each upd
- make upd/zts/logname dictionaries more easily extendible
- change log file naming to be on seconds rather than minutes
- read in logmeta table on startup, and set log file counter to be max value from that table
- initialise directory name from schema name rather than hardcoded
- default the timer to 1000ms if not set
- remove totalmsgcount (not needed)
- synchronise updates of msgcount with flush to log file
- add rowcounts per table
- revert autobatch to be one log file message one update per batch
- make errorlog name configurable (avoid clashes with table names)
- fix for closelog to suppress incorrect log messages being printed
- fix for .u.end publish (one param rather than two)
- add baseline config
