### PR TITLE
Filter torq.sh summary based on hostname

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -118,12 +118,17 @@ debug() {
  }
 
 summary() {
-  if [[ -z $(findproc "$1") ]]; then                                                                # check process not running
-    printf "%s | %s | down |" "$(date '+%H:%M:%S')" "$1"                                            # summary table row for down process
-  else
-    pid=$((findproc "$1")|awk 'END{print}')
-    port=$(echo $(netstat -nlp 2>/dev/null | grep "$pid" | awk '{ print $4 }' | awk -F: '{ print $2 }'))  # get port process is running on
-    printf "%s | %s | up | %s | %s" "$(date '+%H:%M:%S')" "$1" "$pid" "$port"                       # summary table row for running process
+  procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")
+  host=$(getfield "$procno" "host")
+  if [[ $host == "localhost" || $host == `hostname -i`  ||                                          # check if process is configured to run on current host
+        ${hostips[@]}  =~ $host || ${hostnames[@]} =~ $host ]]; then
+    if [[ -z $(findproc "$1") ]]; then                                                              # check process not running
+        printf "%s | %s | down |" "$(date '+%H:%M:%S')" "$1"                                        # summary table row for down process
+    else
+        pid=$((findproc "$1")|awk 'END{print}')
+        port=$(echo $(netstat -nlp 2>/dev/null | grep "$pid" | awk '{ print $4 }' | awk -F: '{ print $2 }'))  # get port process is running on
+        printf "%s | %s | up | %s | %s" "$(date '+%H:%M:%S')" "$1" "$pid" "$port"                   # summary table row for running process
+    fi
   fi
  }
 


### PR DESCRIPTION
TorQ allows specifying different hostnames for different processes in `process.csv` & `torq.sh` will only start those configured for current host.

When running the summary, all processes are shown, which can be a bit unclear if only a small subset of processes are configured for current host (e.g. easy to miss one that should be up but is instead down)

This change modifies the summary function to skip any processes not configured for the current host.

e.g.

```
(base) jmcmurray@homer ~/deploy/TorQ $ head appconfig/process.csv -n 5
host,port,proctype,procname,U,localtime,g,T,w,load,startwithall,extras,qcmd
localhost,{KDBBASEPORT}+1,discovery,discoveryhasamuchlongername1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/discovery.q,1,,q
homer,{KDBBASEPORT},tickerplant,tickerplant1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/tickerplant.q,1,-schemafile ${TORQHOME}/database -tplogdir ${KDBTPLOG},q
homer,{KDBBASEPORT}+2,rdb,rdb1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,180,,${KDBCODE}/processes/rdb.q,1,,q
nothomer,{KDBBASEPORT}+3,hdb,hdb1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
(base) jmcmurray@homer ~/deploy/TorQ $ ./torq.sh summary | head -n 5
TIME      |  PROCESS                       |  STATUS  |  PID    |  PORT
15:20:02  |  discoveryhasamuchlongername1  |  down    |
15:20:02  |  tickerplant1                  |  up      |  6646   |
15:20:02  |  rdb1                          |  down    |
15:20:02  |  hdb2                          |  up      |  7026   |
(base) jmcmurray@homer ~/deploy/TorQ $
```

`hdb1` is configured with a different hostname, and not shown in summary.