### PR TITLE
Use qcmd from process.csv where defined

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -65,7 +65,11 @@ startline() {
     a=$(parameter "$procno" "$p");                                                                  # get param
     sline="$sline$a";                                                                               # append to startup line
   done
-  sline="$QCMD $sline $(getfield "$procno" extras) -procfile $CSVPATH $EXTRAS"                      # append csv file and extra arguments to startup line
+  qcmd=$(getfield "$procno" "qcmd")
+  if [ -z $qcmd ]; then                                                                             # if qcmd is undefined then default to $QCMD
+    qcmd="$QCMD"
+  fi
+  sline="$qcmd $sline $(getfield "$procno" extras) -procfile $CSVPATH $EXTRAS"                      # append csv file and extra arguments to startup line
   echo "$sline"
  }
 


### PR DESCRIPTION
In a recent change, a default `QCMD` was added to be read from an env variable if defined or default to `q`.

However, the change meant that if a `qcmd` was specified in `process.csv`, it was being ignored. This change restores that functionality, falling back to the `QCMD` if nothing in `process.csv`