### PR TITLE
Update tickerlogreplay.q to work with STP

### DIFF
--- a/code/processes/tickerlogreplay.q
+++ b/code/processes/tickerlogreplay.q
@@ -120,8 +120,8 @@ logstoreplay:$[not null tplogfile;
 // similar check for using regular tp
 $[segmentedmode;
   (if[not any 0<count@'key each logstoreplay;.err.ex[`replayinit;"failed to find any tickerplant logs to replay";1]]);
-  (if[0=count logstoreplay;.err.ex[`replayinit;"failed to find any tickerplant logs to replay";5]]);
-  .lg.o[`replayinit;"tp logs to replay are "," " sv string logstoreplay]]
+  (if[0=count logstoreplay;.err.ex[`replayinit;"failed to find any tickerplant logs to replay";5]])];
+  .lg.o[`replayinit;"tp logs to replay are "," " sv string logstoreplay]
 
 
 // the path to the table to save

--- a/code/processes/tickerlogreplay.q
+++ b/code/processes/tickerlogreplay.q
@@ -212,7 +212,7 @@ replaylog:{[logfile]
 	@[`.;`upd;:;.replay.realupd]];
  .replay.tablecounts:.replay.errorcounts:.replay.pathlist:()!();
  // extract date from timestamp if stp, extract date from date if tp
- $[segmentedmode;.replay.replaydate:"D"$-6_-12#string logfile;.replay.replaydate:"D"$-10#string logfile];
+ $[segmentedmode;.replay.replaydate:"D"$-6_-14#string logfile;.replay.replaydate:"D"$-10#string logfile];
  if[ .replay.clean and (`$st:string .replay.replaydate) in key hdbdir;
     .lg.o[`replay;"HDB directory already contains ",st," partition. Deleting from the HDB directory"];
     .os.deldir .os.pth[.Q.par[hdbdir;.replay.replaydate;`]]; // delete the current dates HDB directory before performing replay

--- a/code/processes/tickerlogreplay.q
+++ b/code/processes/tickerlogreplay.q
@@ -354,7 +354,7 @@ merge:{[dir;pt;tablename;mergelimits;h]
 
 if[.replay.autoreplay;
   // grab stp meta table before replaying logs if in segmentedmode
-  if[.replay.segmentedmode;.replay.stpm::get `:stpmeta];
+  // TO DO - define meta table here for replay flexibility
   .lg.o[`replay;"replay starting from script by default"];
   // expand stp log directories if using segmentedmode
   if[.replay.segmentedmode;.replay.logstoreplay:.replay.expandstplogs[.replay.logstoreplay]];

--- a/code/processes/tickerlogreplay.q
+++ b/code/processes/tickerlogreplay.q
@@ -220,7 +220,7 @@ replaylog:{[logfile]
  if[lastmessage<firstmessage; .lg.o[`replay;"lastmessage (",(string lastmessage),") is less than firstmessage (",(string firstmessage),"). Not replaying log file"]; :()];
  .lg.o[`replay;"replaying data from logfile ",(string logfile)," from message ",(string firstmessage)," to ",(string lastmessage),". Message indices are from 0 and inclusive - so both the first and last message will be replayed"];
  // when we do the replay, need to move the indexing, otherwise we wont replay the last message correctly
- $[all "stpmeta" in string logfile;stpm:get logfile;-11!($[lastmessage<0W; lastmessage+1;lastmessage];logfile)];
+ $[all "stpmeta" in string logfile;.lg.o[`replay;"skipping meta table: ",string[logfile]];-11!($[lastmessage<0W; lastmessage+1;lastmessage];logfile)];
  .lg.o[`replay;"replayed data into tables with the following counts: ","; " sv {" = " sv string x}@'flip(key .replay.tablecounts;value .replay.tablecounts)];
  if[count .replay.errorcounts;
   .lg.e[`replay;"errors were hit when replaying the following tables: ","; " sv {" = " sv string x}@'flip(key .replay.errorcounts;value .replay.errorcounts)]];
@@ -353,6 +353,8 @@ merge:{[dir;pt;tablename;mergelimits;h]
 
 
 if[.replay.autoreplay;
+  // grab stp meta table before replaying logs if in segmentedmode
+  if[.replay.segmentedmode;.replay.stpm::get `:stpmeta];
   .lg.o[`replay;"replay starting from script by default"];
   // expand stp log directories if using segmentedmode
   if[.replay.segmentedmode;.replay.logstoreplay:.replay.expandstplogs[.replay.logstoreplay]];

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -65,13 +65,13 @@ seqnum:0
 // Functions to add columns on updates
 updtab:@[value;`.stplg.updtab;enlist[`]!enlist {(enlist(count first x)#y),x}]
 
-// If set to autobatch, publish and write to disk will be run in batches
+// If set to memorybatch, publish and write to disk will be run in batches
 // insert to table in memory, on a timer flush the table to disk and publish, update counts
-upd[`autobatch]:{[t;x;now]
+upd[`memorybatch]:{[t;x;now]
   t insert updtab[t] . (x;now);
  };
 
-zts[`autobatch]:{
+zts[`memorybatch]:{
   {[t]
     if[count value t;
       `..loghandles[t] enlist (`upd;t;value flip value t);
@@ -141,8 +141,9 @@ getlogs[`day]:{[t]
 // Open log for a single table at start of logging period
 openlog:{[multilog;dir;tab;p]
   lname:logname[multilog][dir;tab;p];
-  h:$[(not type key lname)or null h0:exec first handle from `..currlog where logname=lname;
-    [.[lname;();:;()];hopen lname];
+  .lg.o[`openlog;"opening logfile: ",string lname];
+  h:$[(notexists:not type key lname)or null h0:exec first handle from `..currlog where logname=lname;
+    [.[if[notexists;lname;();:;()]];hopen lname];
     h0
   ];
   `..currlog upsert (tab;lname;h);
@@ -165,8 +166,9 @@ badmsg:{[e;t;x]
  };
 
 closelog:{[tab]
-  if[null h:`..currlog[tab;`handle];.lg.o[`closelog;"No open handle to log file"];:()];
-  @[hclose;h;{.lg.e[`closelog;"Handle already closed"]}];
+  if[null h:`..currlog[tab;`handle];.lg.o[`closelog;"no open handle to log file"];:()];
+  .lg.o[`closelog;"closing log file ",string `..currlog[tab;`logname]];
+  @[hclose;h;{.lg.e[`closelog;"handle already closed"]}];
   update handle:0N from `..currlog where tbl=tab;
  };
 
@@ -176,44 +178,49 @@ rolllog:{[multilog;dir;tabs;p]
   closelog each tabs;
   @[`.stplg.msgcount;tabs;:;0];
   {[m;d;t]
-    .[openlog;(m;d;t;.eodtime.currperiod);
+    .[openlog;(m;d;t;currperiod);
       {.lg.e[`stp;"failed to open log for table ",string[y],": ",x]}[;t]]
   }[multilog;dir;]each tabs;
   .stpm.updmeta[multilog][`open;tabs;p];
  };
 
-// Send close of period message to subscribers, update logging period times, roll logs
-endofperiod:{[p]
-  .stpps.endp . .eodtime`currperiod`nextperiod;
-  .eodtime.currperiod:.eodtime.nextperiod;
-  if[p>.eodtime.nextperiod:.eodtime.getperiod[multilogperiod;.eodtime.currperiod];
+// Send close of period message to subscribers, update logging period times
+// roll logs if flag is specified - we don't want to roll logs if end-of-day is also going to be triggered
+endofperiod:{[p;rolllogs]
+  .lg.o[`endofperiod;"executing end of period for ",.Q.s1 `currentperiod`nextperiod!.stplg`currperiod`nextperiod];
+  .stpps.endp . .stplg`currperiod`nextperiod;
+  currperiod::nextperiod;
+  if[p>nextperiod::multilogperiod+currperiod;
     system"t 0";'"next period is in the past"];
-  getnextend[];
+  getnextendUTC[];
   i+::1;
-  rolllog[multilog;dldir;rolltabs;p];
+  if[rolllogs;rolllog[multilog;dldir;rolltabs;p]];
+  .lg.o[`endofperiod;"end of period complete, new values for current and next period are ",.Q.s1 .stplg`currperiod`nextperiod];
  };
 
 // send end of day to subscribers, close out current logs, roll the day, 
 // create new and directory for the next day
 endofday:{[p]
+  .lg.o[`endofday;"executing end of day for ",.Q.s1 .eodtime.d];
   .stpps.end .eodtime.d;
   if[p>.eodtime.nextroll:.eodtime.getroll[p];system"t 0";'"next roll is in the past"];
-  getnextend[];
-  .stpm.updmeta[multilog][`close;logtabs;p];
+  getnextendUTC[];
+  .stpm.updmeta[multilog][`close;logtabs;p+.eodtime.dailyadj];
   .stpm.metatable:0#.stpm.metatable;
   closelog each logtabs;
   .eodtime.d+:1;
   init[`. `dbname];
+  .lg.o[`endofday;"end of day complete, new value for date is ",.Q.s1 .eodtime.d];
  };
 
 // get the next end time to compare to
-getnextend:{nextend::min(.eodtime.nextroll;.eodtime.nextperiod)}
+getnextendUTC:{nextendUTC::-1+min(.eodtime.nextroll;nextperiod - .eodtime.dailyadj)}
 
 checkends:{
   // jump out early if don't have to do either 
-  if[nextend > x; :()];
-  if[.eodtime.nextperiod < x; endofperiod[x]];
-  if[.eodtime.nextroll < x;if[.eodtime.d<("d"$x)-1;system"t 0";'"more than one day?"];endofday[x]];
+  if[nextendUTC > x; :()];
+  if[nextperiod < x1:x+.eodtime.dailyadj; endofperiod[x1;not isendofday:.eodtime.nextroll < x]];
+  if[isendofday;if[.eodtime.d<("d"$x)-1;system"t 0";'"more than one day?"];endofday[x]];
  };
 
 init:{[dbname]
@@ -221,9 +228,9 @@ init:{[dbname]
   @[`.stplg.msgcount;t;:;0];
   logtabs::$[multilog~`custom;key custommode;t];
   rolltabs::$[multilog~`custom;logtabs except where custommode in `tabular`none;t];
-  .eodtime.currperiod:multilogperiod xbar .z.p+.eodtime.dailyadj;
-  .eodtime.nextperiod:.eodtime.getperiod[multilogperiod;.eodtime.currperiod];
-  getnextend[]; 
+  currperiod::multilogperiod xbar .z.p+.eodtime.dailyadj;
+  nextperiod::multilogperiod+currperiod;
+  getnextendUTC[]; 
   createdld[dbname;.eodtime.d];
   openlog[multilog;dldir;;.z.p+.eodtime.dailyadj]each logtabs;
   // read in the meta table from disk 

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -153,7 +153,7 @@ errorlogname:@[value;`.stplg.errorlogname;`err]
 
 // Error log for failed updates in error mode
 openlogerr:{[dir]
-  lname:` sv(hsym dir;`$string[errorlogname],string[.eodtime.d]except".");
+  lname:hsym`$string[dir],"/",string[errorlogname],(raze string"dv"$(.z.p+.eodtime.dailyadj)) except".:";
   if[not type key lname;.[lname;();:;()]];
   h:hopen lname;
   `..currlog upsert (errorlogname;lname;h);

--- a/config/settings/tickerlogreplay.q
+++ b/config/settings/tickerlogreplay.q
@@ -16,11 +16,12 @@ emptytables:1b                          // whether to overwrite any tables at st
 sortafterreplay:1b                      // whether to re-sort the data at the end of the replay.  Sort order is determined by the result of sortandpart[`tablename]
 partafterreplay:1b                      // whether to apply the parted attribute after the replay.  Parted column is determined by result of first sortandpart[`tablename]
 basicmode:0b                            // do a basic replay, which replays everything in, then saves it down with .Q.hdpf[`::;d;p;`sym]
+segmentedmode:1b                        // use if logs are written using the segmented tickerplant
 exitwhencomplete:1b                     // exit when the replay is complete
 checklogfiles:0b                        // check if the log file is corrupt, if it is then write a new "good" file and replay it instead
 gc:1b                                   // garbage collect at appropriate points (after each table save and after the full log replay)
 autoreplay:1b                           // start replaying logs at the end of the script without any further user input
-clean:1b				// clean existing folders on start up. Needed if a replay screws up and we are replaying by chunk or multiple tp logs
+clean:1b				                // clean existing folders on start up. Needed if a replay screws up and we are replaying by chunk or multiple tp logs
 upd:{[t;x] insert[t;x]}                 // default upd function used for replaying data
 
 sortcsv:`:config/sort.csv               //location of  sort csv file


### PR DESCRIPTION
- add segmented mode flag for tickerlogreplay to know its using STP
- add logic to define `logstoreplay` depending on if STP is being used
- update `realupd` to know if segmentedmode is being used or not
- tabular and none logging modes for stp now use timestamp rather than just .z.d
- stpmeta log file loaded using get rather than -11!

To do still:
- replay logs based on `stpmeta` table

 