### PR TITLE
Add error trapping, setmeta function, adjust namespaces

### DIFF
--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -38,8 +38,8 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 			.lg.o[`subscribe;"autoreconnect was set to true but server functionality is disabled - unable to use autoreconnect"]]];
 	/-check the tables which are available on the server to subscribe to
 	/-if using segmented tickerplant, use .u.w equivalent
-	if[`default~tpmode;utabs:@[proc`w;(key;`.u.w);()]];
-	if[`segmented~tpmode;utabs:@[proc`w;(key;`.stpps.subrequestall);()]];
+	if[`default~.proc.tptype;utabs:@[proc`w;(key;`.u.w);()]];
+	if[`segmented~.proc.tptype;utabs:@[proc`w;`.stpps.t;()]];
 	subtabs:$[tabs~`;utabs;tabs];
 	/-make tabs a list if it isn't already
 	subtabs,:();
@@ -88,7 +88,7 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 			/-the second element of details is a pair (log count;logfile)
 			/-or list of pairs for stp ((count 1;log 1);(count 2;log 2);..)
 			d:$[0=type details[1;0];details 1;enlist details 1];
-			{[d]@[{-11!x;};d;{.lg.e[`subscribe;"could not replay the log file: ", x]}]}each d;
+			{[d]@[{.lg.o[`subscribe;"replaying log file ",.Q.s1 x]; -11!x;};d;{.lg.e[`subscribe;"could not replay the log file: ", x]}]}each d;
 			/-reset the upd function back to original upd
 			@[`.;`upd;:;origupd]];
 		if[replaylog&null raze[details 1]1;

--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -99,9 +99,9 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 	/-return the names of the tables that have been subscribed for and
 	/-the date from the name of the tickerplant log file (assuming the tp log has a name like `: sym2014.01.01
 	/-plus .u.i and .u.icounts if existing on TP - details[1;0] is .u.i, details[2] is .u.icounts (or null)
-	if[`default~tptype;
+	if[`default~.proc.tptype;
 		:(`subtables`tplogdate!(details[0;;0];(first "D" $ -10 sublist string last details 1)^logdate)),{(where 101 = type each x)_x}(`i`icounts`d)!(details[1;0];details[2];details[3])];
-	if[`segmented~tptype;
+	if[`segmented~.proc.tptype;
 		retdic:(`logdir`subtables)!(`$getenv[`KDBSTPLOG];details[0;;0]);
 		retdic,:{(where 101 = type each x)_x}(`i`icounts`d`tplogdate)!(details[1;];details[2];details[3];("D"$8#-12 sublist string d1 first where not null d1:details[1;;1])^logdate);
 		:retdic,`errtables`errmsg!(errtabs;string[errtabs],\:" table  not available to be subscribed to"),'(details[0;;0];details[0;;1])@\:where 10=type each details[0;;1]];

--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -62,7 +62,7 @@ subscribe:{[tabs;instrs;setschema;replaylog;proc]
 	/-set the function to send to the server based on this
 	.lg.o[`subscribe;"getting details from the server"];
 	df:{(.u.sub\:[x;y];(.u`i`L);(.u `icounts);(.u `d))};
-	if[`segmentedtickerplant=proc`proctype;
+	if[`segmented~.proc.tptype;
 		df:{(.u.sub\:[x;y];.stplg.replaylog[x];x#.stplg `msgcount;(.eodtime `d))}];
 	details:@[proc`w;(df;subtabs;instrs);{.lg.e[`subscribe;"subscribe failed : ",x];()}];
 	/-to be returned at end of function (null if there is no log)

--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -9,137 +9,169 @@ tptype:@[value;`tptype;`segmented];    // [segmented|default] tp type to determi
 AUTORECONNECT:@[value;`AUTORECONNECT;1b];									//resubscribe to processes when they come back up
 checksubscriptionperiod:(not @[value;`.proc.lowpowermode;0b]) * @[value;`checksubscriptionperiod;0D00:00:10]  	//how frequently you recheck connections.  0D = never
 
-/-table of subscriptions
+// table of subscriptions
 SUBSCRIPTIONS:([]procname:`symbol$();proctype:`symbol$();w:`int$();table:();instruments:();createdtime:`timestamp$();active:`boolean$());
 
 getsubscriptionhandles:{[proctype;procname;attributes]
-	/-grab data from .serves.SERVERS, add handling for passing in () as an argument
-	data:{select procname,proctype,w from x}each .servers.getservers[;;attributes;1b;0b]'[`proctype`procname;(proctype;procname)];
-	$[0h in type each (proctype;procname);distinct raze data;inter/[data]]
-	}
+ // grab data from .serves.SERVERS, add handling for passing in () as an argument
+ data:{select procname,proctype,w from x}each .servers.getservers[;;attributes;1b;0b]'[`proctype`procname;(proctype;procname)];
+ $[0h in type each (proctype;procname);distinct raze data;inter/[data]]
+ }
 
 updatesubscriptions:{[proc;tab;instrs]
-	/-delete any inactive subscriptions
-	delete from `.sub.SUBSCRIPTIONS where not active;
-	if[instrs~`;instrs,:()];
-	.sub.SUBSCRIPTIONS::0!(4!SUBSCRIPTIONS)upsert enlist proc,`table`instruments`createdtime`active!(tab;instrs;.proc.cp[];1b);
-	}
+ // delete any inactive subscriptions
+ delete from `.sub.SUBSCRIPTIONS where not active;
+ if[instrs~`;instrs,:()];
+ .sub.SUBSCRIPTIONS::0!(4!SUBSCRIPTIONS)upsert enlist proc,`table`instruments`createdtime`active!(tab;instrs;.proc.cp[];1b);
+ }
 
 reconnectinit:0b;		//has the reconnect custom function been initialised
+
+reducesubs:{[tabs;utabs;instrs;proc]
+ // for a given list of subscription tables, remove any which have already been subscribed to
+
+ // if asking for all tables, subscribe to the full list available from the publisher
+ subtabs:$[tabs~`;utabs;tabs],();
+ .lg.o[`subscribe;"attempting to subscribe to ",(","sv string subtabs)," on handle ",string proc`w];
+ 
+ // if the process has already been subscribed to
+ if[not instrs~`; instrs,:()];
+ s:select from SUBSCRIPTIONS where ([]procname;proctype;w)~\:proc, table in subtabs,instruments~\:instrs, active;
+ if[count s;
+   .lg.o[`subscribe;"already subscribed to specified instruments from  ",(","sv string s`table)," on handle ",string proc`w];
+   subtabs:subtabs except s`table];
+ 
+ // if the requested tables aren't available, ignore them and log a message
+ if[count errtabs:subtabs except utabs;
+   .lg.o[`subscribe;"tables ",("," sv string errtabs)," are not available to be subscribed to, they will be ignored"];
+   subtabs:subtabs inter utabs;];
+ 
+ // return a dict of the reduced subscriptions
+ :`subtabs`errtabs`instrs!(subtabs;errtabs;instrs)
+ } 
+
+createtables:{
+ // x is a list of pairs (tablename; schema)
+ .lg.o[`subscribe;"setting the schema definition"];
+ // this is the same as (tablename set schema)each table subscribed to
+ (@[`.;;:;].)each x where not 0=count each x;
+ }
+
+replay:{[tabs;realsubs;schemalist;logfilelist]
+ // realsubs is a dict of `subtabs`errtabs`instrs
+ // schemalist is a list of (tablename;schema)
+ // logfilelist is a list of (log count; logfile) 
+ .lg.o[`subscribe;"replaying the log file(s)"];
+ // store the orig version of upd
+ origupd:@[value;`..upd;{{[x;y]}}];
+ // only use tables user has access to
+ subtabs:realsubs[`subtabs];
+ if[count where nullschema:0=count each schemalist;
+    tabs:(schemalist where not nullschema)[;0];
+    subtabs:tabs inter realsubs[`subtabs]];
+ // set the replayupd function to be upd globally
+ if[not (tabs;realsubs[`instrs])~(`;`);
+    .lg.o[`subscribe;"using the .sub.replayupd function as not replaying all tables or instruments"];
+    @[`.;`upd;:;.sub.replayupd[origupd;subtabs;realsubs[`instrs]]]];
+ {[d] @[{.lg.o[`subscribe;"replaying log file ",.Q.s1 x]; -11!x;};d;{.lg.e[`subscribe;"could not replay the log file: ", x]}]}each logfilelist;
+ // reset the upd function back to original upd
+ @[`.;`upd;:;origupd];
+ .lg.o[`subscribe;"finished log file replay"];
+ // return updated version of realsubs
+ realsubs[`subtabs]:subtabs;
+ realsubs
+ }
+
 subscribe:{[tabs;instrs;setschema;replaylog;proc]
-	/-if proc dictionary is empty then exit - no connection
-	if[0=count proc;.lg.o[`subscribe;"no connections made"]; :()];
+ // if proc dictionary is empty then exit - no connection
+ if[0=count proc;.lg.o[`subscribe;"no connections made"]; :()];
 
-	/-check required flags are set, and add a definintion to the reconnection logic
-	/-when the process is notified of a new connection, it will try and resubscribe
-	if[(not .sub.reconnectinit)&.sub.AUTORECONNECT;
-		$[.servers.enabled;
-			[.servers.connectcustom:{x@y;.sub.autoreconnect[y]}[.servers.connectcustom]; .sub.reconnectinit:1b];
-			.lg.o[`subscribe;"autoreconnect was set to true but server functionality is disabled - unable to use autoreconnect"]]];
-	/-check the tables which are available on the server to subscribe to
-	/-if using segmented tickerplant, use .u.w equivalent
-	if[`default~.proc.tptype;utabs:@[proc`w;(key;`.u.w);()]];
-	if[`segmented~.proc.tptype;utabs:@[proc`w;`.stpps.t;()]];
-	subtabs:$[tabs~`;utabs;tabs];
-	/-make tabs a list if it isn't already
-	subtabs,:();
-	.lg.o[`subscribe;"attempting to subscribe to ",(","sv string subtabs)," on handle ",string proc`w];
-	/-if the process has already been subscribed to
-	if[not instrs~`; instrs,:()];
-	s:select from SUBSCRIPTIONS where ([]procname;proctype;w)~\:proc, table in subtabs,instruments~\:instrs, active;
-	if[count s;
-		.lg.o[`subscribe;"already subscribed to specified instruments from  ",(","sv string s`table)," on handle ",string proc`w];
-		subtabs:subtabs except s`table];
+ // check required flags are set, and add a definintion to the reconnection logic
+ // when the process is notified of a new connection, it will try and resubscribe
+ if[(not .sub.reconnectinit)&.sub.AUTORECONNECT;
+  $[.servers.enabled;
+     [.servers.connectcustom:{x@y;.sub.autoreconnect[y]}[.servers.connectcustom]; .sub.reconnectinit:1b];
+     .lg.o[`subscribe;"autoreconnect was set to true but server functionality is disabled - unable to use autoreconnect"]];
+   ];
+ 
+ // work out from the remote connection what type of tickerplant we are subscribing to
+ // default to `standard
+ tptype:@[proc`w;({@[value;`tptype;`standard]};`);`];
+ if[null tptype; .lg.e[`subscribe;e:"could not determine tickerplant type"]; 'e];
+ 
+ // depending on the type of tickerplant being subscribed to, change the functions for requesting
+ // the tables and subscriptions
+ $[tptype=`standard;
+   [tablesfunc:{key `.u.w};
+    subfunc:{`schemalist`logfilelist`rowcounts`date!(.u.sub\:[x;y];enlist(.u`i`L);(.u `icounts);(.u `d))}];
+  tptype=`segmented;
+   [tablesfunc:`tablelist;
+    subfunc:`subdetails];
+  [.lg.e[`subscribe;e:"unrecognised tickerplant type: ",string tptype]; 'e]];
+ 
+ // pull out the full list of tables to subscribe to
+ utabs:@[proc`w;(tablesfunc;`);()];
+ // reduce down the subscription list
+ realsubs:reducesubs[tabs;utabs;instrs;proc];
+ // check if anything to subscribe to, and jump out
+ if[0=count realsubs`subtabs;
+  .lg.o[`subscribe;"all tables have already been subscribed to"];
+  :()];
 
-	/-if all the tables have been subscribed to on specified instruments
-	if[0=count subtabs; :()];
-	/-if the requested tables aren't available, ignore them and log a message
-	if[count errtabs:subtabs except utabs;
-		.lg.o[`subscribe;"tables ",("," sv string errtabs)," are not available to be subscribed to, they will be ignored"];
-		subtabs:subtabs inter utabs;];
-	/-subscribe and get the details for the tables
-	/-if replaylog is false,dont try to get the log file details - they may not exist
-	/-set the function to send to the server based on this
-	.lg.o[`subscribe;"getting details from the server"];
-	df:{(.u.sub\:[x;y];(.u`i`L);(.u `icounts);(.u `d))};
-	if[`segmented~.proc.tptype;
-		df:{(.u.sub\:[x;y];.stplg.replaylog[x];x#.stplg `msgcount;(.eodtime `d))}];
-	details:@[proc`w;(df;subtabs;instrs);{.lg.e[`subscribe;"subscribe failed : ",x];()}];
-	/-to be returned at end of function (null if there is no log)
-	logdate: 0Nd;
-	if[count details;
-		if[setschema;
-			.lg.o[`subscribe;"setting the schema definition"];
-			/-the first element of details is a list of pairs (tablename; schema)
-			/-this is the same as (tablename set schema)each table subscribed to
-			(@[`.;;:;].)each details[0] where not nulldetail:0=count each details 0;];
-		if[replaylog&not null raze[details 1]1;
-			.lg.o[`subscribe;"replaying the log file"];
-			/-store the orig version of upd
-			origupd:@[value;`..upd;{{[x;y]}}];
-			/-only use tables user has access to
-			if[count where nulldetail;
-				tabs:(details[0] where not nulldetail)[;0];
-				subtabs:tabs inter subtabs];
-			/-set the replayupd function to be upd globally
-			if[not (tabs;instrs)~(`;`);
-				.lg.o[`subscribe;"using the .sub.replayupd function as not replaying all tables or instruments"];
-				@[`.;`upd;:;.sub.replayupd[origupd;subtabs;instrs]]];
-			/-the second element of details is a pair (log count;logfile)
-			/-or list of pairs for stp ((count 1;log 1);(count 2;log 2);..)
-			d:$[0=type details[1;0];details 1;enlist details 1];
-			{[d]@[{.lg.o[`subscribe;"replaying log file ",.Q.s1 x]; -11!x;};d;{.lg.e[`subscribe;"could not replay the log file: ", x]}]}each d;
-			/-reset the upd function back to original upd
-			@[`.;`upd;:;origupd]];
-		if[replaylog&null raze[details 1]1;
-			.lg.e[`subscribe;"replaylog set to true but TP not using log file"]];
-		/-insert the details into the SUBSCRIPTIONS table
-		.lg.o[`subscribe;"subscription successful"];
-		updatesubscriptions[proc;;instrs]each subtabs];
-	/-return the names of the tables that have been subscribed for and
-	/-the date from the name of the tickerplant log file (assuming the tp log has a name like `: sym2014.01.01
-	/-plus .u.i and .u.icounts if existing on TP - details[1;0] is .u.i, details[2] is .u.icounts (or null)
-	if[`default~.proc.tptype;
-		:(`subtables`tplogdate!(details[0;;0];(first "D" $ -10 sublist string last details 1)^logdate)),{(where 101 = type each x)_x}(`i`icounts`d)!(details[1;0];details[2];details[3])];
-	if[`segmented~.proc.tptype;
-		retdic:(`logdir`subtables)!(`$getenv[`KDBSTPLOG];details[0;;0]);
-		retdic,:{(where 101 = type each x)_x}(`i`icounts`d`tplogdate)!(details[1;];details[2];details[3];("D"$8#-12 sublist string d1 first where not null d1:details[1;;1])^logdate);
-		:retdic,`errtables`errmsg!(errtabs;string[errtabs],\:" table  not available to be subscribed to"),'(details[0;;0];details[0;;1])@\:where 10=type each details[0;;1]];
-	}
+ // pull out subscription details from the TP
+ details:@[proc`w;(subfunc;realsubs[`subtabs];realsubs[`instrs]);{.lg.e[`subscribe;"subscribe failed : ",x];()}];
+ if[count details;
+  if[setschema;createtables[details[`schemalist]]];
+  if[replaylog;realsubs:replay[tabs;realsubs;details[`schemalist];details[`logfilelist]]];
+  .lg.o[`subscribe;"subscription successful"];
+  updatesubscriptions[proc;;realsubs[`instrs]]each realsubs[`subtabs]];
 
-/-wrapper function around upd which is used to only replay syms and tables from the log file that
-/-the subscriber has requested
+ // return the names of the tables that have been subscribed for and
+ // the date from the name of the tickerplant log file (assuming the tp log has a name like `: sym2014.01.01
+ // plus .u.i and .u.icounts if existing on TP - details[1;0] is .u.i, details[2] is .u.icounts (or null)
+ logdate:0Nd;
+ if[tptype=`standard;
+   :(`subtables`tplogdate!(details[`schemalist][;0];(first "D" $ -10 sublist string last first details[`logfilelist])^logdate)),{(where 101 = type each x)_x}(`i`icounts`d)!(details[`logfilelist][0;0];details[`rowcounts];details[`date])];
+ if[tptype~`segmented;
+   retdic:`logdir`subtables!(details[`logdir];details[`schemalist][;0]);
+   retdic,:{(where 101 = type each x)_x}(`i`icounts`d`tplogdate)!(details[`logfilelist];details[`rowcounts];details[`date];details[`date]);
+   :retdic]
+ }
+
+// wrapper function around upd which is used to only replay syms and tables from the log file that
+// the subscriber has requested
 replayupd:{[f;tabs;syms;t;x]
-	/-escape if the table is not one of the subscription tables
-	if[not (t in tabs) or tabs ~ `;:()];
-	/-if subscribing for all syms then call upd and then escape
-	if[(syms ~ `)or 99=type syms; f[t;x];:()];
-	/-filter down on syms
-	/-assuming the the log is storing messages (x) as arrays as opposed to tables
-	c:cols[`. t];
-	/-convert x into a table
-	x:select from $[type[x] in 98 99h; x; 0>type first x;enlist c!x;flip c!x] where sym in syms;
- 	/-call upd on the data
-	f[t;x]
-	}
+ // escape if the table is not one of the subscription tables
+ if[not (t in tabs) or tabs ~ `;:()];
+ // if subscribing for all syms then call upd and then escape
+ if[(syms ~ `)or 99=type syms; f[t;x];:()];
+ // filter down on syms
+ // assuming the the log is storing messages (x) as arrays as opposed to tables
+ c:cols[`. t];
+ // convert x into a table
+ x:select from $[type[x] in 98 99h; x; 0>type first x;enlist c!x;flip c!x] where sym in syms;
+ // call upd on the data
+ f[t;x]
+ }
 
 checksubscriptions:{update active:0b from `.sub.SUBSCRIPTIONS where not w in key .z.W;}
 
 retrysubscription:{[row]
-	subscribe[row`table;$[((),`) ~ insts:row`instruments;`;insts];0b;0b;3#row];
-	}
-//-if something becomes available again try to reconnect to any previously subscribed tables/instruments
+ subscribe[row`table;$[((),`) ~ insts:row`instruments;`;insts];0b;0b;3#row];
+ }
+
+// if something becomes available again try to reconnect to any previously subscribed tables/instruments
 autoreconnect:{[rows]
-	s:select from SUBSCRIPTIONS where ([]procname;proctype)in (select procname, proctype from rows), not active;
-	s:s lj 2!select procname,proctype,w from rows;
-	if[count s;.sub.retrysubscription each s];
-	}
+ s:select from SUBSCRIPTIONS where ([]procname;proctype)in (select procname, proctype from rows), not active;
+ s:s lj 2!select procname,proctype,w from rows;
+ if[count s;.sub.retrysubscription each s];
+ }
 
 pc:{[result;W] update active:0b from `.sub.SUBSCRIPTIONS where w=W;result}
-/-set .z.pc handler to update the subscriptions table
+// set .z.pc handler to update the subscriptions table
 .z.pc:{.sub.pc[x y;y]}@[value;`.z.pc;{[x]}];
 
-/- if timer is set, trigger reconnections
+// if timer is set, trigger reconnections
 $[.timer.enabled and checksubscriptionperiod > 0;
     .timer.rep[.proc.cp[];0Wp;checksubscriptionperiod;(`.sub.checksubscriptions`);0h;"check all subscriptions are still active";1b];
   checksubscriptionperiod > 0;

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -151,12 +151,12 @@ subscribe:{[]
 			@[loadsubfilters;();{.lg.e[`rdb;"failed to load subscription filters"]}];];
 		/-set the date that was returned by the subscription code i.e. the date for the tickerplant log file
 		/-and a list of the tables that the process is now subscribing for
-		subinfo: .sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];
+		subinfo:.sub.subscribe[subscribeto;subscribesyms;schema;replaylog;first s];
 		/-setting subtables and tplogdate globals
-		@[`.rdb;;:;]'[key subinfo;value subinfo];
+		@[`.rdb;;:;]'[`subtables`tplogdate;subinfo`subtables`tplogdate];
 		/-apply subscription filters to replayed data
 		if[subfiltered&replaylog;
-			applyfilters[;subscribesyms]each subscribeto except errtables];];}
+			applyfilters[;subscribesyms]each subtables];];}
 
 setpartition:{[]
 	part: $[parvaluesrc ~ `log; /-get date from the tickerplant log file

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -169,7 +169,7 @@ setpartition:{[]
 	.lg.o[`setpartition;"rdbpartition contains - ","," sv string rdbpartition];}
 	
 loadsubfilters:{[]
-	.sub.filterparams:1!("SSS";enlist",")0: .rdb.subcsv;
+	.sub.filterparams:@[{1!("SSS";enlist",")0: x};.rdb.subcsv;{.lg.e[`loadsubfilters;"Failed to load .rdb.subcsv with error: ",x]}];
 	.rdb.subscribeto:raze value flip key .sub.filterparams;
 	.rdb.subscribesyms:.sub.filterparams;}
 

--- a/code/processes/segmentedtickerplant.q
+++ b/code/processes/segmentedtickerplant.q
@@ -16,34 +16,30 @@ $[`schemafile in key .proc.params;
   [.lg.e[`stp;"schema file required"];exit 1]
  ]
 
-\d .stpps
 // Populate pub/sub tables list with schema tables
-t:tables[]except `currlog;
-schemas:.stpps.t!value each .stpps.t;
+.stpps.t:tables[]except `currlog;
+.stpps.schemas:.stpps.t!value each .stpps.t;
 
 // amend the main schemas to not have any attributes
-{@[x;cols x;`#]}each t;
+{@[x;cols x;`#]}each .stpps.t;
 
 // store attribute free empty versions of the tables
-schemasnoattributes:t!value each t
+.stpps.schemasnoattributes:.stpps.t!value each .stpps.t
 
 // updtab stores functions to add/modify columns
 // Default functions timestamp updates
 // Preserve any prior definitions, but default all tables if not specified
-
-\d .stplg
-updtab:(.stpps.t!(count .stpps.t)#{(enlist(count first x)#y),x}),updtab
+.stplg.updtab:(.stpps.t!(count .stpps.t)#{(enlist(count first x)#y),x}),.stplg.updtab
 
 // In none or tabular mode, intraday rolling not required
-if[multilog in `none`tabular;multilogperiod:1D];
+if[.stplg.multilog in `none`tabular;.stplg.multilogperiod:1D];
 
 // In custom mode, load logging type for each table
-if[multilog~`custom;
-  @[{custommode:1_(!) . ("SS";",")0: x};customcsv;
+if[.stplg.multilog~`custom;
+  @[{.stplg.custommode:1_(!) . ("SS";",")0: x};.stplg.customcsv;
     {.lg.e[`stp;"failed to load custom mode csv"]}]
  ];
- 
-\d .
+
 init:{[b]
   if[not all b in/:(key .stplg.upd;key .stplg.zts);'"mode ",(string b)," must be defined in both .stplg.upd and .stplg.zts"];
   .stplg.updmsg:.stplg.upd[b];

--- a/code/processes/segmentedtickerplant.q
+++ b/code/processes/segmentedtickerplant.q
@@ -6,6 +6,9 @@
 // All - publish all data for table
 // Filtered - apply filters to published data, filters defined on client side
 
+// subscribers use this to determine what type of process they are talking to
+tptype:`segmented
+
 .proc.loadf[getenv[`KDBCODE],"/common/os.q"];
 .proc.loadf[getenv[`KDBCODE],"/common/timezone.q"];
 .proc.loadf[getenv[`KDBCODE],"/common/eodtime.q"];
@@ -39,6 +42,12 @@ if[.stplg.multilog~`custom;
   @[{.stplg.custommode:1_(!) . ("SS";",")0: x};.stplg.customcsv;
     {.lg.e[`stp;"failed to load custom mode csv"]}]
  ];
+
+// functions used by subscribers
+tablelist:{.stpps.t}
+// subscribers who want to replay need this info 
+subdetails:{[tabs;instruments]
+ `schemalist`logfilelist`rowcounts`date`logdir!(.u.sub\:[tabs;instruments];.stplg.replaylog[tabs];tabs#.stplg `rowcount;(.eodtime `d);`$getenv`KDBSTPLOG)}
 
 init:{[b]
   if[not all b in/:(key .stplg.upd;key .stplg.zts);'"mode ",(string b)," must be defined in both .stplg.upd and .stplg.zts"];

--- a/code/processes/segmentedtickerplant.q
+++ b/code/processes/segmentedtickerplant.q
@@ -16,30 +16,34 @@ $[`schemafile in key .proc.params;
   [.lg.e[`stp;"schema file required"];exit 1]
  ]
 
+\d .stpps
 // Populate pub/sub tables list with schema tables
-.stpps.t:tables[]except `currlog;
-.stpps.schemas:.stpps.t!value each .stpps.t;
+t:tables[]except `currlog;
+schemas:.stpps.t!value each .stpps.t;
 
 // amend the main schemas to not have any attributes
-{@[x;cols x;`#]}each .stpps.t;
+{@[x;cols x;`#]}each t;
 
 // store attribute free empty versions of the tables
-.stpps.schemasnoattributes:.stpps.t!value each .stpps.t
+schemasnoattributes:t!value each t
 
 // updtab stores functions to add/modify columns
 // Default functions timestamp updates
 // Preserve any prior definitions, but default all tables if not specified
-.stplg.updtab:(.stpps.t!(count .stpps.t)#{(enlist(count first x)#y),x}),.stplg.updtab
+
+\d .stplg
+updtab:(.stpps.t!(count .stpps.t)#{(enlist(count first x)#y),x}),updtab
 
 // In none or tabular mode, intraday rolling not required
-if[.stplg.multilog in `none`tabular;.stplg.multilogperiod:1D];
+if[multilog in `none`tabular;multilogperiod:1D];
 
 // In custom mode, load logging type for each table
-if[.stplg.multilog~`custom;
-  @[{.stplg.custommode:1_(!) . ("SS";",")0: x};.stplg.customcsv;
+if[multilog~`custom;
+  @[{custommode:1_(!) . ("SS";",")0: x};customcsv;
     {.lg.e[`stp;"failed to load custom mode csv"]}]
  ];
-
+ 
+\d .
 init:{[b]
   if[not all b in/:(key .stplg.upd;key .stplg.zts);'"mode ",(string b)," must be defined in both .stplg.upd and .stplg.zts"];
   .stplg.updmsg:.stplg.upd[b];

--- a/code/segmentedtickerplant/pubsub.q
+++ b/code/segmentedtickerplant/pubsub.q
@@ -15,9 +15,9 @@ subrequestfiltered:([]tbl:`$();handle:`int$();filts:();columns:())
 
 // Function to send end of period messages to subscribers
 // Assumes that .u.endp has been defined on the client side
-endp:{
-  (neg distinct raze union/[value subrequestall;exec handle from subrequestfiltered])@\:(`.u.endp;x;y);
- };
+// endp:{
+//   (neg distinct raze union/[value subrequestall;exec handle from subrequestfiltered])@\:(`.u.endp;x;y);
+//  };
 
 // Function to send end of day messages to subscribers      
 // Assumes that .u.end has been defined on the client side   
@@ -28,7 +28,7 @@ endp:{
 // combine endp and end
 // keep original available until tested
 end:{
-  (neg raze union/[value subrequestall;exec handle from .stpps.subrequestfiltered])@\: $[1<count x;`.u.endp;`.u.end],x
+  (neg distinct raze union/[value subrequestall;exec handle from .stpps.subrequestfiltered])@\: $[1<count x;`.u.endp;`.u.end],x
  };
 
 suball:{

--- a/code/segmentedtickerplant/pubsub.q
+++ b/code/segmentedtickerplant/pubsub.q
@@ -16,13 +16,13 @@ subrequestfiltered:([]tbl:`$();handle:`int$();filts:();columns:())
 // Function to send end of period messages to subscribers
 // Assumes that .u.endp has been defined on the client side
 endp:{
-  (neg distinct raze union/[value subrequestall;exec handle from .stpps.subrequestfiltered])@\:(`.u.endp;x;y);
+  (neg distinct raze union/[value subrequestall;exec handle from subrequestfiltered])@\:(`.u.endp;x;y);
  };
 
 // Function to send end of day messages to subscribers      
 // Assumes that .u.end has been defined on the client side   
 end:{
-  (neg distinct raze union/[value subrequestall;exec handle from .stpps.subrequestfiltered])@\:(`.u.end;x);
+  (neg distinct raze union/[value subrequestall;exec handle from subrequestfiltered])@\:(`.u.end;x);
  };
 
 suball:{

--- a/code/segmentedtickerplant/pubsub.q
+++ b/code/segmentedtickerplant/pubsub.q
@@ -21,8 +21,14 @@ endp:{
 
 // Function to send end of day messages to subscribers      
 // Assumes that .u.end has been defined on the client side   
+// end:{
+//   (neg distinct raze union/[value subrequestall;exec handle from subrequestfiltered])@\:(`.u.end;x);
+//  };
+
+// combine endp and end
+// keep original available until tested
 end:{
-  (neg distinct raze union/[value subrequestall;exec handle from subrequestfiltered])@\:(`.u.end;x);
+  (neg raze union/[value subrequestall;exec handle from .stpps.subrequestfiltered])@\: $[1<count x;`.u.endp;`.u.end],x
  };
 
 suball:{

--- a/code/segmentedtickerplant/pubsub.q
+++ b/code/segmentedtickerplant/pubsub.q
@@ -68,7 +68,7 @@ pub:{[t;x]
   if[count x;
     if[count h:subrequestall[t];-25!(h;(`upd;t;x))];
     if[t in subrequestfiltered`tbl;
-      {[t;x]data:?[t;x`filts;0b;x`columns];-25!((),x`handle;(`upd;t;data))}
+      {[t;x]data:?[t;x`filts;0b;x`columns];neg[x`handle](`upd;t;data)}
       [t;]each select handle,filts,columns from subrequestfiltered where tbl=t
     ];
   ];

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -153,9 +153,9 @@ errorlogname:@[value;`.stplg.errorlogname;`err]
 
 // Error log for failed updates in error mode
 openlogerr:{[dir]
-  lname:hsym`$string[dir],"/",string[errorlogname],(raze string"dv"$(.z.p+.eodtime.dailyadj)) except".:";
+  lname:.[{hsym`$string[x],"/",string[y],(raze string"dv"$(.z.p+.eodtime.dailyadj)) except".:"};(dir;errorlogname);{.lg.e[`openlogerr;"failed to make error log: ",x]}];
   if[not type key lname;.[lname;();:;()]];
-  h:hopen lname;
+  h:@[{hopen x};lname;{.lg.e[`openlogerr;"failed to open handle to error log with error: ",x]}];
   `..currlog upsert (errorlogname;lname;h);
  };
 

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -57,7 +57,7 @@ upd:@[value;`.stplg.upd;enlist[`]!enlist ()];
 zts:@[value;`.stplg.zts;enlist[`]!enlist ()];
 
 // Number of update messages received for each table
-msgcount:rowcount:tmpmsgcount:tmprowcount:enlist[`]!enlist ()
+msgcount:rowcount:tmpmsgcount:tmprowcount:(`symbol$())!`long$()
 
 // Sequence number
 seqnum:0
@@ -128,9 +128,8 @@ getlogs[`period]:{[t]
 
 // If replayperiod set to `day, replay all of today's logs
 getlogs[`day]:{[t]
-  lnames:distinct uj/[{
-    select seq,tbls,logname,msgcount from .stpm.metatable where x in/: tbls
-    }each t];
+  // set the msgcount to 0Wj for all logs which have closed
+  lnames:select seq,tbls,logname,msgcount:0Wj from .stpm.metatable where any each tbls in\: t;
   // Meta table does not store counts for live logs, so these are populated here
   lnames:update msgcount:sum each .stplg.msgcount[tbls] from lnames where seq=.stplg.i;
   flip value exec `long$msgcount,logname from lnames
@@ -231,6 +230,7 @@ checkends:{
 init:{[dbname]
   t::tables[`.]except `currlog;
   @[`.stplg.msgcount;t;:;0];
+  @[`.stplg.rowcount;t;:;0];
   logtabs::$[multilog~`custom;key custommode;t];
   rolltabs::$[multilog~`custom;logtabs except where custommode in `tabular`none;t];
   currperiod::multilogperiod xbar .z.p+.eodtime.dailyadj;

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -143,7 +143,7 @@ openlog:{[multilog;dir;tab;p]
   lname:logname[multilog][dir;tab;p];
   .lg.o[`openlog;"opening logfile: ",string lname];
   h:$[(notexists:not type key lname)or null h0:exec first handle from `..currlog where logname=lname;
-    [.[if[notexists;lname;();:;()]];hopen lname];
+    [if[notexists;.[lname;();:;()]];hopen lname];
     h0
   ];
   `..currlog upsert (tab;lname;h);
@@ -187,7 +187,7 @@ rolllog:{[multilog;dir;tabs;p]
 // creates dictionary of process data to be used at endofday/endofperiod
 endofdaydata:{
   `proctype`procname`tables!(.proc.proctype;.proc.procname;exec table from .sub.SUBSCRIPTIONS where proctype=`segmentedtickerplant)
-}
+ }
 
 // Send close of period message to subscribers, update logging period times
 // roll logs if flag is specified - we don't want to roll logs if end-of-day is also going to be triggered

--- a/code/segmentedtickerplant/stpmeta.q
+++ b/code/segmentedtickerplant/stpmeta.q
@@ -11,12 +11,12 @@ updmeta:enlist[`]!enlist ()
 
 updmeta[`tabperiod]:{[x;t;p]
   getmeta[x;p;;]'[enlist each t;`..currlog[([]tbl:t)]`logname];
-  (hsym`$string[.stplg.dldir],"/stpmeta") set metatable;
+  setmeta[.stplg.dldir;metatable];
  };
 
 updmeta[`none]:{[x;t;p]
   getmeta[x;p;t;`..currlog[first t]`logname];
-  (hsym`$string[.stplg.dldir],"/stpmeta") set metatable;
+  setmeta[.stplg.dldir;metatable];
  };
 
 updmeta[`periodic]:updmeta[`none]
@@ -40,5 +40,10 @@ getmeta:{[x;p;t;ln]
   if[x~`close;
     ![`.stpm.metatable;enlist (=;`logname;`ln);0b;`end`msgcount!(p;(sum;(`.stplg.msgcount;`t)))]
   ]
+ };
+
+setmeta:{[dir;mt]
+  t:(hsym`$string[dir],"/stpmeta");
+  .[{x set y};(t;mt);{.lg.e[`setmeta;"Failed to set metatable with error: ",x]}];
  };
 

--- a/config/settings/segmentedtickerplant.q
+++ b/config/settings/segmentedtickerplant.q
@@ -12,6 +12,7 @@ replayperiod:`day               // [period|day|prior]
 \d .proc
 
 loadprocesscode:1b        
+tptype:`segmented
 
 \d .eodtime
 

--- a/config/settings/tickerplant.q
+++ b/config/settings/tickerplant.q
@@ -2,6 +2,7 @@
 
 \d .proc
 loadcommoncode:0b		// do not load common code
+tptype:`default
 
 logroll:0b			// do not roll logs
 // Configuration used by the usage functions - logging of client interaction

--- a/torq.q
+++ b/torq.q
@@ -470,7 +470,7 @@ loadf0:{[reload;x]
   if[not[reload]&x in loadedf;.lg.o[`fileload;"already loaded ",x];:()];
   .lg.o[`fileload;"loading ",x];
   // error trapped loading of file
-  @[system;"l ",x;{.lg.e[`fileload;"failed to load",x," : ",y]}[x]];
+  @[system;"l ",x;{.lg.e[`fileload;"failed to load ",x," : ",y]}[x]];
   // if we got this far, file is loaded
   loadedf,:enlist x;
   .lg.o[`fileload;"successfully loaded ",x]


### PR DESCRIPTION
PR addresses some older comments from main STP branch:

- more error trapping
- new stpmeta function to error trap when `set` is called
- change from root namespace to .stpps and .stplg in `code/processes/segmentedtickerplant.q` to match TorQ code structure

To do:
- [x] change filtered publish from -25! to just use handle
- [x] change end and endp to be one function; function called is determined by if count of the arg is > 1
- [x] define `utabs` in `subscriptions.q` based on `.stpps.subrequestall` instead of `.u.w`
- [x] add tptype flag to subscriptions.q for tp logic instead of using proc`procname