### PR TITLE
Changes and fixes to how DQS handles time variables

### DIFF
--- a/code/dqe/datecheck.q
+++ b/code/dqe/datecheck.q
@@ -1,0 +1,5 @@
+\d .dqe
+
+datecheck:{[tab]
+  (enlist tab)!enlist "j"$last .Q.PV
+  }

--- a/code/processes/dqc.q
+++ b/code/processes/dqc.q
@@ -15,6 +15,8 @@ detailcsv:@[value;`.dqe.detailcsv;first .proc.getconfigfile["dqedetail.csv"]];  
 testing:@[value;`.dqe.testing;0b];                                              // testing varible for unit tests, default to 0b
 compcounter:([id:`long$()]counter:`long$();procs:();results:());                // table that results return to when a comparison is being performed
 
+/ - function for loading in config csv with multiple processes in one line
+duplicateconfig:{[t] update proc:raze[t `proc] from ((select from t)where count each t[`proc])};
 
 / - end of default parameters
 
@@ -31,9 +33,8 @@ init:{
   .dqe.compcounter[0N]:(0N;();());
 
   configtable:([] action:`$(); params:(); proc:(); mode:`$(); starttime:`timespan$(); endtime:`timespan$(); period:`timespan$())
-
   /- Set up configtable from csv
-  `.dqe.configtable upsert .dqe.readdqeconfig[.dqe.configcsv;"S**SNNN"];
+  `.dqe.configtable upsert .dqe.duplicateconfig[update ";"vs/:proc from (.dqe.readdqeconfig[.dqe.configcsv;"S**SNNN"])];
   update checkid:til count .dqe.configtable from `.dqe.configtable;
   /- from timespan to timestamp
   update starttime:(`date$(.z.D,.z.d).dqe.utctime)+starttime from `.dqe.configtable;

--- a/code/processes/dqc.q
+++ b/code/processes/dqc.q
@@ -4,7 +4,7 @@
 configcsv:@[value;`.dqe.configcsv;first .proc.getconfigfile["dqcconfig.csv"]];  // loading up the config csv file
 dqcdbdir:@[value;`dqcdbdir;`:dqcdb];                                            // location of dqcdb database
 detailcsv:@[value;`.dqe.detailcsv;first .proc.getconfigfile["dqedetail.csv"]];  // csv file that contains information regarding dqc checks
-utctime:@[value;`utctime;1b];                                                   // define wehter the process is on UTC time or not
+utctime:@[value;`utctime;1b];                                                   // define whether the process is on UTC time or not
 partitiontype:@[value;`partitiontype;`date];                                    // set type of partition (defaults to `date)
 writedownperiod:@[value;`writedownperiod;0D01:00:00];                           // dqc periodically writes down to dqcdb, writedownperiod determines the period between writedowns
 .servers.CONNECTIONS:`tickerplant`rdb`hdb`dqe`dqedb                             // set to connect to tickerplant, rdb, hdb, dqe, and dqedb

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -69,7 +69,7 @@ loadtimer:{[d]
 /- adds today's date to the time from config csv, before loading the queries to the timer
 configtimer:{[]
   t:.dqe.readdqeconfig[.dqe.configcsv;"S**SN"];
-  t:update starttime:?[((.z.N,.z.n).dqe.utctime)>starttime;01:00+(.z.P,.z.p).dqe.utctime;(`date$(.z.D,.z.d).dqe.utctime)+starttime] from t;
+  t:update starttime:(`date$(.z.D,.z.d).dqe.utctime)+starttime from t;
   {.dqe.loadtimer[x]}each t
   }
 

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -77,6 +77,12 @@ configtimer:{[]
 
 writedownengine:{
   if[0=count .dqe.tosavedown`.dqe.resultstab;:()];
+  dbprocs:exec distinct procname from raze .servers.getservers[`proctype;;()!();0b;1b]each`hdb`dqedb`dqcdb;  // Get a list of all databases.
+  restemp1:select from .dqe.resultstab where procs in dbprocs;
+  restemp2:select from .dqe.resultstab where not procs in dbprocs;
+  .dqe.resultstab:restemp1;
+  .dqe.savedata[.dqe.dqedbdir;.dqe.getpartition[]-1;.dqe.tosavedown[`.dqe.resultstab];`.dqe;`resultstab];
+  .dqe.resultstab:restemp2;
   .dqe.savedata[.dqe.dqedbdir;.dqe.getpartition[];.dqe.tosavedown[`.dqe.resultstab];`.dqe;`resultstab];
   /- get handles for DBs that need to reload
   hdbs:distinct raze exec w from .servers.SERVERS where proctype=`dqedb;

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -27,7 +27,7 @@ init:{
   .dqe.configtimer[];
   st:.dqe.writedownperiodengine+ min .timer.timer[;`periodstart];
   et:.eodtime.nextroll-.dqe.writedownperiodengine;
-  if[((.z.Z,.z.z)gmttime)>st;st:1D+st;et:1D+et];
+  if[((.z.Z,.z.z)utctime)>st;st:1D+st;et:1D+et];
   .timer.repeat[st;et;.dqe.writedownperiodengine;(`.dqe.writedownengine;`);"Running periodic writedown"];
   .lg.o[`init;"initialization completed"];
   }

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -28,6 +28,8 @@ init:{
   st:.dqe.writedownperiodengine+ min .timer.timer[;`periodstart];
   et:.eodtime.nextroll-.dqe.writedownperiodengine;
   if[((.z.Z,.z.z)utctime)>st;st:1D+st;et:1D+et];
+  .lg.o[`init;"start time of periodic writedown is: ",string st];
+  .lg.o[`init;"end time of periodic writedown is: ",string et];
   .timer.repeat[st;et;.dqe.writedownperiodengine;(`.dqe.writedownengine;`);"Running periodic writedown"];
   .lg.o[`init;"initialization completed"];
   }
@@ -103,6 +105,7 @@ writedownengine:{
   .timer.removefunc'[exec funcparam from .timer.timer where `.dqe.writedownengine in' funcparam];
   /- clear EOD timer
   .timer.removefunc'[exec funcparam from .timer.timer where `.u.end in' funcparam];
+  .lg.o[`dqe;"removed functions from .timer.timer, .u.end continues"];
   .dqe.currentpartition:pt+1;
   /- Checking whether .eodtime.nextroll is correct as it affects periodic writedown
   if[(`timestamp$.dqe.currentpartition)>=.eodtime.nextroll;

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -27,7 +27,7 @@ init:{
   .dqe.configtimer[];
   st:.dqe.writedownperiodengine+ min .timer.timer[;`periodstart];
   et:.eodtime.nextroll-.dqe.writedownperiodengine;
-  if[((.z.Z,.z.z).dqe.utctime)>st;st:(.z.Z,.z.z).dqe.utctime)+.dqe.writedownperiodengine];
+  if[((.z.Z,.z.z).dqe.utctime)>st;st:((.z.Z,.z.z).dqe.utctime)+.dqe.writedownperiodengine];
   .lg.o[`init;"start time of periodic writedown is: ",string st];
   .lg.o[`init;"end time of periodic writedown is: ",string et];
   .timer.repeat[st;et;.dqe.writedownperiodengine;(`.dqe.writedownengine;`);"Running periodic writedown"];

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -2,7 +2,7 @@
 \d .dqe
 
 dqedbdir:@[value;`dqedbdir;`:dqedb];                                                // location of dqedb database
-utctime:@[value;`utcime;1b];                                                       // define whether the process is on UTC time or not
+utctime:@[value;`utctime;1b];                                                       // define whether the process is on UTC time or not
 partitiontype:@[value;`partitiontype;`date];                                        // set type of partition (defaults to `date)
 getpartition:@[value;`getpartition;                                                 // determines the partition value
   {{@[value;`.dqe.currentpartition;

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -19,7 +19,7 @@ init:{
   .lg.o[`init;"searching for servers"];
   /- Open connection to discovery
   .servers.startupdependent[`dqedb;10];
-  if[utctime=1b;.eodtime.nextroll:.eodtime.getroll[`timestamp$.dqe.currentpartition]+(.z.T-.z.t)];
+  if[.dqe.utctime=1b;.eodtime.nextroll:.eodtime.getroll[`timestamp$.dqe.currentpartition]+(.z.T-.z.t)];
   /- set timer to call EOD
   .timer.once[.eodtime.nextroll;(`.u.end;.dqe.getpartition[]);"Running EOD on Engine"];
   /- store i numbers of rows to be saved down to DB
@@ -27,7 +27,7 @@ init:{
   .dqe.configtimer[];
   st:.dqe.writedownperiodengine+ min .timer.timer[;`periodstart];
   et:.eodtime.nextroll-.dqe.writedownperiodengine;
-  if[((.z.Z,.z.z)utctime)>st;st:1D+st;et:1D+et];
+  if[((.z.Z,.z.z).dqe.utctime)>st;st:(.z.Z,.z.z).dqe.utctime)+.dqe.writedownperiodengine];
   .lg.o[`init;"start time of periodic writedown is: ",string st];
   .lg.o[`init;"end time of periodic writedown is: ",string et];
   .timer.repeat[st;et;.dqe.writedownperiodengine;(`.dqe.writedownengine;`);"Running periodic writedown"];
@@ -112,7 +112,7 @@ writedownengine:{
     .eodtime.nextroll:.eodtime.getroll[`timestamp$.dqe.currentpartition];
     .lg.o[`dqe;"Moving .eodtime.nextroll to match current partition"]
     ];
-  if[utctime=1b;.eodtime.nextroll:.eodtime.getroll[`timestamp$.dqe.currentpartition]+(.z.T-.z.t)];
+  if[.dqe.utctime=1b;.eodtime.nextroll:.eodtime.getroll[`timestamp$.dqe.currentpartition]+(.z.T-.z.t)];
   .lg.o[`dqe;".eodtime.nextroll set to ",string .eodtime.nextroll];
   .dqe.init[];
   .lg.o[`dqe;".u.end finished"];

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -80,10 +80,12 @@ writedownengine:{
   dbprocs:exec distinct procname from raze .servers.getservers[`proctype;;()!();0b;1b]each`hdb`dqedb`dqcdb;  // Get a list of all databases.
   restemp1:select from .dqe.resultstab where procs in dbprocs;
   restemp2:select from .dqe.resultstab where not procs in dbprocs;
+  restemp3:.dqe.resultstab;
   .dqe.resultstab:restemp1;
   .dqe.savedata[.dqe.dqedbdir;.dqe.getpartition[]-1;.dqe.tosavedown[`.dqe.resultstab];`.dqe;`resultstab];
   .dqe.resultstab:restemp2;
   .dqe.savedata[.dqe.dqedbdir;.dqe.getpartition[];.dqe.tosavedown[`.dqe.resultstab];`.dqe;`resultstab];
+  .dqe.resultstab:restemp3;
   /- get handles for DBs that need to reload
   hdbs:distinct raze exec w from .servers.SERVERS where proctype=`dqedb;
   /- send message for DBs to reload

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -94,6 +94,12 @@ writedownengine:{
 /- setting up .u.end for dqe
 .u.end:{[pt]
   .lg.o[`dqe;".u.end initiated"];
+  dbprocs:exec distinct procname from raze .servers.getservers[`proctype;;()!();0b;1b]each`hdb`dqedb`dqcdb;  // Get a list of all databases.
+  restemp1:select from .dqe.resultstab where procs in dbprocs;
+  restemp2:select from .dqe.resultstab where not procs in dbprocs;
+  .dqe.resultstab::restemp1;
+  .dqe.endofday[.dqe.dqedbdir;.dqe.getpartition[]-1;`resultstab;`.dqe;.dqe.tosavedown[`.dqe.resultstab]];
+  .dqe.resultstab::restemp2;
   .dqe.endofday[.dqe.dqedbdir;.dqe.getpartition[];`resultstab;`.dqe;.dqe.tosavedown[`.dqe.resultstab]];
   /- get handles for DBs that need to reload
   hdbs:distinct raze exec w from .servers.SERVERS where proctype=`dqedb;

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -69,7 +69,7 @@ loadtimer:{[d]
 /- adds today's date to the time from config csv, before loading the queries to the timer
 configtimer:{[]
   t:.dqe.readdqeconfig[.dqe.configcsv;"S**SN"];
-  t:update starttime:$[((.z.N,.z.n).dqe.utctime>starttime);01:00+(.z.P,.z.p).dqe.utctime;(`date$(.z.D,.z.d).dqe.utctime)+starttime] from t;
+  t:update starttime:?[((.z.N,.z.n).dqe.utctime)>starttime;01:00+(.z.P,.z.p).dqe.utctime;(`date$(.z.D,.z.d).dqe.utctime)+starttime] from t;
   {.dqe.loadtimer[x]}each t
   }
 

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -27,6 +27,7 @@ init:{
   .dqe.configtimer[];
   st:.dqe.writedownperiodengine+ min .timer.timer[;`periodstart];
   et:.eodtime.nextroll-.dqe.writedownperiodengine;
+  if[((.z.Z,.z.z)gmttime)>st;st:1D+st;et:1D+et];
   .timer.repeat[st;et;.dqe.writedownperiodengine;(`.dqe.writedownengine;`);"Running periodic writedown"];
   .lg.o[`init;"initialization completed"];
   }

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -69,7 +69,7 @@ loadtimer:{[d]
 /- adds today's date to the time from config csv, before loading the queries to the timer
 configtimer:{[]
   t:.dqe.readdqeconfig[.dqe.configcsv;"S**SN"];
-  t:update starttime:(`date$(.z.D,.z.d).dqe.utctime)+starttime from t;
+  t:update starttime:$[((.z.N,.z.n).dqe.utctime>starttime);01:00+(.z.P,.z.p).dqe.utctime;(`date$(.z.D,.z.d).dqe.utctime)+starttime] from t;
   {.dqe.loadtimer[x]}each t
   }
 

--- a/config/settings/dqc.q
+++ b/config/settings/dqc.q
@@ -5,7 +5,7 @@
 configcsv:first .proc.getconfigfile["dqcconfig.csv"]
 dqcdbdir:hsym`$getenv[`KDBDQCDB]  // location to save dqc data
 hdbdir:hsym`$getenv[`KDBHDB]      // for locating the sym file
-gmttime:1b                        // define whether this process is on gmt time or not
+utctime:1b                        // define whether this process is on UTC time or not
 partitiontype:`date               // default partition type to date
 writedownperiod:0D00:05:00        // period for writedown
 getpartition:{@[value;`.dqe.currentpartition;(`date^partitiontype)$(.z.D,.z.d)gmttime]}

--- a/config/settings/dqc.q
+++ b/config/settings/dqc.q
@@ -8,7 +8,7 @@ hdbdir:hsym`$getenv[`KDBHDB]      // for locating the sym file
 utctime:1b                        // define whether this process is on UTC time or not
 partitiontype:`date               // default partition type to date
 writedownperiod:0D00:05:00        // period for writedown
-getpartition:{@[value;`.dqe.currentpartition;(`date^partitiontype)$(.z.D,.z.d)gmttime]}
+getpartition:{@[value;`.dqe.currentpartition;(`date^partitiontype)$(.z.D,.z.d)utctime]}
 
 \d .proc
 loadprocesscode:1b                // whether to load the process specific code defined at ${KDBCODE}/{process type}

--- a/config/settings/dqe.q
+++ b/config/settings/dqe.q
@@ -1,7 +1,7 @@
 \d .dqe
 dqedbdir:hsym`$getenv[`KDBDQEDB]  // location to save dqc data
 hdbdir:hsym`$getenv[`KDBHDB]      // for locating the sym file
-gmttime:1b                        // define whether this process is on gmt time or not
+utctime:1b                        // define whether this process is on UTC time or not
 partitiontype:`date               // default partition type to date
 getpartition:{@[value;`.dqe.currentpartition;(`date^partitiontype)$(.z.D,.z.d)gmttime]}
 writedownperiodengine:0D00:05:00  // period for writedown

--- a/config/settings/dqe.q
+++ b/config/settings/dqe.q
@@ -3,7 +3,7 @@ dqedbdir:hsym`$getenv[`KDBDQEDB]  // location to save dqc data
 hdbdir:hsym`$getenv[`KDBHDB]      // for locating the sym file
 utctime:1b                        // define whether this process is on UTC time or not
 partitiontype:`date               // default partition type to date
-getpartition:{@[value;`.dqe.currentpartition;(`date^partitiontype)$(.z.D,.z.d)gmttime]}
+getpartition:{@[value;`.dqe.currentpartition;(`date^partitiontype)$(.z.D,.z.d)utctime]}
 writedownperiodengine:0D00:05:00  // period for writedown
 
 \d .proc

--- a/docs/Processes.md
+++ b/docs/Processes.md
@@ -1634,7 +1634,7 @@ As an example, to run the customcheck above with the following settings -
 
 **params** - Not comparing two processes, and running with the two variables being
 `abc` and `def`.
-**proc** - running on the process `rdb1`.
+**proc** - running on the processes `rdb1` and `rdb2`.
 **mode** - the function being run repeatedly.
 **starttime** - 9AM.
 **endtime** - not specified.
@@ -1644,7 +1644,7 @@ The line in dqcconfig.csv should be:
 
 ```
 action,params,proc,mode,starttime,endtime,period
-customcheck,`comp`vars!(0b;(`abc;`def)),`rdb1,repeat,09:00:00.000000000,0Wn,0D00:10:00
+customcheck,`comp`vars!(0b;(`abc;`def)),`rdb1;`rdb2,repeat,09:00:00.000000000,0Wn,0D00:10:00
 ```
 
 To add a check that compares two processes, the check function would have to return


### PR DESCRIPTION
changing variable name gmttime to utctime, how kdb homepage names it
changing variable .eodtime.nextroll, which dictates when .u.end is ran, for whether utctime is 1b/0b
