### PR TITLE
Permissions fixes

### DIFF
--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -39,13 +39,19 @@ virtualtable:([name:`symbol$()]table:`symbol$();whereclause:())
 publictrack:([name:`symbol$()] handle:`int$())
 
 / api
-adduser:{[u;a;h;p]user,:(u;a;h;p)}
+adduser:{[u;a;h;p]
+  if[u in key groupinfo;'"pm: cannot add user with same name as existing group"];
+  user,:(u;a;h;p)}
 removeuser:{[u]user::.[user;();_;u]}
-addgroup:{[n;d]groupinfo,:(n;d)}
+addgroup:{[n;d]
+  if[n in key user;'"pm: cannot add group with same name as existing user"];
+  groupinfo,:(n;d)}
 removegroup:{[n]groupinfo::.[groupinfo;();_;n]}
 addrole:{[n;d]roleinfo,:(n;d)}
 removerole:{[n]roleinfo::.[roleinfo;();_;n]}
-addtogroup:{[u;g]if[not (u;g) in usergroup;usergroup,:(u;g)];}
+addtogroup:{[u;g]
+  if[u=g;'"pm: cannot have username match group name"];
+  if[not (u;g) in usergroup;usergroup,:(u;g)];}
 removefromgroup:{[u;g]if[(u;g) in usergroup;usergroup::.[usergroup;();_;usergroup?(u;g)]]}
 assignrole:{[u;r]if[not (u;r) in userrole;userrole,:(u;r)];}
 unassignrole:{[u;r]if[(u;r) in userrole;userrole::.[userrole;();_;userrole?(u;r)]]}
@@ -127,7 +133,10 @@ dotqf:{[u;q;b;pr]
   p[u;q;b;pr]}
 
 lamq:{[u;e;l;b;pr]
-  rt:(distinct exec object from access where entity<>`public); / allow public tables 
+  / get names of all defined variables to look for references to in expression
+  rt:raze .api.varnames[;"v";1b]'[.api.allns[]];
+  / allow public tables to always be accessed
+  rt:rt except distinct exec object from access where entity=`public;
   pq:(raze `$distinct {-4!x} (raze/)(s:raze each string e) ,' " ");
   rqt:rt where rt in pq;
   prohibited: rqt where not achk[u;;`read;pr] each rqt;

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -50,10 +50,12 @@ removegroup:{[n]groupinfo::.[groupinfo;();_;n]}
 addrole:{[n;d]roleinfo,:(n;d)}
 removerole:{[n]roleinfo::.[roleinfo;();_;n]}
 addtogroup:{[u;g]
-  if[u=g;'"pm: cannot have username match group name"];
+  if[not g in key groupinfo;'"pm: no such group, .pm.addgroup first"];
   if[not (u;g) in usergroup;usergroup,:(u;g)];}
 removefromgroup:{[u;g]if[(u;g) in usergroup;usergroup::.[usergroup;();_;usergroup?(u;g)]]}
-assignrole:{[u;r]if[not (u;r) in userrole;userrole,:(u;r)];}
+assignrole:{[u;r]
+  if[not r in key roleinfo;'"pm: no such role, .pm.addrole first"];
+  if[not (u;r) in userrole;userrole,:(u;r)];}
 unassignrole:{[u;r]if[(u;r) in userrole;userrole::.[userrole;();_;userrole?(u;r)]]}
 addfunction:{[f;g]if[not (f;g) in functiongroup;functiongroup,:(f;g)];}
 removefunction:{[f;g]if[(f;g) in functiongroup;functiongroup::.[functiongroup;();_;functiongroup?(f;g)]]}

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -176,8 +176,8 @@ mainexpr:{[u;e;b;pr]
   if[isq e; :query[u;e;b;pr]];
   / .q keywords
   if[xdq e;:dotqf[u;e;b;pr]];
-  / lambdas
-  if[any 100=type each raze e; :lamq[u;ie;b;pr]];
+  / lambdas - value any dict args before razing
+  if[any 100=type each raze @[e;where 99h=type'[e];value]; :lamq[u;ie;b;pr]];
   / if we get down this far we don't have specific handling for the expression - require superuser
   if[not (fchk[u;ALL;()] or fchk[u;`$string(first e);()]); $[b;'err[`expr][f]; :0b]];
   $[b; exe ie; 1b]}

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -240,7 +240,8 @@ droppublic:{[w]
 init:{
   .z.ps:{@[x;(`.pm.req;y)]}.z.ps;
   .z.pg:{@[x;(`.pm.req;y)]}.z.pg;
-  .z.pi:{$[x~enlist"\n";.Q.s value x;.Q.s $[.z.w=0;value;req]@x]}; 
+  // skip permissions for empty lines in q console/qcon
+  .z.pi:{$[x in (1#"\n";"");.Q.s value x;.Q.s $[.z.w=0;value;req]@x]};
   .z.pp:{'"pm: HTTP POST requests not permitted"};
   // from V3.5 2019.11.23, .h.val is used in .z.ph to evaluate request; below that disallow .z.ph
   $[(.z.K>=3.5)&.z.k>=2019.11.13;.h.val:req;.z.ph:{'"pm: HTTP GET requests not permitted"}];

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -153,7 +153,7 @@ lamq:{[u;e;b;pr]
   if[count prohibited;'" | " sv .pm.err[`selt] each prohibited];
   $[b; :exe e; :1b]}
 
-exe:{if[(100<abs type first x); v:val x]; v:valp x;
+exe:{v:$[(100<abs type first x);val;valp]x;
   if[maxsize<-22!v; 'err[`size][]]; v} 
 
 qexe:{v:val x; if[maxsize<-22!v; 'err[`size][]]; v}

--- a/config/permissions/default.q
+++ b/config/permissions/default.q
@@ -35,6 +35,7 @@
 .pm.grantfunction[`postback;`systemuser;{1b}]
 .pm.grantfunction[`killhandle;`systemuser;{1b}]
 .pm.grantfunction[`$string(!:);`systemuser;{1b}]
+.pm.grantfunction[`checkresulthandler;`systemuser;{1b}]
 
 .pm.addgroup[`systemuser;"full access to data"]
 .pm.grantaccess[`trade;`systemuser;`read]

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -233,13 +233,13 @@ The access schema consists of 7 control tables:
 
   |**Name**       | **Descriptions**|
   |---------------| ------------------------------------------------------------------------------------------------------------|
-  |User           |Username, locality, encryption type and password hash|
-  |Usergroup      |User and their group.|
-  |Userrole       |User and role.|
-  |Functiongroup  |Functions and their group|
-  |Function       |Function names, the roles which can access them, and a lambda checking the parameters those roles can use.|
-  |Access         |Variable names, the groups which can access them, and the read or write access level.|
-  |Virtualtable   |Virtual table name, main table name, and the where clause it enforces on access to that table.|
+  |user           |Username, locality, encryption type and password hash|
+  |usergroup      |User and their group.|
+  |userrole       |User and role.|
+  |functiongroup  |Functions and their group|
+  |function       |Function names, the roles which can access them, and a lambda checking the parameters those roles can use.|
+  |access         |Variable names, the groups which can access them, and the read or write access level.|
+  |virtualtable   |Virtual table name, main table name, and the where clause it enforces on access to that table.|
 
   
 In addition to groupinfo and roleinfo tables, which contain the
@@ -247,7 +247,8 @@ group/role name and a string describing each group and role. A user can
 belong to multiple groups, and have multiple roles. In particular the
 schema supports group hierarchy, where a user group can be listed as a
 user in the group table, and inherit all the permissions from another
-other group, effectively inheriting the second group itself.
+other group, effectively inheriting the second group itself. Note that
+a group cannot have the same name as an individual user.
 
 A user belonging to a group listed in the access table will have the
 specified level of access (read or write) to that group’s variables,

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -18,6 +18,9 @@ comment,,,,,,,test lambda expressions with nested structures
 run,,,q,e:({x};({x[`i]+x[`j]+value y};`i`j!1 2;"345")),,,create nested lambda structure with dict/string etc.
 true,,,q,348=value .pm.expr[`bob;e],,,contains no references to defined variables so can be run by anyone
 
+comment,,,,,,,test lambda expression with dict arg
+true,,,q,3=.pm.expr[`bob;({x[`i]+x[`j]};`i`j!1 2)],,,lambda expression with dict arg
+
 comment,,,,,,,test groups/users with same name
 fail,,,q,.pm.addtogroup[`tom;`tom],,,can't have group & username matching
 fail,,,q,.pm.addtogroup[`tom;`group2],,,can't add to a group that doesn't exist

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -29,3 +29,9 @@ fail,,,q,.pm.adduser[`group1;`local;`md5;md5"fail"],,,can't add user matching gr
 fail,,,q,.pm.assignrole[`tom;`role1],,,can't assign role that doesn't exist
 run,,,q,.pm.addrole[`role1;"test role"],,,create test role
 run,,,q,.pm.assignrole[`tom;`role1],,,can assign role that does exist
+
+comment,,,,,,,test calls where first item is a primitive
+run,,,q,.pm.grantfunction[.pm.ALL;`role1;{1b}],,,grant all function permission in order to use count
+run,,,q,y:1 2 3,,,variable to be counted
+true,,,q,3=.pm.expr[`tom;"count y"],,,should be able to count variable
+true,,,q,3=.pm.expr[`tom;"count 1 2 3"],,,should be able to count non-variable

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -1,0 +1,28 @@
+action,ms,bytes,lang,code,repeat,minver,comment
+comment,,,,,,,test access to variables within lambdas
+run,,,q,a:1;b:2;c:3,,,set up some variables to use in tests
+fail,,,q,.pm.expr[`tom;({1+a};`)],,,no permissions configured yet so this should fail
+run,,,q,.pm.adduser[`tom;`local;`md5;md5"pass"],,,add tom user
+run,,,q,.pm.addgroup[`group1;"group for tests"],,,add group for tests
+run,,,q,.pm.addtogroup[`tom;`group1],,,add tom to test group
+run,,,q,.pm.grantaccess[`a;`group1;`read],,,grant access to variable a
+true,,,q,2=.pm.expr[`tom;({1+a};`)],,,tom should now have read access to a
+run,,,q,.pm.grantaccess[`b;`public;`read],,,grant public access to variable b
+true,,,q,3=.pm.expr[`tom;({a+b};`)],,,tom should be able to access a and b
+fail,,,q,3=.pm.expr[`harry;({a+b};`)],,,harry should not be able to access a
+true,,,q,3=.pm.expr[`harry;({1+b};`)],,,harry should be able to access b (public)
+fail,,,q,.pm.expr[`tom;({a+b+c};`)],,,no one has access to c
+fail,,,q,.pm.expr[`harry;({a+b+c};`)],,,no one has access to c
+
+comment,,,,,,,test lambda expressions with nested structures
+run,,,q,e:({x};({x[`i]+x[`j]+value y};`i`j!1 2;"345")),,,create nested lambda structure with dict/string etc.
+true,,,q,348=value .pm.expr[`bob;e],,,contains no references to defined variables so can be run by anyone
+
+comment,,,,,,,test groups/users with same name
+fail,,,q,.pm.addtogroup[`tom;`tom],,,can't have group & username matching
+fail,,,q,.pm.addtogroup[`tom;`group2],,,can't add to a group that doesn't exist
+fail,,,q,.pm.addgroup[`tom;"already a user"],,,can't add group matching user
+fail,,,q,.pm.adduser[`group1;`local;`md5;md5"fail"],,,can't add user matching group
+fail,,,q,.pm.assignrole[`tom;`role1],,,can't assign role that doesn't exist
+run,,,q,.pm.addrole[`role1;"test role"],,,create test role
+run,,,q,.pm.assignrole[`tom;`role1],,,can assign role that does exist


### PR DESCRIPTION
Number of items addressed in this PR:

* Creating a user & group with same name caused an infinite loop, now rejects a name if already used for user/group
* On newer versions of kdb+, we can inject permissions into HTTP (GET) requests without modifying `.z.ph` by setting `.h.val` - previously HTTP requests just weren't supported in TorQ permissions
* Parsing to check permissions was broken for some nested expressions containing lambdas (e.g. the requests sent by TorQ monitor to other processes)
* When checking permissions on expressions containing lambdas, was only checked for references to variables that were already permissioned for at least some users i.e. was essentially "allowlisting" all variables by default, even in non-permissive mode. Now checks against all defined variables in all namespaces.
* Allow `systemuser` access to `checkresulthandler`, necessary for monitor process to work
* Allow lambda expressions of the form `(lambda;dict)`
* Fix conditional in `.pm.exe` so `eval` output is returned were applicable (e.g. `"count x"` - before would always return 1, regardless of what `x` contained)
* Skip empty lines from qcon (sends `""` rather than `"\n"` at q console)

Above changes are also unit tested, with exception of HTTP requests; couldn't find a good way to test this without spawning additional processes etc., as calling `.z.ph` directly means that `.z.w=0` and permissions checks are bypassed. Tested manually and appears to work fine (tom permissioned for `f:{x+y}`, bob not):

```
(base) jmcmurray@homer ~/git/TorQ (pm_fixes) $ curl -w '\n' 'http://tom:pass@127.0.0.1:15000/?f\[1;2\]'
<html><head><style>a{text-decoration:none}a:link{color:024C7E}a:visited{color:024C7E}a:active{color:958600}body{font:10pt verdana;text-align:justify}</style></head><body><pre>3
</pre></body></html>
(base) jmcmurray@homer ~/git/TorQ (pm_fixes) $ curl -w '\n' 'http://bob:pass@127.0.0.1:15000/?f\[1;2\]'
'pm: user role does not permit running function [f]
(base) jmcmurray@homer ~/git/TorQ (pm_fixes) $
```