### PR TITLE
Fix bugs in permissions framework

### DIFF
--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -158,8 +158,8 @@ exe:{v:$[(100<abs type first x);val;valp]x;
 
 qexe:{v:val x; if[maxsize<-22!v; 'err[`size][]]; v}
 
-/ check if arg is symbol, and if so if type is <100h i.e. variable
-isvar:{$[-11h<>type x;0b;100h>type get x]}
+/ check if arg is symbol, and if so if type is <100h i.e. variable - if name invalid, return read error
+isvar:{$[-11h<>type x;0b;100h>type @[get;x;{[x;y]'err[`selt][x]}[x]]]}
 
 mainexpr:{[u;e;b;pr]
   / store initial expression to use with value

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -124,7 +124,7 @@ query:{[u;q;b;pr]
   if[not fchk[u;ALL;()]; $[b; 'err[`selx][]; :0b]];
   $[b; :qexe q; :1b]}
 
-dotqd:enlist[`]!enlist{[u;e;b;pr]if[not (fchk[u;ALL;()] or fchk[u;`$string(first e);()]);$[b;'err[`expr][]];:0b];$[b;exe e;1b]};
+dotqd:enlist[`]!enlist{[u;e;b;pr]if[not (fchk[u;ALL;()] or fchk[u;`$string(first e);()]);$[b;'err[`expr][]];:0b];$[b;qexe e;1b]};
 dotqd[`lj`ij`pj`uj]:{[u;e;b;pr] $[b;val @[e;1 2;expr[u]];1b]}
 dotqd[`aj`ej]:{[u;e;b;pr] $[b;val @[e;2 3;expr[u]];1b]}
 dotqd[`wj`wj1]:{[u;e;b;pr] $[b;val @[e;2;expr[u]];1b]}
@@ -158,17 +158,26 @@ exe:{v:$[(100<abs type first x);val;valp]x;
 
 qexe:{v:val x; if[maxsize<-22!v; 'err[`size][]]; v}
 
+isvar:{[f]
+  / if first element is not a symbol, not a var ref
+  if[-11h<>type f;:0b];
+  / if first element is symbol, check if it's a variable (type<100h) or named function
+  :$[99h<type get f;0b;1b];
+ }
+
+enlistsyms:{[x]$[0h=t:type x;.z.s'[x];-11h=t;enlist x;x]}
+
 mainexpr:{[u;e;b;pr]
   / store initial expression to use with value
   ie:e;
-  e:$[10=type e;parse e;e];
+  e:$[10=type e;parse e;enlistsyms e];
   / variable reference
-  if[-11h=type e;
-    if[not achk[u;e;`read;pr]; $[b;'err[`selt][e]; :0b]];
-    $[b; :qexe $[e in key virtualtable;exec (?;table;enlist whereclause;0b;()) from virtualtable[e];e]; :1b];
+  if[isvar f:first e;
+    if[not achk[u;f;`read;pr]; $[b;'err[`selt][f]; :0b]];
+    $[b; :qexe $[f in key virtualtable;exec (?;table;enlist whereclause;0b;()) from virtualtable[f];e]; :1b];
   ];
   / named function calls
-  if[-11h=type f:first e;
+  if[-11h=type f;
     if[not fchk[u;f;1_ e]; $[b;'err[`func][f]; :0b]];
     $[b; :exe ie; :1b];
   ];

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -165,12 +165,10 @@ isvar:{[f]
   :$[99h<type get f;0b;1b];
  }
 
-enlistsyms:{[x]$[0h=t:type x;.z.s'[x];-11h=t;enlist x;x]}
-
 mainexpr:{[u;e;b;pr]
   / store initial expression to use with value
   ie:e;
-  e:$[10=type e;parse e;enlistsyms e];
+  e:$[10=type e;parse e;e];
   / variable reference
   if[isvar f:first e;
     if[not achk[u;f;`read;pr]; $[b;'err[`selt][f]; :0b]];

--- a/code/handlers/permissions.q
+++ b/code/handlers/permissions.q
@@ -158,12 +158,8 @@ exe:{v:$[(100<abs type first x);val;valp]x;
 
 qexe:{v:val x; if[maxsize<-22!v; 'err[`size][]]; v}
 
-isvar:{[f]
-  / if first element is not a symbol, not a var ref
-  if[-11h<>type f;:0b];
-  / if first element is symbol, check if it's a variable (type<100h) or named function
-  :$[99h<type get f;0b;1b];
- }
+/ check if arg is symbol, and if so if type is <100h i.e. variable
+isvar:{$[-11h<>type x;0b;100h>type get x]}
 
 mainexpr:{[u;e;b;pr]
   / store initial expression to use with value
@@ -172,7 +168,7 @@ mainexpr:{[u;e;b;pr]
   / variable reference
   if[isvar f:first e;
     if[not achk[u;f;`read;pr]; $[b;'err[`selt][f]; :0b]];
-    $[b; :qexe $[f in key virtualtable;exec (?;table;enlist whereclause;0b;()) from virtualtable[f];e]; :1b];
+    :$[b;qexe $[f in key virtualtable;exec (?;table;enlist whereclause;0b;()) from virtualtable[f];e];1b];
   ];
   / named function calls
   if[-11h=type f;

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -43,6 +43,11 @@ true,,,q,1 2 3~.pm.expr[`tom;"d`a"],,,test dictionary lookup
 true,,,q,`a=.pm.expr[`tom;"l 0"],,,test list index
 fail,,,q,.pm.expr[`harry;"d`a"],,,harry doesn't have access to d
 fail,,,q,.pm.expr[`harry;"l 0"],,,harry doesn't have access to l
+run,,,q,f:{1+x},,,define function for testing named function call
+true,,,q,2=.pm.expr[`tom;"f 1"],,,tom should have access to f
+true,,,q,2=.pm.expr[`tom;(`f;1)],,,tom should have access to f
+fail,,,q,2=.pm.expr[`harry;"f 1"],,,harry should not have access to f
+fail,,,q,2=.pm.expr[`harry;(`f;1)],,,harry should not have access to f
 
 comment,,,,,,,test expressions where first item is lambda from .q
 true,,,q,(`a`b`c!1 4 7)~.pm.expr[`tom;"first each d"],,,test expression with each

--- a/tests/permissions/permissions.csv
+++ b/tests/permissions/permissions.csv
@@ -35,3 +35,16 @@ run,,,q,.pm.grantfunction[.pm.ALL;`role1;{1b}],,,grant all function permission i
 run,,,q,y:1 2 3,,,variable to be counted
 true,,,q,3=.pm.expr[`tom;"count y"],,,should be able to count variable
 true,,,q,3=.pm.expr[`tom;"count 1 2 3"],,,should be able to count non-variable
+
+comment,,,,,,,test indexing into allowed/disallowed variables
+run,,,q,d:`a`b`c!(1 2 3;4 5 6;7 8 9);l:`a`b`c,,,set up a dictionary and list for tests
+run,,,q,.pm.grantaccess[;`group1;`read]'[`d`l],,,grant group1 access to test variables
+true,,,q,1 2 3~.pm.expr[`tom;"d`a"],,,test dictionary lookup
+true,,,q,`a=.pm.expr[`tom;"l 0"],,,test list index
+fail,,,q,.pm.expr[`harry;"d`a"],,,harry doesn't have access to d
+fail,,,q,.pm.expr[`harry;"l 0"],,,harry doesn't have access to l
+
+comment,,,,,,,test expressions where first item is lambda from .q
+true,,,q,(`a`b`c!1 4 7)~.pm.expr[`tom;"first each d"],,,test expression with each
+fail,,,q,.pm.expr[`harry;"first each d"],,,harry doesn't have access to d
+


### PR DESCRIPTION
Addressing a couple of bugs in permissions framework:

* expressions such as `first each x` were breaking because `each` becomes lambda on parse & PM framework was always using `value` instead of `eval` when first item in expression is a lambda - switched to `eval` when lambda is from `.q` namespace
* indexing into lists/dicts was broken as variable name was being interpreted by PM framework as a function name

Unit tests for both cases included