### PR TITLE
added timezone adjustment

### DIFF
--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -200,5 +200,5 @@ reload:.rdb.reload
 .rdb.setpartition[]
 
 /-change timeout to zero before eod flush
-.timer.repeat[.eodtime.nextroll+.eodtime.adjtime[]-00:01;0W;1D;
+.timer.repeat[.eodtime.nextroll+`second$(.proc.cp[]-.z.p)-00:01;0W;1D;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -201,5 +201,5 @@ reload:.rdb.reload
 
 /-change timeout to zero before eod flush
 /-GMT offset rounded to nearest 15 mins and added to roll time
-.timer.repeat[.eodtime.nextroll+{00:01*15*"j"$(`minute$x)%15}(.proc.cp[]-.z.p)-00:01;0W;1D;
+.timer.repeat[.eodtime.nextroll-00:01+{00:01*15*"j"$(`minute$x)%15}(.proc.cp[]-.z.p);0W;1D;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -200,5 +200,5 @@ reload:.rdb.reload
 .rdb.setpartition[]
 
 /-change timeout to zero before eod flush
-.timer.repeat[.eodtime.nextroll-00:01;0W;1D;
+.timer.repeat[.eodtime.nextroll+.eodtime.adjtime[]-00:01;0W;1D;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -199,6 +199,9 @@ reload:.rdb.reload
 /-set the partition that is held in the rdb (for use by the gateway)
 .rdb.setpartition[]
 
+/-rounds GMT offset to nearest hour
+localoffset: {01:00*"j"$(`minute$x)%60}(.proc.cp[]-.z.p)
+
 /-change timeout to zero before eod flush
-.timer.repeat[.eodtime.nextroll+`second$(.proc.cp[]-.z.p)-00:01;0W;1D;
+.timer.repeat[.eodtime.nextroll+localoffset-00:01;0W;1D;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -199,9 +199,7 @@ reload:.rdb.reload
 /-set the partition that is held in the rdb (for use by the gateway)
 .rdb.setpartition[]
 
-/-rounds GMT offset to nearest hour
-localoffset: {01:00*"j"$(`minute$x)%60}(.proc.cp[]-.z.p)
-
 /-change timeout to zero before eod flush
-.timer.repeat[.eodtime.nextroll+localoffset-00:01;0W;1D;
+/-GMT offset rounded to nearest 15 mins and added to roll time
+.timer.repeat[.eodtime.nextroll+{00:01*15*"j"$(`minute$x)%15}(.proc.cp[]-.z.p)-00:01;0W;1D;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];


### PR DESCRIPTION
Problem:
The input given in the RDB proc script for the timeout reset is incorrect when the RDB is running in a different timezone.

Test Case: 
- TP is running in GMT and rolls at 6pm, 
- RDB is in EST time and rolls at 6pm EST time (23:00 GMT)

In this case, the TP rolls before the RDB has had a chance to reset the timeout (which will happen at 22:59 GMT).

Solution:
Include the GMT offset for .eodtime.nextroll by using the difference between the UTC current time and the current time of the RDB. This method accounts for whether the localtime flag is applied or not since .proc.cp[] - .z.p will either be the value of the appropriate time offset or 0 respectively. 

resolves #354 