### PR TITLE
set loghandles to be null when sctp is not creating own logs

### DIFF
--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -276,6 +276,11 @@ init:{[dbname]
     // add the info to the meta table
     .stpm.updmeta[multilog][`open;logtabs;.z.p+.eodtime.dailyadj];
     ]
+
+  // set loghandles to null if sctp is not creating logs
+  if[.sctp.chainedtp and not .sctp.loggingmode=`create;
+    `..loghandles set t! (count t) # enlist  (::)
+   ]
  };
 
 \d .


### PR DESCRIPTION
fixes log writing bug for when sctp is NOT in "create" logging mode, in this case logs should be ignored so set handles to be null