### PR TITLE
Fix localtime flag to allow 0

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -46,7 +46,7 @@ getfield() {
 
 parameter() {
   fieldval=$(getfield "$1" "$2")
-  if [[ "" == "$fieldval" ]]; then                                                                  # check for empty string
+  if [[ ("" == "$fieldval") || ("0" == "$fieldval" && "localtime" == "$2") ]]; then                 # check for empty string or 0 for localtime 
     echo ""
   else
     echo " -""$2" "$fieldval"


### PR DESCRIPTION
**Issue:**
At the moment setting the localtime flag (in `process.csv`) to 0 does not change the behaviour of the process, and instead it will run in localtime, eg using `.z.P` for the `.proc.cp `.
In order to get around this, a user would have to leave the field blank for the process to not run in localtime.

**Fix:**
Added extra condition within the `parameter` function of `torq.sh` , to not append the localtime flag if it is set to 0 within the `process.csv`.