### PR TITLE
Fix EOD not occurring when not an EOP

### DIFF
--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -246,10 +246,12 @@ dayrollover:{[data]
 getnextendUTC:{nextendUTC::-1+min(.eodtime.nextroll;nextperiod - .eodtime.dailyadj)}
 
 checkends:{
-  // jump out early if don't have to do either 
+  // jump out early if don't have to do either
   if[nextendUTC > x; :()];
-  if[nextperiod < x1:x+.eodtime.dailyadj; stpeoperiod[.stplg`currperiod;.stplg`nextperiod;.stplg.endofdaydata[],(enlist `p)!enlist x1;not isendofday:.eodtime.nextroll < x]];
-  if[isendofday;if[.eodtime.d<("d"$x)-1;system"t 0";'"more than one day?"]; stpeod[.eodtime.d;.stplg.endofdaydata[],(enlist `p)!enlist x]];
+  // check for endofperiod
+  if[nextperiod < x1:x+.eodtime.dailyadj; stpeoperiod[.stplg`currperiod;.stplg`nextperiod;.stplg.endofdaydata[],(enlist `p)!enlist x1;not .eodtime.nextroll < x]];
+  // check for endofday
+  if[.eodtime.nextroll < x;if[.eodtime.d<("d"$x)-1;system"t 0";'"more than one day?"]; stpeod[.eodtime.d;.stplg.endofdaydata[],(enlist `p)!enlist x]];
  };
 
 init:{[dbname]

--- a/config/settings/segmentedtickerplant.q
+++ b/config/settings/segmentedtickerplant.q
@@ -10,19 +10,8 @@ replayperiod:`day               // [period|day|prior]
 customcsv:hsym first .proc.getconfigfile["stpcustom.csv"];       // Location for custom logging mode csv
 
 \d .proc
-
-loadprocesscode:1b
-
-\d .eodtime
-
-datatimezone:@[value;`datatimezone;`GMT];
-rolltimezone:@[value;`rolltimezone;`GMT];
-
-  
-\d .proc
 loadcommoncode:0b               // do not load common code
 loadprocesscode:1b              // load process code
-
 logroll:0b                      // do not roll logs
 
 // Configuration used by the usage functions - logging of client interaction

--- a/config/settings/segmentedtickerplant.q
+++ b/config/settings/segmentedtickerplant.q
@@ -15,8 +15,8 @@ loadprocesscode:1b
 
 \d .eodtime
 
-datatimezone:`GMT
-rolltimezone:`GMT
+datatimezone:@[value;`datatimezone;`GMT];
+rolltimezone:@[value;`rolltimezone;`GMT];
 
   
 \d .proc

--- a/tests/stp/tz/settings.q
+++ b/tests/stp/tz/settings.q
@@ -12,7 +12,7 @@ testtrade:((5#`GOOG),5?`4;10?100.0;10?100i;10#0b;10?.Q.A;10?.Q.A;10#`buy);
 eodinit:{
   // Default offset
   off:0D00;
-
+  
   // If adding a synthetic TZ, set roll time to 2 seconds from now +- any rolloffsets
   if[x in `custom`customoffsetplus`customoffsetminus;
     dt:"p"$0;doff:"n"$0;
@@ -20,11 +20,22 @@ eodinit:{
     `.tz.t upsert (x;dt;adj;doff;adj;dt);
     .stplg.nextendUTC:"p"$0
     ];
-
+  
   // Re-init eodtime
   .eodtime.datatimezone:x;
   .eodtime.rolltimezone:x;
   .eodtime.rolltimeoffset:neg off;
+  .eodtime.dailyadj:.eodtime.getdailyadjustment[];
+  .eodtime.d:.eodtime.getday[.z.p];
+  .eodtime.nextroll:.eodtime.getroll[.z.p];
+  };
+
+eodchange:{
+  // change eod, no custom tz
+  .eodtime.datatimezone:`GMT;
+  .eodtime.rolltimezone:`GMT;
+  // eod set to 2 seconds after stp init
+  .eodtime.rolltimeoffset:.z.p+00:00:02-"p"$.z.d+1;
   .eodtime.dailyadj:.eodtime.getdailyadjustment[];
   .eodtime.d:.eodtime.getday[.z.p];
   .eodtime.nextroll:.eodtime.getroll[.z.p];

--- a/tests/stp/tz/tzrolloffset.csv
+++ b/tests/stp/tz/tzrolloffset.csv
@@ -1,0 +1,10 @@
+action,ms,bytes,lang,code,repeat,minver,comment
+before,0,0,q,(hs:value handles) @\: (eodchange;::),1,,"Set custom STP TZ"
+before,0,0,q,hs @\: (`.stplg.init;testlogdb),1,,"Reset STP with new TZ"
+before,0,0,q,currd1:hs @\: ".eodtime.d",1,,"Get date"
+run,0,0,q,system "sleep 2",1,,"Wait for 2 seconds"
+run,0,0,q,hs @\: ".z.ts[]",1,,"Trigger EOD"
+true,0,0,q,(1+currd1)~hs @\: ".eodtime.d",1,,"See if date has rolled"
+true,0,0,q,all not null currd1, hs @\: ".eodtime.d",1,,"Check no dates are null"
+run,0,0,q,logdir:1_string handles[`imm](`.stplg.dldir),1,,"Get log directory"
+after,0,0,q,.os.deldir logdir,1,,"Delete test STP logs"


### PR DESCRIPTION
**Issue:**
Setting the end of day on the STP to a time which didn't align with an end of period resulted in the end of day function not being called. This is because the ``isendoday`` variable within [``.stplg.checkends``](https://github.com/AquaQAnalytics/TorQ/blob/master/code/segmentedtickerplant/stplog.q#L248), was only set if the input time was after an end of period.

The issue can be replicated by setting ``eodtime`` to the following and watching the ``STP`` in debug. EOD will happen 42 seconds after STP start up. 
```
\d .eodtime
rolltimeoffset:.z.p+00:00:42-"p"$.z.d+1;        // offset from default midnight roll
datatimezone:`GMT;                      // timezone for TP to timestamp data in
rolltimezone:`GMT;                      // timezone to perform rollover in
```  

**Fix:**
Remove the dependency of the EOD check also being an EOP within the ``.stplg.checkends`` function.

Also updated config files to stop overwrites of custom EOD that could be set in ``default.q``.

**To do:**

- [ ] Update unit tests to catch this case
