### PR TITLE
Move .aqrest.execute definition for the Data Access API on the gateway 

### DIFF
--- a/code/common/dataaccess.q
+++ b/code/common/dataaccess.q
@@ -26,6 +26,7 @@ metainfo:([tablename:`$()]partfield:`$();metas:();proctype:`$());
 //-   - load config for checking input parameters
 //-   - write meta info for tables in current process to .dataaccess.metainfo
 init:{[tablepropertiespath]
+  if[.proc.proctype = `gateway; .aqrest.execute::{[req;props] @[value;req;{(neg .z.w)(.gw.formatresponse[0b;0b;"error: ",x])}]}];
   .lg.o[`.dataaccess.init;"running .dataaccess.init"];
   .proc.loaddir getenv[`KDBCODE],"/dataaccess";
   if[not validtablepropertiespath[];resettablepropertiespath tablepropertiespath];

--- a/code/gateway/daqrest.q
+++ b/code/gateway/daqrest.q
@@ -1,5 +1,3 @@
-.aqrest.execute:{[req;props] @[value;req;{(neg .z.w)(.gw.formatresponse[0b;0b;"error: ",x])}]};
-
 \d .dataaccess
 
 // .gw.formatresponse:{[status;sync;result]$[not[status]and sync;'result;result]}};


### PR DESCRIPTION
.aqrest.execute was defined on gateway startup and this was causing issues with using q-REST. 
Define .aqrest.execute on the gateway after Data Access API initialization instead. 