### PR TITLE
Add functionality to check for user queries missing date clauses

### DIFF
--- a/code/processes/gateway.q
+++ b/code/processes/gateway.q
@@ -393,8 +393,14 @@ asyncexecjpts:{[query;servertype;joinfunction;postback;timeout;sync]
      if[10h<>type res; if[0=count raze res; errstr:.gw.errorprefix,"no servers match given attributes"]];
      servertype:res;
     ];
+/   if[serverid=`hdb;]
    ]
   ];
+    checkdate:{[query] 
+       conds:parse query; 
+       $[count ss[.Q.s1 @[conds;2];"date"];0;"Please add a date clause to your query"]};
+    errcheck:checkdate[query];
+    if[10h=type errcheck; errstr:errcheck]
  // error has been hit
  if[count errstr;
   @[neg .z.w;.gw.formatresponse[0b;sync;$[()~postback;errstr;$[-11h=type postback;enlist postback;postback],enlist[query],enlist errstr]];()];


### PR DESCRIPTION
The checkdate function parses the user query and checks for a date clause (there are edge cases which will also have to be dealt with, for example a date clause with a massive date range should also be warned against, but this is what we have for the moment) and returns an error string if none is found. Based on similar checks in the surrounding code, this is then assigned to errstr. The problem we have encountered is where exactly this fits into the rest of the code, as we have tried a few locations but the bad user queries still run at the moment.