### PR TITLE
Fixed wdb EOD failure caused by syms containing special chars or lead…

### DIFF
--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -313,7 +313,15 @@ merge:{[dir;pt;tableinfo;mergelimits;hdbsettings]
 	      curr[0]:curr[0],select from get segment;
 	      curr[1]:curr[1],segment;		
       	$[islast or mergemaxrows < count curr[0];
-	        [.lg.o[`merge;"upserting ",(string count curr[0])," rows to ",string dest];
+	        
+                [pattrtest:@[{@[x;y;`p#]}[curr[0];];`sym;{x}];
+                if[10h=type pattrtest;
+                  /p attribute could not be applied, data must be re-sorted by subpartition col (sym):
+                  curr[0]: xasc[.merge.getextrapartitiontype[tablename];curr[0]];
+                  .lg.o[`resort;"The p attribute can now be applied"];
+                 ];
+                
+                .lg.o[`merge;"upserting ",(string count curr[0])," rows to ",string dest];
 	        dest upsert curr[0];
 	        .lg.o[`merge;"removing segments", (", " sv string curr[1])];
 	        .os.deldir each string curr[1];


### PR DESCRIPTION
…ing/trailing spaces.

When dealing with two or more syms which are identical apart from
 special chars or leading/trailing spaces, .wdb.upserttopartition
groups them all into the same sym subpartition in the wdbhdb. This
 can lead to a u-fail when the `p attr cannot be applied to the
 mixed syms. Now, however, .wdb.merge checks whether `p# can be
applied to the contents of each subpartition before they are saved
to the hdb. If not, the data is reordered by the subpartition
column (usually sym), which prevents the EOD failure.