### PR TITLE
Made STP upd function work for tables that have compound columns

### DIFF
--- a/code/processes/segmentedtickerplant.q
+++ b/code/processes/segmentedtickerplant.q
@@ -39,7 +39,7 @@ generateschemas:{
   // Table UPD functions attach the current timestamp by default, if STP is chained these do nothing
   $[.sctp.chainedtp;
     .stplg.updtab:(.stpps.t!(count .stpps.t)#{[x;y] x}),.stplg.updtab;
-    .stplg.updtab:(.stpps.t!(count .stpps.t)#{(enlist(count first x)#y),x}),.stplg.updtab
+    .stplg.updtab:(.stpps.t!(count .stpps.t)#{(enlist $[0>type first x;y;(count first x)#y]),x}),.stplg.updtab
     ]
   }
 

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -50,7 +50,9 @@ upd:@[value;`.stplg.upd;enlist[`]!enlist ()];
 zts:@[value;`.stplg.zts;enlist[`]!enlist ()];
 
 // Functions to add columns on updates
-updtab:@[value;`.stplg.updtab;enlist[`]!enlist {(enlist(count first x)#y),x}]
+// The conditional is necessary when x is a single row of data and the table contains compound (e.g. string) columns
+// Still there is an edge case where the first element of x is for a compound column
+updtab:@[value;`.stplg.updtab;enlist[`]!enlist {(enlist $[0>type first x;y;(count first x)#y]),x}]
 
 // If set to memorybatch, publish and write to disk will be run in batches
 // insert to table in memory, on a timer flush the table to disk and publish, update counts


### PR DESCRIPTION
If a table has compound columns like of string type, pushing a single row of data into segmented tickerplant in unchained mode gives a "length" error while inserting into the table. This is because the default implementation adds the current timestamp as the first element in the format of 1-size array, which may conflict with the length of the value for the compound column. 

To illustrate with an example, the below `.u.upd` call fails silently as no data is inserted into table `t` in either tp or rdb.
```
t:([] time:`timestamp$(); sym:`symbol$(); comment:());
.u.upd[`t;(`dummy;"test")];
```