### PR TITLE
wdb reloadproc improvement 

### DIFF
--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -390,7 +390,8 @@ reloadproc:{[h;d;ptype]
         syncreloadfunc:{[h;d;ptype] r:@[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],". The error was : ",e];e}[ptype]];
         .lg.o[`reloadproc;"the ", string[ptype]," ", $[10h~type r; "failed to reload with error ",r;"successfully reloaded"]]}; 
         $[eodwaittime>0;
-                 sendfunc[(reloadfunc;d;ptype);h;ptype];     
+                 (.lg.o[`reloadproc;"reload call has been sent to ", string[ptype]];
+                         sendfunc[(reloadfunc;d;ptype);h;ptype]);     
 		 syncreloadfunc[h;d;ptype]
         ];
         }

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -384,11 +384,11 @@ reloadproc:{[h;d;ptype]
         sendfunc:{[x;y;ptype].[{neg[y]@x};(x;y);{[ptype;x].lg.e[`reloadproc;"failed to reload the ",string[ptype]];'x}[ptype]]};
         /-reload function sent to processes by sendfunc in order to call process to reload. If process fail to reload log error 
         /-and call .wdb.handler with failed reload message. If reload is successful call .wdb.handler with successful reload message.
-        reloadfunc:{[d;ptype] r:@[`. `reload;d;{x}];
+        reloadfunc:{[d;ptype] r:@[`. `reload;d;{.lg.e[`reloadproc;"failed to reload from .wdb.reloadproc call. The error was : ",x];x}];
 	$[10h = type r;
-                 ((neg .z.w)(`.wdb.handler;(ptype;0b;`$"reload failed with error ",r));(neg .z.w)[];
-                          .lg.e[`reloadproc;"failed to reload ",string[ptype]," from .wdb.reloadproc call. The error was : ",r]);
-                 ((neg .z.w)(`.wdb.handler;(ptype;1b;`$"reloaded successfully"))(neg .z.w)[])]};
+                 (reloadstatus:(ptype;0b;`$"reload failed with error ",r));
+                 (reloadstatus:(ptype;1b;`$"reloaded successfully"))];
+                 (neg .z.w)(`.wdb.handler;reloadstatus);(neg .z.w)[]};
         $[eodwaittime>0;
                  sendfunc[(reloadfunc;d;ptype);h;ptype];     
 		 @[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e]}[ptype]]

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -385,10 +385,7 @@ reloadproc:{[h;d;ptype]
         /-reload function sent to processes by sendfunc in order to call process to reload. If process fail to reload log error 
         /-and call .wdb.handler with failed reload message. If reload is successful call .wdb.handler with successful reload message.
         reloadfunc:{[d;ptype] r:@[`. `reload;d;{.lg.e[`reloadproc;"failed to reload from .wdb.reloadproc call. The error was : ",x];x}];
-	$[10h = type r;
-                 (reloadstatus:(ptype;0b;`$"reload failed with error ",r));
-                 (reloadstatus:(ptype;1b;`$"reloaded successfully"))];
-                 (neg .z.w)(`.wdb.handler;reloadstatus);(neg .z.w)[]};
+        (neg .z.w)(`.wdb.handler;(ptype;10h<>type r;$[10h~type r;`$"reload failed with error ",r;`$"reloaded successfully"]));(neg .z.w)[]};
         $[eodwaittime>0;
                  sendfunc[(reloadfunc;d;ptype);h;ptype];     
 		 @[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e]}[ptype]]

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -385,10 +385,10 @@ reloadproc:{[h;d;ptype]
         /-reload function sent to processes by sendfunc in order to call process to reload. If process fail to reload log error 
         /-and call .wdb.handler with failed reload message. If reload is successful call .wdb.handler with successful reload message.
         reloadfunc:{[d;ptype] r:@[`. `reload;d;{.lg.e[`reloadproc;"failed to reload from .wdb.reloadproc call. The error was : ",x];x}];
-        (neg .z.w)(`.wdb.handler;(ptype;10h<>type r;$[10h~type r;`$"reload failed with error ",r;`$"reloaded successfully"]));(neg .z.w)[]};
+                (neg .z.w)(`.wdb.handler;(ptype;10h<>type r;$[10h~type r;`$"reload failed with error ",r;`$"reloaded successfully"]));(neg .z.w)[]};
         /-reload function to be executed if eodwaitime = 0 - sync message processes to reload and log if reload was successful or failed
         syncreloadfunc:{[h;d;ptype] r:@[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],". The error was : ",e];e}[ptype]];
-        .lg.o[`reloadproc;"the ", string[ptype]," ", $[10h~type r; "failed to reload with error ",r;"successfully reloaded"]]}; 
+                .lg.o[`reloadproc;"the ", string[ptype]," ", $[10h~type r; "failed to reload with error ",r;"successfully reloaded"]]}; 
         $[eodwaittime>0;
                  (.lg.o[`reloadproc;"reload call has been sent to ", string[ptype]];
                          sendfunc[(reloadfunc;d;ptype);h;ptype]);     

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -206,9 +206,9 @@ endofdaysave:{[dir;pt]
 /- add entries to table of callbacks. if timeout has expired or d now contains all expected rows then it releases each waiting process
 handler:{
 	/-insert process reload outcome into .wdb.reloadsummary 
-                 .wdb.reloadsummary[.z.w]:x;
+        .wdb.reloadsummary[.z.w]:x;
         /-log result of reload in wdb out log 
-                .lg.o[`reloadproc;"the ", string[.wdb.reloadsummary[.z.w]`process]," process ", string[.wdb.reloadsummary[.z.w]`result]];
+        .lg.o[`reloadproc;"the ", string[.wdb.reloadsummary[.z.w]`process]," process ", string[.wdb.reloadsummary[.z.w]`result]];
         if[(.proc.cp[]>.wdb.timeouttime) or (count[.wdb.reloadsummary]=.wdb.countreload);
                 .lg.o[`handler;"releasing processes"];
                 .lg.o[`reload;string[count select from .wdb.reloadsummary where status=1]," out of ", string[count .wdb.reloadsummary]," processes successfully reloaded"];
@@ -228,7 +228,7 @@ flushend:{
 	};
 
 /- initialise reloadsummary, keyed tale to track status of local reloads
-reloadsummary:([`int$handle:()]`symbol$process:();`boolean$status:();`symbol$result:());
+reloadsummary:([handle:`int$()]process:`symbol$();status:`boolean$();result:`symbol$());
 
 doreload:{[pt]
 	.wdb.reloadcomplete:0b;

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -208,6 +208,8 @@ handler:{
 	/-insert process reload outcome into .wdb.d
 	if[not .z.w in  key .wdb.d;
         	.wdb.d[.z.w]:x];
+	if[(not .wdb.d[.z.w]`status);
+		.lg.o[`reload;string[.wdb.d[.z.w]`process]," reload ", .wdb.d[.z.w]`result]];
 	if[(.proc.cp[]>.wdb.timeouttime) or (count[.wdb.d]=.wdb.countreload);
 		.lg.o[`handler;"releasing processes"];
 		.lg.o[`reload;string[count select from .wdb.d where status=1]," out of ", string[count .wdb.d]," processes successfully reloaded"];

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -209,13 +209,13 @@ handler:{
 	if[not .z.w in  key .wdb.d;
         	.wdb.d[.z.w]:x];
 	if[(not .wdb.d[.z.w]`status);
-		.lg.o[`reload;string[.wdb.d[.z.w]`process]," reload ", .wdb.d[.z.w]`result]];
+		.lg.o[`reload;string[.wdb.d[.z.w]`process]," reload ", string[.wdb.d[.z.w]`result]]];
 	if[(.proc.cp[]>.wdb.timeouttime) or (count[.wdb.d]=.wdb.countreload);
 		.lg.o[`handler;"releasing processes"];
 		.lg.o[`reload;string[count select from .wdb.d where status=1]," out of ", string[count .wdb.d]," processes successfully reloaded"];
 		.wdb.flushend[]];
-	/-clear out .wdb.d when reloads completed
-	if[.wdb.reloadcomplete;.wdb.d:([handle:()]process:();status:();result:())];
+	/-delete .wdb.d when reloads completed
+	if[.wdb.reloadcomplete;delete d from `.wdb];
 	};
 
 /- evaluate contents of d dictionary asynchronously
@@ -229,7 +229,7 @@ flushend:{
 	};
 
 /- initialise d, keyed tale to track status of local reloads
-d:([handle:()]process:();status:();result:());
+d:([`int$handle:()]`symbol$process:();`boolean$status:();`symbol$result:());
 
 /-initialise reload complete
 reloadcomplete:0b;
@@ -386,10 +386,10 @@ reloadproc:{[h;d;ptype]
                 {[x;y;ptype].[{neg[y]@x};(x;y);{[ptype;x].lg.e[`reloadproc;"failed to reload the ",string[ptype]];'x}[ptype]]}
                         [({@[`. `reload;x;
 	/-if process fails to reload message with error entered into .wdb.d and  output error to process error log
-                                {[ptype;e](neg .z.w)(`.wdb.handler;(ptype;0b;"failed with error: ",e));
+                                {[ptype;e](neg .z.w)(`.wdb.handler;(ptype;0b;`$"failed with error: ",e));
                                 .lg.e[`reloadproc;"failed to reload ",string[ptype]," from .wdb.reloadproc call. The error was : ",e]}[y]];
         /-Successful reload message to be sent to handler and entered into .wdb.d for end of reload summary logging
-	                         (neg .z.w)(`.wdb.handler;(y;1b;"successfully reloaded")); (neg .z.w)[]};d;ptype);h;ptype];       
+	                         (neg .z.w)(`.wdb.handler;(y;1b;`$"successfully reloaded")); (neg .z.w)[]};d;ptype);h;ptype];       
 		 @[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e]}[ptype]]
         ];
         .lg.o[`reload;string[ptype]," reload has finished"];

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -214,8 +214,8 @@ handler:{
 		.lg.o[`handler;"releasing processes"];
 		.lg.o[`reload;string[count select from .wdb.d where status=1]," out of ", string[count .wdb.d]," processes successfully reloaded"];
 		.wdb.flushend[]];
-	/-delete .wdb.d when reloads completed
-	if[.wdb.reloadcomplete;delete d from `.wdb];
+	/-delete contents from .wdb.d when reloads completed
+	if[.wdb.reloadcomplete;delete from `.wdb.d];
 	};
 
 /- evaluate contents of d dictionary asynchronously

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -205,11 +205,11 @@ endofdaysave:{[dir;pt]
 
 /- add entries to dictionary of callbacks. if timeout has expired or d now contains all expected rows then it releases each waiting process
 handler:{
-	/-insert process reload outcome into .wdb.reloadstatus
+	/-insert process reload outcome into .wdb.reloadstatus 
         if[not .z.w in  key .wdb.reloadstatus;
                 .wdb.reloadstatus[.z.w]:x];
         if[(not .wdb.reloadstatus[.z.w]`status);
-                .lg.o[`reload;string[.wdb.reloadstatus[.z.w]`process]," reload ", string[.wdb.reloadstatus[.z.w]`result]]];
+                .lg.o[`reload;"the ", string[.wdb.reloadstatus[.z.w]`process]," process reload has ", string[.wdb.reloadstatus[.z.w]`result]]];
         if[(.proc.cp[]>.wdb.timeouttime) or (count[.wdb.reloadstatus]=.wdb.countreload);
                 .lg.o[`handler;"releasing processes"];
                 .lg.o[`reload;string[count select from .wdb.reloadstatus where status=1]," out of ", string[count .wdb.reloadstatus]," processes successfully reloaded"];
@@ -384,12 +384,13 @@ reloadproc:{[h;d;ptype]
         .wdb.countreload:count[raze .servers.getservers[`proctype;;()!();1b;0b]each reloadorder];
         $[eodwaittime>0;
                 {[x;y;ptype].[{neg[y]@x};(x;y);{[ptype;x].lg.e[`reloadproc;"failed to reload the ",string[ptype]];'x}[ptype]]}
-                        [({@[`. `reload;x;
-	/-if process fails to reload message with error entered into .wdb.reloadstatus and  output error to process error log
-                                {[ptype;e](neg .z.w)(`.wdb.handler;(ptype;0b;`$"failed with error: ",e));
-                                .lg.e[`reloadproc;"failed to reload ",string[ptype]," from .wdb.reloadproc call. The error was : ",e]}[y]];
-        /-Successful reload message to be sent to handler and entered into .wdb.reloadstatus for end of reload summary logging
-	                        (neg .z.w)(`.wdb.handler;(y;1b;`$"successfully reloaded")); (neg .z.w)[]};d;ptype);h;ptype];       
+                [({@[`. `reload;x;
+	/-error trap lambda to execute if process fails to reload error added to .wdb.reloadstatus and logged in process error log
+                        {[ptype;e](neg .z.w)(`.wdb.handler;(ptype;0b;`$"failed with error: ",e));
+                        .lg.e[`reloadproc;"failed to reload ",string[ptype]," from .wdb.reloadproc call. The error was : ",e]}[y]];
+        /-successful reload message to be sent to handler and entered into .wdb.reloadstatus for end of reload summary logging
+        /-this message will alway be sent to wdb however if process has failed .wdb.handler will not log this successful reload 
+	                 (neg .z.w)(`.wdb.handler;(y;1b;`$"successfully reloaded")); (neg .z.w)[]};d;ptype);h;ptype];       
 		 @[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e]}[ptype]]
         ];
         .lg.o[`reload;string[ptype]," reload has finished"];

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -384,14 +384,14 @@ reloadproc:{[h;d;ptype]
         sendfunc:{[x;y;ptype].[{neg[y]@x};(x;y);{[ptype;x].lg.e[`reloadproc;"failed to reload the ",string[ptype]];'x}[ptype]]};
         /-reload function sent to processes by sendfunc in order to call process to reload. If process fail to reload log error 
         /-and call .wdb.handler with failed reload message. If reload is successful call .wdb.handler with successful reload message.
-        reloadfunc:{[d;ptype] r:@[`. `reload;d;{.lg.e[`reloadproc;"failed to reload from .wdb.reloadproc call. The error was : ",x];x}];
-                (neg .z.w)(`.wdb.handler;(ptype;10h<>type r;$[10h~type r;`$"reload failed with error ",r;`$"reloaded successfully"]));(neg .z.w)[]};
+        reloadfunc:{[d;ptype] r:@[{(1b;`. `reload x)};d;{.lg.e[`reloadproc;"failed to reload from .wdb.reloadproc call. The error was : ",x];(0b;x)}];
+                (neg .z.w)(`.wdb.handler;(ptype;first r;$[first r;`$"reloaded successfully";`$"reload failed with error ",last r]));(neg .z.w)[]};
         /-reload function to be executed if eodwaitime = 0 - sync message processes to reload and log if reload was successful or failed
-        syncreloadfunc:{[h;d;ptype] r:@[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],". The error was : ",e];e}[ptype]];
-                .lg.o[`reloadproc;"the ", string[ptype]," ", $[10h~type r; "failed to reload with error ",r;"successfully reloaded"]]}; 
+        syncreloadfunc:{[h;d;ptype] r:@[h;({(1b;`reload x)};d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],". The error was : ",e];(0b;e)}[ptype]];
+                .lg.o[`reloadproc;"the ", string[ptype]," ", $[first r; "successfully reloaded"; "failed to reload with error ",last r]]}; 
+        .lg.o[`reloadproc;"sending reload call to ", string[ptype]];
         $[eodwaittime>0;
-                 (.lg.o[`reloadproc;"reload call has been sent to ", string[ptype]];
-                         sendfunc[(reloadfunc;d;ptype);h;ptype]);     
+                 sendfunc[(reloadfunc;d;ptype);h;ptype];     
 		 syncreloadfunc[h;d;ptype]
         ];
         }

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -374,7 +374,8 @@ endofdaysort:{[dir;pt;tablist;writedownmode;mergelimits;hdbsettings]
 reloadproc:{[h;d;ptype]
 	.wdb.countreload:count[raze .servers.getservers[`proctype;;()!();1b;0b]each reloadorder];
 	$[eodwaittime>0;
-		{[x;y;ptype].[{neg[y]@x};(x;y);{[ptype;x].lg.e[`reloadproc;"failed to reload the ",string[ptype]];'x}[ptype]]}[({@[`. `reload;x;()]; (neg .z.w)(`.wdb.handler;1b); (neg .z.w)[]};d);h;ptype];
+		{[x;y;ptype].[{neg[y]@x};(x;y);{[ptype;x].lg.e[`reloadproc;"failed to reload the ",string[ptype]];'x}[ptype]]}
+		 [({@[`. `reload;x;{.lg.e[`reloadproc;"failed to reload from .wdb.reloadproc call. The error was : ",x]}]; (neg .z.w)(`.wdb.handler;1b); (neg .z.w)[]};d);h;ptype];
 		@[h;(`reload;d);{[ptype;e] .lg.e[`reloadproc;"failed to reload the ",string[ptype],".  The error was : ",e]}[ptype]]
 	];
 	.lg.o[`reload;"the ",string[ptype]," has been successfully reloaded"];


### PR DESCRIPTION
Catch and log error if async callback reload fails (when .wdb.eodwaittime>0).
Once .wdb.reloadproc has been called for each process add summary logging to log the number of processes which have successfully reloaded.