### PR TITLE
 ensure sym has grouped attribute for schema returned to new subscriber

### DIFF
--- a/code/common/html.q
+++ b/code/common/html.q
@@ -35,7 +35,7 @@ sel:{[x;y] x}
 // Apply the modifier before sending the data
 pub:{[t;x]{[t;x;w]if[count x:sel[x]w 1;(neg first w) modifier[t]@(`upd;t;x)]}[t;x]each w t}
 
-add:{$[(count w x)>i:w[x;;0]?.z.w;.[`.u.w;(x;i;1);union;y];w[x],:enlist(.z.w;y)];(x;$[99=type v:value x;sel[v]y;0#v])}
+add:{$[(count w x)>i:w[x;;0]?.z.w;.[`.u.w;(x;i;1);union;y];w[x],:enlist(.z.w;y)];(x;$[99=type v:value x;sel[v]y;@[0#v;`sym;`g#]])}
 
 sub:{if[x~`;:sub[;y]each t];if[not x in t;'x];del[x].z.w;add[x;y]}
 // add wssub method - have to subscribe to everything, don't return anything

--- a/code/common/u.q
+++ b/code/common/u.q
@@ -13,7 +13,7 @@ sel:{$[`~y;x;select from x where sym in y]}
 
 pub:{[t;x]{[t;x;w]if[count x:sel[x]w 1;(neg first w)(`upd;t;x)]}[t;x]each w t}
 
-add:{$[(count w x)>i:w[x;;0]?.z.w;.[`.u.w;(x;i;1);union;y];w[x],:enlist(.z.w;y)];(x;$[99=type v:value x;sel[v]y;0#v])}
+add:{$[(count w x)>i:w[x;;0]?.z.w;.[`.u.w;(x;i;1);union;y];w[x],:enlist(.z.w;y)];(x;$[99=type v:value x;sel[v]y;@[0#v;`sym;`g#]])}
 
 sub:{if[x~`;:sub[;y]each t];if[not x in t;'x];del[x].z.w;add[x;y]}
 


### PR DESCRIPTION
When subscription happens via .u.sub, the tickerplant passes back schema via .u.add. There is no issue with this in standard mode, but in batch mode there is a chance the table argument (x) to .u.add is not empty. In the case of x not being empty the schema returned will be missing attributes, i.e. sym column will be missing the grouped attribute. 