### PR TITLE
Fix for .dqc.rangechk function

### DIFF
--- a/code/dqc/rangechk.q
+++ b/code/dqc/rangechk.q
@@ -8,8 +8,8 @@ rangechk:{[tn;colslist;tlower;tupper;thres]
   tab:get tn;
   if[1<>sum differ count each (tab;tupper;tlower);
     :(0b; "ERROR: Input tables are different lengths.")
-    ]
-  if[any any tupper<tlower;:(0b;"ERROR: tlower and tupper wrong way round.")]
+    ];
+  if[any any tupper<tlower;:(0b;"ERROR: tlower and tupper wrong way round.")];
   /- exclude columns that do not have pre-defined limits
   colslist:((),colslist) except exec c from meta tab where t in "csSC ";
   tupper:colslist#tupper;


### PR DESCRIPTION
Found this when fixing up dqe tests. **Here's the problem:**
If statements that execute an early escape were missing a semi-colon so the line that was meant to be returned ran on to the next line of code.  For instance if tables being compared are different lengths this error message should be returned ```0b;"ERROR: tlower and tupper wrong way round."```
but it actually throws a length error as the next if statement is attempting to execute.
**What's been added:**
Semi-colons at end of if statements 