### PR TITLE
Tcs 112 combining all configuration for segmenting into one table in the stp and update any functions that previously read from the multiple tables to run of one table

### DIFF
--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -234,7 +234,4 @@ $[.rdb.connectonstart;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];
 
 //Updating .rdb.subtables to only include tables that actually subscribed
-//if[.ds.datastripe;
-//  .rdb.subtables:.rdb.subtables[where 98h=type each value each .rdb.subtables];
-//  ];
 .rdb.subtables:$[.ds.datastripe;tables[] except `heartbeat;.rdb.subtables];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -234,6 +234,7 @@ $[.rdb.connectonstart;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];
 
 //Updating .rdb.subtables to only include tables that actually subscribed
-if[.ds.datastripe;
-  .rdb.subtables:.rdb.subtables[where 98h=type each value each .rdb.subtables];
-  ];
+//if[.ds.datastripe;
+//  .rdb.subtables:.rdb.subtables[where 98h=type each value each .rdb.subtables];
+//  ];
+.rdb.subtables:$[.ds.datastripe;tables[] except `heartbeat;.rdb.subtables];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -232,3 +232,8 @@ $[.rdb.connectonstart;
 /-GMT offset rounded to nearest 15 mins and added to roll time
 .timer.repeat[.eodtime.nextroll-00:01+{00:01*15*"j"$(`minute$x)%15}(.proc.cp[]-.z.p);0W;1D;
   (`.rdb.timeoutreset;`);"Set rdb timeout to 0 for EOD writedown"];
+
+//Updating .rdb.subtables to only include tables that actually subscribed
+if[.ds.datastripe;
+  .rdb.subtables:.rdb.subtables[where 98h=type each value each .rdb.subtables];
+  ];

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -6,11 +6,11 @@
 
 configload:{
      scpath:first .proc.getconfigfile[string .ds.stripeconfig];
-     {if[()~key hsym x;.lg.e[`init;"The following file can not be found: ",string scpath]]};
-     .stpps.stripeconfig:.j.k raze read0 scpath;
+     if[()~key hsym scpath;.lg.e[`init;"The qollowing file can not be found: ",string scpath]];
+     .stpps.stripeconfig:.j.k read1 scpath;
      defaults:{first (flip .stpps.stripeconfig[x])[`subscriptiondefault]}each key .stpps.stripeconfig;
      errors:1+ where {[x] not ("ignore"~x) or ("all"~x)}each defaults;
-     {if[0<count errors;.lg.e[`sub;m:"subscriptiondefault not defined for segment/segments ",string[x]," "]]}each errors;
+     {if[0<count x;.lg.e[`sub;m:"subscriptiondefault not defined as \"ignore\" or \"all\" for segment ",string[x]," "]]}each errors;
      };
 
 initdatastripe:{
@@ -22,11 +22,9 @@ initdatastripe:{
 \d .stpps
 
 //makes a dictionary of tables and there filters for segmentedsubdetails
-
 filtermap:{[tabs;id] if[tabs~`;tabs:.stpps.t]; ((),tabs)!.stpps.segmentfilter\:[(),tabs;id]}
 
 //grabs filters from the config files and for the "ignoretable" filter converts to "" to allow segmentedsudetails to run
-
 segmentfilter:{[tbl;segid]
      id:`$string segid;
      filter:first (flip .stpps.stripeconfig[id])[tbl];
@@ -45,19 +43,18 @@ subsegment:{[tbl;segid];
      if[tbl~`;:.z.s[;segid] each .stpps.t];
      stripedtables:inter [key flip .stpps.stripeconfig[id];.stpps.t];
 //if the defualt is "all" tables not mentioned in striping.json will be subscribed unfiltered
-     if[default~"all";suballtabs: except[.stpps.t;stripedtables];
+     if[default~"all";suballtabs: .stpps.t except stripedtables;
      .lg.o[`sub;m:"Table ",string[tbl]," is to be subscribed unfiltered for segment ",string[segid],""]];
 //if default is ignore creates a list to of tables to ignore
-     if[default~"ignore"; ignoredtables: except[.stpps.t;stripedtables]];
+     if[default~"ignore"; ignoredtables: .stpps.t except stripedtables];
      filter:.stpps.segmentfilter[tbl;segid];
 //for case when filter is "ignoretable" adds that table to ignoredtables list
      if[(first (flip .stpps.stripeconfig[id])[tbl])~"ignoretable";ignoredtables:ignoredtables,tbl];
      if[tbl in ignoredtables;
       .lg.o[`sub;m:"Table ",string[tbl]," is to be ignored for segment ",string[segid],""];
- :()];
+      :()];
      .ps.subtablefiltered[string[tbl];filter;""]
      };
-
 
 \d .
 

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -1,5 +1,8 @@
+//Allows config file to be overwritten in process.csv
+
 .ds.stripeconfig:@[value;`.ds.stripeconfig;`striping.json];
 
+//Loads the striping.json config file checks if each subscriptiondefault is set for each segment and errors if not defined
 
 configload:{
      scpath:first .proc.getconfigfile[string .ds.stripeconfig];
@@ -18,25 +21,37 @@ initdatastripe:{
 
 \d .stpps
 
+//makes a dictionary of tables and there filters for segmentedsubdetails
+
 filtermap:{[tabs;id] if[tabs~`;tabs:.stpps.t]; ((),tabs)!.stpps.segmentfilter\:[(),tabs;id]}
+
+//grabs filters from the config files and for the "ignoretable" filter converts to "" to allow segmentedsudetails to run
 
 segmentfilter:{[tbl;segid]
      id:`$string segid;
-     first (flip .stpps.stripeconfig[id])[tbl]
+     filter:first (flip .stpps.stripeconfig[id])[tbl];
+     $[filter~"ignoretable";filter:"";filter]
      };
 
+//subscribe to a table using segmentID to determine filtering
 subsegment:{[tbl;segid];
-     //casting segid to an symbol as json is restrictive
+//casting segid to an symbol as json is restrictive
      id:`$string segid;
-     //setting the default for non-configured tables
-     default:first (flip .stpps.stripeconfig[id])[`subscriptiondefault];
+     if[not (id in (key .stpps.stripeconfig));
+       .lg.e[`sub;m:"Segment ",string[segid]," is not defined in striping.json"];:()];
+     ignoredtables:`$();
+//setting the default for non-configured tables
+     default:.stpps.segmentfilter[`subscriptiondefault;segid];
      if[tbl~`;:.z.s[;segid] each .stpps.t];
      stripedtables:inter [key flip .stpps.stripeconfig[id];.stpps.t];
+//if the defualt is "all" tables not mentioned in striping.json will be subscribed unfiltered
      if[default~"all";suballtabs: except[.stpps.t;stripedtables];
      .lg.o[`sub;m:"Table ",string[tbl]," is to be subscribed unfiltered for segment ",string[segid],""]];
+//if default is ignore creates a list to of tables to ignore
      if[default~"ignore"; ignoredtables: except[.stpps.t;stripedtables]];
-     filter:first (flip .stpps.stripeconfig[id])[tbl];
-     if[filter~"ignoredtable";ignoredtables:tbl];
+     filter:.stpps.segmentfilter[tbl;segid];
+//for case when filter is "ignoretable" adds that table to ignoredtables list
+     if[(first (flip .stpps.stripeconfig[id])[tbl])~"ignoretable";ignoredtables:ignoredtables,tbl];
      if[tbl in ignoredtables;
       .lg.o[`sub;m:"Table ",string[tbl]," is to be ignored for segment ",string[segid],""];
  :()];

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -18,20 +18,21 @@ initdatastripe:{
 filtermap:{[tabs;id] if[tabs~`;tabs:.stpps.t]; ((),tabs)!.stpps.segmentfilter\:[(),tabs;id]}
 
 segmentfilter:{[tbl;segid]
-     segid:`$string segid;
-     (flip .stpps.stripeconfig[segid])[tbl]
+     id:`$string segid;
+     first (flip .stpps.stripeconfig[id])[tbl]
      };
 
 subsegment:{[tbl;segid];
      //casting segid to an symbol as json is restrictive
-     segid:`$string segid;
+     id:`$string segid;
      //setting the default for non-configured tables
-     default:first (flip .stpps.stripeconfig[segid])[`subscriptiondefault];
+     default:first (flip .stpps.stripeconfig[id])[`subscriptiondefault];
      if[tbl~`;:.z.s[;segid] each .stpps.t];
-     stripedtables:inter [key flip .stpps.stripeconfig[segid];.stpps.t];
+     stripedtables:inter [key flip .stpps.stripeconfig[id];.stpps.t];
      if[default~"all";suballtabs: except[.stpps.t;stripedtables]];
      if[default~"ignore"; ignoredtables: except[.stpps.t;stripedtables]];
-     filter:first (flip .stpps.stripeconfig[segid])[tbl];
+     filter:first (flip .stpps.stripeconfig[id])[tbl];
+     if[filter~"ignore this table";ignoredtables:tbl]
      if[tbl in ignoredtables; :()];
      .ps.subtablefiltered[string[tbl];filter;""]
      };

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -1,24 +1,10 @@
-//configload loads configurable .csv files into memory so relevant filters can be applied to data.
-//loads segmenting.csv which defines how many segments there will be.
-//loads filtermap.csv which defines what filters should be applied to each segment.
+.ds.stripeconfig:@[value;`.ds.stripeconfig;`striping.json];
 
-//.ds.segmentconfig/segmentfiltermap are variables which can take different csv files. These files can be chosen on in process.csv.
-//error trap these .ds variables incase this file is loaded stand alone.
-
-.ds.segmentconfig:@[value;`.ds.segmentconfig;`segmenting.csv];
-.ds.filtermap:@[value;`.ds.filtermap;`filtermap.csv];
-
-//if statement checks segmenting.csv and filtermap.csv exist. If not, process exited and message sent to error logs.
-//configload transfoms segmenting.csv into table format so it can be accessed.
-//configload transforms filtermap.csv into table format then into a mapping of wcRef to filter which can be accessed and applied to data.
-//checks csv files load correctly. If not, process exited and message sent to error logs.
 
 configload:{
-     scpath:first .proc.getconfigfile[string .ds.segmentconfig];
-     fmpath:first .proc.getconfigfile[string .ds.filtermap];
-     {if[()~key hsym x;.lg.e[`init;"The following file can not be found: ",string x]]} each (scpath;fmpath);
-     @[{.stpps.segmentconfig:("SIS";enlist",")0: hsym x};scpath;{.lg.e[`init;"Failure in loading ",string y]}[;scpath]];
-     @[{.stpps.segmentfiltermap:(!/)(("S*";enlist",")0: hsym x)`wcRef`filter};fmpath;{.lg.e[`init;"Failure in loading ",string y]}[;fmpath]];
+     scpath:first .proc.getconfigfile[string .ds.stripeconfig];
+     {if[()~key hsym x;.lg.e[`init;"The following file can not be found: ",string scpath]]};
+     .stpps.stripeconfig:.j.k raze read0 scpath;
      };
 
 initdatastripe:{
@@ -26,46 +12,45 @@ initdatastripe:{
      configload[];
      };
 
+
 \d .stpps
 
-// Function to map the where clause from config table extracted by .stpps.segmentfilter function to tablename
-// Allows use of ` as argument for tables
-filtermap:{[tabs;id] if[tabs~`;tabs:.stpps.t]; ((),tabs)!.stpps.segmentfilter\:[(),tabs;id]}
-
-// Find where clause from config tables
-segmentfilter:{[tbl;segid]
-     wcref:first exec wcRef from .stpps.segmentconfig where table=tbl , segmentID=segid;
-     .stpps.segmentfiltermap[wcref]
+substripe:{[tbl;segid];
+     //casting segid to an symbol as json is restrictive
+     segid:`$string segid;
+     //setting the default non-configured table
+     default:first (flip .stpps.stripeconfig[segid])[`subscriptiondefault];
+     if[default~"ignore";.stpps.substripeignore[tbl;segid]];
+     if[default~"all";.stpps.substripeall[tbl;segid]];
+//     if[default~"all except list";.stpps.substripeignorelisted[tbl;segid]];
      };
 
-// Subscribe to particular segment using segmentID based on .u.sub
-subsegment:{[tbl;segid];
-     //tablename and segmentid used to get filters
+substripeignore:{[tbl;segid]
      if[tbl~`;:.z.s[;segid] each .stpps.t];
-     if[not tbl in .stpps.t;
-          .lg.e[`sub;m:"Table ",string[tbl]," not in list of stp pub/sub tables"];
-          :();
-     ];
-     filter:segmentfilter[tbl;segid];
-     if[filter~"";
-          .lg.e[`sub;m:"Incorrect pairing of table ",string[tbl]," and segmentID ",string[segid]," not found in .stpps.segmentconfig"];
-          :();
-     ];
-     
-     .ps.subtablefiltered[string[tbl];filter;""]
+     stripedtables:inter [key flip .stpps.stripeconfig[segid];.stpps.t];
+     filter:first (flip .stpps.stripeconfig[segid])[tbl];
+     if[tbl in stripedtables;.ps.subtablefiltered[string[tbl];filter;""]]
+     };
+
+substripeall:{[tbl;segid]
+     if[tbl~`;:.z.s[;segid] each .stpps.t];
+     stripedtables:inter [key flip .stpps.stripeconfig[segid];.stpps.t];
+     filter:first (flip .stpps.stripeconfig[segid])[tbl];
+     ignoredtables:`$();
+     if[filter~"ignore this table";stripedtables:stripedtables where stripedtables<>tbl;ignoredtables:ignoredtables,tbl];
+     if[tbl in stripedtables;.ps.subtablefiltered[string[tbl];filter;""]];
+     if[&[not(tbl in stripedtables);not(tbl in ignoredtables)];.stpps.suball[tbl]]
      };
 
 \d .
 
 // the subdetails function adapted to also retrieve filters from the segmented tickerplant
 segmentedsubdetails: {[tabs;instruments;segid] (!). flip 2 cut (
-     `schemalist ; .stpps.subsegment\:[tabs;segid];                                 
+     `schemalist ; .stpps.substripe\:[tabs;segid];                                 
      `logfilelist ; .stplg.replaylog[tabs];                                         
      `rowcounts ; ((),tabs)#.stplg `rowcount;	                                              
      `date ; (.eodtime `d);                                                         
-     `logdir ; `$getenv`KDBTPLOG;                                                   
-     `filters ; .stpps.filtermap[tabs;segid]
+     `logdir ; `$getenv`KDBTPLOG                                                   
 	)}
-        
-if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];
 
+if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -5,6 +5,9 @@ configload:{
      scpath:first .proc.getconfigfile[string .ds.stripeconfig];
      {if[()~key hsym x;.lg.e[`init;"The following file can not be found: ",string scpath]]};
      .stpps.stripeconfig:.j.k raze read0 scpath;
+     defaults:{first (flip .stpps.stripeconfig[x])[`subscriptiondefault]}each key .stpps.stripeconfig;
+     errors:1+ where {[x] not ("ignore"~x) or ("all"~x)}each defaults;
+     {if[0<count errors;.lg.e[`sub;m:"subscriptiondefault not defined for segment/segments ",string[x]," "]]}each errors;
      };
 
 initdatastripe:{
@@ -29,11 +32,14 @@ subsegment:{[tbl;segid];
      default:first (flip .stpps.stripeconfig[id])[`subscriptiondefault];
      if[tbl~`;:.z.s[;segid] each .stpps.t];
      stripedtables:inter [key flip .stpps.stripeconfig[id];.stpps.t];
-     if[default~"all";suballtabs: except[.stpps.t;stripedtables]];
+     if[default~"all";suballtabs: except[.stpps.t;stripedtables];
+     .lg.o[`sub;m:"Table ",string[tbl]," is to be subscribed unfiltered for segment ",string[segid],""]];
      if[default~"ignore"; ignoredtables: except[.stpps.t;stripedtables]];
      filter:first (flip .stpps.stripeconfig[id])[tbl];
-     if[filter~"ignore this table";ignoredtables:tbl]
-     if[tbl in ignoredtables; :()];
+     if[filter~"ignoredtable";ignoredtables:tbl];
+     if[tbl in ignoredtables;
+      .lg.o[`sub;m:"Table ",string[tbl]," is to be ignored for segment ",string[segid],""];
+ :()];
      .ps.subtablefiltered[string[tbl];filter;""]
      };
 

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -15,7 +15,7 @@ initdatastripe:{
 
 \d .stpps
 
-substripe:{[tbl;segid];
+subsegment:{[tbl;segid];
      //casting segid to an symbol as json is restrictive
      segid:`$string segid;
      //setting the default for non-configured tables
@@ -34,11 +34,11 @@ substripe:{[tbl;segid];
 
 // the subdetails function adapted to also retrieve filters from the segmented tickerplant
 segmentedsubdetails: {[tabs;instruments;segid] (!). flip 2 cut (
-     `schemalist ; .stpps.substripe\:[tabs;segid];                                 
+     `schemalist ; .stpps.subsegment\:[tabs;segid];                                 
      `logfilelist ; .stplg.replaylog[tabs];                                         
      `rowcounts ; ((),tabs)#.stplg `rowcount;	                                              
      `date ; (.eodtime `d);                                                         
      `logdir ; `$getenv`KDBTPLOG
-	)};
+	)}
 
 if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -15,6 +15,13 @@ initdatastripe:{
 
 \d .stpps
 
+filtermap:{[tabs;id] if[tabs~`;tabs:.stpps.t]; ((),tabs)!.stpps.segmentfilter\:[(),tabs;id]}
+
+segmentfilter:{[tbl;segid]
+     segid:`$string segid;
+     (flip .stpps.stripeconfig[segid])[tbl]
+     };
+
 subsegment:{[tbl;segid];
      //casting segid to an symbol as json is restrictive
      segid:`$string segid;
@@ -38,7 +45,8 @@ segmentedsubdetails: {[tabs;instruments;segid] (!). flip 2 cut (
      `logfilelist ; .stplg.replaylog[tabs];                                         
      `rowcounts ; ((),tabs)#.stplg `rowcount;	                                              
      `date ; (.eodtime `d);                                                         
-     `logdir ; `$getenv`KDBTPLOG
+     `logdir ; `$getenv`KDBTPLOG;
+     `filters ; .stpps.filtermap[tabs;segid]
 	)}
 
 if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -18,29 +18,17 @@ initdatastripe:{
 substripe:{[tbl;segid];
      //casting segid to an symbol as json is restrictive
      segid:`$string segid;
-     //setting the default non-configured table
+     //setting the default for non-configured tables
      default:first (flip .stpps.stripeconfig[segid])[`subscriptiondefault];
-     if[default~"ignore";.stpps.substripeignore[tbl;segid]];
-     if[default~"all";.stpps.substripeall[tbl;segid]];
-//     if[default~"all except list";.stpps.substripeignorelisted[tbl;segid]];
-     };
-
-substripeignore:{[tbl;segid]
      if[tbl~`;:.z.s[;segid] each .stpps.t];
      stripedtables:inter [key flip .stpps.stripeconfig[segid];.stpps.t];
+     if[default~"all";suballtabs: except[.stpps.t;stripedtables]];
+     if[default~"ignore"; ignoredtables: except[.stpps.t;stripedtables]];
      filter:first (flip .stpps.stripeconfig[segid])[tbl];
-     if[tbl in stripedtables;.ps.subtablefiltered[string[tbl];filter;""]]
+     if[tbl in ignoredtables; :()];
+     .ps.subtablefiltered[string[tbl];filter;""]
      };
 
-substripeall:{[tbl;segid]
-     if[tbl~`;:.z.s[;segid] each .stpps.t];
-     stripedtables:inter [key flip .stpps.stripeconfig[segid];.stpps.t];
-     filter:first (flip .stpps.stripeconfig[segid])[tbl];
-     ignoredtables:`$();
-     if[filter~"ignore this table";stripedtables:stripedtables where stripedtables<>tbl;ignoredtables:ignoredtables,tbl];
-     if[tbl in stripedtables;.ps.subtablefiltered[string[tbl];filter;""]];
-     if[&[not(tbl in stripedtables);not(tbl in ignoredtables)];.stpps.suball[tbl]]
-     };
 
 \d .
 
@@ -50,7 +38,7 @@ segmentedsubdetails: {[tabs;instruments;segid] (!). flip 2 cut (
      `logfilelist ; .stplg.replaylog[tabs];                                         
      `rowcounts ; ((),tabs)#.stplg `rowcount;	                                              
      `date ; (.eodtime `d);                                                         
-     `logdir ; `$getenv`KDBTPLOG                                                   
-	)}
+     `logdir ; `$getenv`KDBTPLOG
+	)};
 
 if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -38,10 +38,11 @@ subsegment:{[tbl;segid];
      //setting the default for non-configured tables
      default:.stpps.segmentfilter[`subscriptiondefault;segid];
      if[tbl~`;:.z.s[;segid] each .stpps.t];
-     stripedtables:inter [key flip .stpps.stripeconfig[id];.stpps.t];
+     stripedtables:.stpps.t inter key flip .stpps.stripeconfig[id];
      //if the defualt is "all" tables not mentioned in striping.json will be subscribed unfiltered
      if[default~"all";suballtabs: .stpps.t except stripedtables;
-     .lg.o[`sub;m:"Table ",string[tbl]," is to be subscribed unfiltered for segment ",string[segid],""]];
+       if[tbl in suballtabs;
+          .lg.o[`sub;m:"Table ",string[tbl]," is to be subscribed unfiltered for segment ",string[segid],""]]];
      //if default is ignore creates a list to of tables to ignore
      if[default~"ignore"; ignoredtables: .stpps.t except stripedtables];
      filter:.stpps.segmentfilter[tbl;segid];

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -1,12 +1,10 @@
 //Allows config file to be overwritten in process.csv
-
 .ds.stripeconfig:@[value;`.ds.stripeconfig;`striping.json];
 
 //Loads the striping.json config file checks if each subscriptiondefault is set for each segment and errors if not defined
-
 configload:{
      scpath:first .proc.getconfigfile[string .ds.stripeconfig];
-     if[()~key hsym scpath;.lg.e[`init;"The qollowing file can not be found: ",string scpath]];
+     if[()~key hsym scpath;.lg.e[`init;"The following file can not be found: ",string scpath]];
      .stpps.stripeconfig:.j.k read1 scpath;
      defaults:{first (flip .stpps.stripeconfig[x])[`subscriptiondefault]}each key .stpps.stripeconfig;
      errors:1+ where {[x] not ("ignore"~x) or ("all"~x)}each defaults;
@@ -18,10 +16,9 @@ initdatastripe:{
      configload[];
      };
 
-
 \d .stpps
 
-//makes a dictionary of tables and there filters for segmentedsubdetails
+//makes a dictionary of tables and their filters for segmentedsubdetails
 filtermap:{[tabs;id] if[tabs~`;tabs:.stpps.t]; ((),tabs)!.stpps.segmentfilter\:[(),tabs;id]}
 
 //grabs filters from the config files and for the "ignoretable" filter converts to "" to allow segmentedsudetails to run
@@ -38,17 +35,17 @@ subsegment:{[tbl;segid];
      if[not (id in (key .stpps.stripeconfig));
        .lg.e[`sub;m:"Segment ",string[segid]," is not defined in striping.json"];:()];
      ignoredtables:`$();
-//setting the default for non-configured tables
+     //setting the default for non-configured tables
      default:.stpps.segmentfilter[`subscriptiondefault;segid];
      if[tbl~`;:.z.s[;segid] each .stpps.t];
      stripedtables:inter [key flip .stpps.stripeconfig[id];.stpps.t];
-//if the defualt is "all" tables not mentioned in striping.json will be subscribed unfiltered
+     //if the defualt is "all" tables not mentioned in striping.json will be subscribed unfiltered
      if[default~"all";suballtabs: .stpps.t except stripedtables;
      .lg.o[`sub;m:"Table ",string[tbl]," is to be subscribed unfiltered for segment ",string[segid],""]];
-//if default is ignore creates a list to of tables to ignore
+     //if default is ignore creates a list to of tables to ignore
      if[default~"ignore"; ignoredtables: .stpps.t except stripedtables];
      filter:.stpps.segmentfilter[tbl;segid];
-//for case when filter is "ignoretable" adds that table to ignoredtables list
+     //for case when filter is "ignoretable" adds that table to ignoredtables list
      if[(first (flip .stpps.stripeconfig[id])[tbl])~"ignoretable";ignoredtables:ignoredtables,tbl];
      if[tbl in ignoredtables;
       .lg.o[`sub;m:"Table ",string[tbl]," is to be ignored for segment ",string[segid],""];

--- a/config/filtermap.csv
+++ b/config/filtermap.csv
@@ -1,1 +1,0 @@
-wcRef,filter

--- a/config/segmenting.csv
+++ b/config/segmenting.csv
@@ -1,1 +1,0 @@
-table,segmentID,wcRef

--- a/config/striping.json
+++ b/config/striping.json
@@ -1,0 +1,36 @@
+{
+    "1": [
+        {
+            "subscriptiondefault": "ignore" ,
+            "trade": "" ,
+	    "quote": "sym in `AAPL" ,
+	    "logmsg": "" ,
+	    "packets": "" 
+	    
+        }
+    ],
+
+    "2": [
+        {
+            "subscriptiondefault": "all" ,
+            "quote": "sym in `AAPL" 
+
+        }
+    ],
+
+    "3": [
+	{
+	    "subscriptiondefault": "ignore" ,
+	    "quote": "ex=\"O\""
+
+	}
+    ],
+
+    "4": [
+	{ 
+	    "subscriptiondefault": "all",
+	    "trade": "ignore this table"
+
+	}
+    ]	
+}

--- a/config/striping.json
+++ b/config/striping.json
@@ -12,16 +12,16 @@
 
     "2": [
         {
-            "subscriptiondefault": "all" ,
-            "quote": "sym in `AAPL" 
+            "subscriptiondefault": "all",
+	    "quote": "sym in `AAPL" 
 
         }
     ],
 
     "3": [
 	{
-	    "subscriptiondefault": "ignore" ,
-	    "quote": "ex=\"O\""
+            "subscriptiondefault": "ignore",
+    	    "quote": "ex=\"O\""
 
 	}
     ],
@@ -29,7 +29,9 @@
     "4": [
 	{ 
 	    "subscriptiondefault": "all",
-	    "trade": "ignore this table"
+	    "trade": "ignoredtable",
+	    "quote": "sym in `MSFT"
+
 
 	}
     ]	

--- a/config/striping.json
+++ b/config/striping.json
@@ -1,38 +1,16 @@
 {
     "1": [
         {
-            "subscriptiondefault": "ignore" ,
-            "trade": "" ,
-	    "quote": "sym in `AAPL" ,
-	    "logmsg": "" ,
-	    "packets": "" 
+            "subscriptiondefault": "all" 
 	    
         }
     ],
 
     "2": [
         {
-            "subscriptiondefault": "all",
-	    "quote": "sym in `AAPL" 
+            "subscriptiondefault": "all"
 
         }
-    ],
+    ]
 
-    "3": [
-	{
-            "subscriptiondefault": "ignore",
-    	    "quote": "ex=\"O\""
-
-	}
-    ],
-
-    "4": [
-	{ 
-	    "subscriptiondefault": "all",
-	    "trade": "ignoredtable",
-	    "quote": "sym in `MSFT"
-
-
-	}
-    ]	
 }


### PR DESCRIPTION
added striping.json with two empty segments to show how the json is formatted
updated datastripe.q to work with the json
added loggin to configload in datastripe.q so that if subscriptiondefault is not defined or is defined as anything but "ignore" or "all" the tickerplant will error
when .ds.datastripe is enabled .rdb.subtables is updated to allow the reload function to run. This is only temporary fix until the root of problem is found
