### PR TITLE
Modified torq.sh to add functionality for when the csv flag is used. 

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -230,7 +230,13 @@ flagextras() {
 flagcsv() {
   flag "$*"
   CSVPATH="${BASH_ARGV[$N]}"                                                                        # assign specifed csv file
- }
+  if [ -f "$CSVPATH" ]; then
+          newproc=$(echo $CSVPATH | awk -F/ '{print $NF}')                                                  # find new process name from flagged file
+          currproc=$(cat $SETENV | grep TORQPROCESSES= | awk -F/ '{print $NF}')                             # find previous process name from setenv.sh
+          sed -i 's/'$currproc'/'$newproc'/g' $SETENV                                                       # replace new process with previous in setenv.sh
+          echo "Your process csv has been switched in setenv.sh to your specified csv file: ${newproc}"    # inform the user that their csv file has been changed
+  fi
+}
 
 getextras() {
   if [[ $(echo ${BASH_ARGV[*]} | grep -e extras) ]]; then                                            


### PR DESCRIPTION
The csv file will be checked for if the file exists and then the setenv.sh file is edited with the new process.csv file path. A edit message is then shown to the user. This is necessary as there is a new cloudprocess.csv available which is used for the TorQ Cloud project and they can be interchanged.