### PR TITLE
Add bug fix to .z.exit

### DIFF
--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -299,6 +299,7 @@ init:{[dbname]
 
 // Close logs on clean exit
 .z.exit:{
+  .proc.initialised:1b;
   if[not x~0i;.lg.e[`stpexit;"Bad exit!"];:()];
   .lg.o[`stpexit;"Exiting process"];
   // exit before logs are touched if process is an sctp NOT in create mode

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -299,6 +299,7 @@ init:{[dbname]
 
 // Close logs on clean exit
 .z.exit:{
+  // Set .proc.initialised to true, allows error messages to exit process on startup (stops infinite "Bad Exit!").
   .proc.initialised:1b;
   if[not x~0i;.lg.e[`stpexit;"Bad exit!"];:()];
   .lg.o[`stpexit;"Exiting process"];


### PR DESCRIPTION
There was an issue where on set up of a segmented tickerplant, if an error was thrown an infinite loop was caused. When an error was thown, .z.exit called another error, calling the exit function again.