### PR TITLE
Removed erroneous(?) call to .mformsoreservers.getservers[] in .wdb.informsortandreload[].

### DIFF
--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -424,7 +424,7 @@ informgateway:{[message]
 /- function to call that will cause sort & reload process to sort data and reload rdb and hdbs
 informsortandreload:{[dir;pt;tablist;writedownmode;mergelimits;hdbsettings]
 	.lg.o[`informsortandreload;"attempting to contact sort process to initiate data sort"];
-	$[count sortprocs:.mformsoreservers.getservers[`proctype;sorttypes;()!();1b;0b];
+	$[count sortprocs:.servers.getservers[`proctype;sorttypes;()!();1b;0b];
 		{.[{neg[y]@x;neg[y][]};(x;y);{.lg.e[`informsortandreload;"unable to run command on sort and reload process"];'x}]}[(`.wdb.endofdaysort;dir;pt;tablist;writedownmode;mergelimits;hdbsettings);] each exec w from sortprocs;
 		[.lg.e[`informsortandreload;"can't connect to the sortandreload - no sortandreload process detected"];
 		 // try to run the sort locally


### PR DESCRIPTION
Call in question has been replaced with `.servers.getservers[]`; should resolve `'.mformsoreservers.getservers` error reported when running functions such as `.wdb.endofday[]` in the wdb1 process.