### PR TITLE
Changing casting of segid 

### DIFF
--- a/code/common/datastripe.q
+++ b/code/common/datastripe.q
@@ -5,7 +5,6 @@
 
 // Casting segid to symbol to enable free naming of segments
 // segmentid taken from -segid process parameter
-  
 segmentid: `$.proc.params[`segid]
 
 deletetablebefore:{![x;enlist (<;y;z);0b;0#`]}

--- a/code/common/datastripe.q
+++ b/code/common/datastripe.q
@@ -4,7 +4,7 @@
 
 
 // Casting segid to symbol to enable free naming of segments
-// segmentid variable defined by applying key to dictionary of input values
+// segmentid taken from -segid process parameter
   
 segmentid: `$.proc.params[`segid]
 

--- a/code/common/datastripe.q
+++ b/code/common/datastripe.q
@@ -2,7 +2,6 @@
 
 \d .ds
 
-
 // Casting segid to symbol to enable free naming of segments
 // segmentid taken from -segid process parameter
 segmentid:`$.proc.params[`segid];

--- a/code/common/datastripe.q
+++ b/code/common/datastripe.q
@@ -2,7 +2,11 @@
 
 \d .ds
 
-segmentid: "J"$.proc.params[`segid]		// segmentid variable defined by applying key to dictionary of input values
+
+// Casting segid to symbol to enable free naming of segments
+// segmentid variable defined by applying key to dictionary of input values
+  
+segmentid: `$.proc.params[`segid]
 
 deletetablebefore:{![x;enlist (<;y;z);0b;0#`]}
 

--- a/code/common/datastripe.q
+++ b/code/common/datastripe.q
@@ -5,7 +5,7 @@
 
 // Casting segid to symbol to enable free naming of segments
 // segmentid taken from -segid process parameter
-segmentid: `$.proc.params[`segid]
+segmentid:`$.proc.params[`segid];
 
 deletetablebefore:{![x;enlist (<;y;z);0b;0#`]}
 


### PR DESCRIPTION
Changing casting of segid from long to symbol, allowing for better range of naming constructs 
