### PR TITLE
Tcs 118 extend rdb time window

### DIFF
--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -194,7 +194,6 @@ endofday:{[pt;processdata]
 		$[sortenabled;endofdaysort;informsortandreload] . (savedir;pt;tablist;writedownmode;mergelimits;hdbsettings)];
 	.lg.o[`eod;"deleting data from tabsizes"];
 	@[`.wdb;`tabsizes;0#];
-    // if[.ds.datastripe;.ds.resetrdbwindow[]];
     .lg.o[`eod;"end of day is now complete"];
     .wdb.currentpartition:pt+1;
 	};
@@ -222,6 +221,7 @@ flushend:{
 	 @[{neg[x]"";neg[x][]};;()] each key d;
 	 informgateway(`reloadend;`);
 	 .lg.o[`sort;"end of day sort is now complete"];
+         if[.ds.datastripe;resetrdbwindow[]];
 	 .wdb.reloadcomplete:1b];
 	};
 
@@ -286,6 +286,7 @@ reloadsymfile:{[symfilepath]
   @[load; symfilepath; {.lg.e[`sort;"failed to reload sym file: ",x]}]
  }
 
+/- notify rdb when tail sort process complete
 resetrdbwindow:{
     .lg.o[`rdbwindow;"resetting rdb moving time window"];
     rdbprocs:.servers.getservers[`proctype;.wdb.rdbtypes;()!();1b;0b];
@@ -383,7 +384,6 @@ endofdaymerge:{[dir;pt;tablist;mergelimits;hdbsettings]
   if[permitreload; 
     doreload[pt];
     ];
-  if[.ds.datastripe;resetrdbwindow[]];
   };
 	
 /- end of day sort [depends on writedown mode]

--- a/code/rdb/datastripe.q
+++ b/code/rdb/datastripe.q
@@ -5,10 +5,12 @@
 
     t:tables[`.] except .rdb.ignorelist;
 
+    // check if tail sort process is complete
     if[.rdb.tailsortcomplete;.rdb.extendperiods:.ds.periodstokeep];
 
     // clear data from tables
     lasttime:nextp-.rdb.extendperiods*(nextp-currp);
+    // if eop occurs while tail sort in progress, extend number of periods kept in memory until tailsort complete
     tabs:$[.rdb.tailsortcomplete;.ds.deletetablebefore'[t;`time;lasttime];.rdb.extendperiods+:1];
     .lg.o[`reload;"Kept ",string[.rdb.extendperiods]," period",$[.rdb.extendperiods>1;"s";""]," of data from : ",", " sv string[t]];
 
@@ -18,6 +20,7 @@
 
     };
 
+// end of day function - no savedown functionality, just wipes tables and updates date partition
 .rdb.datastripeendofday:{[date;processdata]
     .rdb.tailsortcomplete:0b;
     // add date+1 to rdbpartition global

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -56,11 +56,6 @@ initdatastripe:{
 if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];
 
 \d .ds
-resetrdbwindow:{
-    .lg.o[`rdbwindow;"resetting moving rdb time window"];
-    rdbprocs:.servers.getservers[`proctype;.wdb.rdbtypes;()!();1b;0b];
-    {neg[x]".rdb.tailsortcomplete:1b";neg[x][]}each exec w from rdbprocs;
-    };
 
 upserttopartition:{[dir;tablename;keycol;enumdata;nextp]
     /- function takes a (dir)ectory handle, tablename as a symbol

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -56,6 +56,11 @@ initdatastripe:{
 if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];
 
 \d .ds
+resetrdbwindow:{
+    .lg.o[`rdbwindow;"resetting moving rdb time window"];
+    rdbprocs:.servers.getservers[`proctype;.wdb.rdbtypes;()!();1b;0b];
+    {neg[x]".rdb.tailsortcomplete:1b";neg[x][]}each exec w from rdbprocs;
+    };
 
 upserttopartition:{[dir;tablename;keycol;enumdata;nextp]
     /- function takes a (dir)ectory handle, tablename as a symbol


### PR DESCRIPTION
Increase the number of periods the rdb/datastore keeps in memory if the end of day tail sort process is still in progress when end of period occurs (tail sort process still to be created)

- [ ] update to work with tail sort process when created
- [ ] unit tests