### PR TITLE
Tcs 135 tailers save access to disc

### DIFF
--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -30,9 +30,7 @@ modaccess:{[accesstab]};
     .lg.o[`reload;"Kept ",string[.ds.periodstokeep]," period",$[.ds.periodstokeep>1;"s";""]," of data from : ",", " sv string[t]];
     
     // update the access table on disk
-    atab:get ` sv(.ds.td;.proc.procname;`access);
-    atab,:() xkey .wdb.access;
-    (` sv(.ds.td;.proc.procname;`access)) set atab;
+    (` sv(.ds.td;.proc.procname;`access)) set .wdb.access;
 
     };
 
@@ -49,8 +47,6 @@ initdatastripe:{
     modaccess[.wdb.access];
     .ds.checksegid[];
     (` sv(.ds.td;.proc.procname;`access)) set .wdb.access;
-    .wdb.access:{[x] last .wdb.access where .wdb.access[`table]=x} each t;
-    .wdb.access:`table xkey .wdb.access;
     };
 
 

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -43,7 +43,7 @@ initdatastripe:{
     t:tables[`.] except .wdb.ignorelist;
 
     // create or load the access table
-    .wdb.access: @[get;(` sv(.ds.td;.proc.procname;`access));([] table:t ; start:0Np ; end:0Np ; stptime:0Np ; keycol:`sym^.wdb.tablekeycols[t])];
+    .wdb.access: @[get;(` sv(.ds.td;.proc.procname;`access));([table:t] start:0Np ; end:0Np ; stptime:0Np ; keycol:`sym^.wdb.tablekeycols[t])];
     modaccess[.wdb.access];
     .ds.checksegid[];
     (` sv(.ds.td;.proc.procname;`access)) set .wdb.access;


### PR DESCRIPTION
- Access tables now saved to disc the same as they are in memory
- Removes need for keying and unkeying