### PR TITLE
Tcs 141 fix initiate data stripe not running

### DIFF
--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -236,5 +236,5 @@ $[.rdb.connectonstart;
 //Updating .rdb.subtables to only include tables that actually subscribed
 .rdb.subtables:$[.ds.datastripe;tables[] except `heartbeat;.rdb.subtables];
 
-//Initialise datastripe
+/- initialise datastripe
 if[.ds.datastripe;initdatastripe[];.lg.o[`dsinit;"datastripe on: initialising datastripe"]];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -235,3 +235,6 @@ $[.rdb.connectonstart;
 
 //Updating .rdb.subtables to only include tables that actually subscribed
 .rdb.subtables:$[.ds.datastripe;tables[] except `heartbeat;.rdb.subtables];
+
+//Initialise datastripe
+if[.ds.datastripe;initdatastripe[];.lg.o[`dsinit;"datastripe on: initialising datastripe"]];

--- a/code/processes/rdb.q
+++ b/code/processes/rdb.q
@@ -237,4 +237,6 @@ $[.rdb.connectonstart;
 .rdb.subtables:$[.ds.datastripe;tables[] except `heartbeat;.rdb.subtables];
 
 /- initialise datastripe
-if[.ds.datastripe;initdatastripe[];.lg.o[`dsinit;"datastripe on: initialising datastripe"]];
+if[.ds.datastripe;
+  .lg.o[`dsinit;"datastripe on: initialising datastripe"];
+  initdatastripe[]];

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -567,4 +567,6 @@ if[.wdb.saveenabled;.wdb.starttimer[]];
 upd:.wdb.upd
 
 /- initialise datastripe
-if[.ds.datastripe;initdatastripe[];.lg.o[`dsinit;"datastripe on: initialising datastripe"]];
+if[.ds.datastripe;
+  .lg.o[`dsinit;"datastripe on: initialising datastripe"];
+  initdatastripe[]];

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -565,3 +565,6 @@ if[.wdb.saveenabled;.wdb.starttimer[]];
 
 /- use the regular up after log replay
 upd:.wdb.upd
+
+/- initialise datastripe
+if[.ds.datastripe;initdatastripe[];.lg.o[`dsinit;"datastripe on: initialising datastripe"]];

--- a/code/rdb/datastripe.q
+++ b/code/rdb/datastripe.q
@@ -28,5 +28,4 @@ initdatastripe:{
     .ds.checksegid[];    
     };
 
-if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];
 

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -54,7 +54,6 @@ initdatastripe:{
     };
 
 
-if[.ds.datastripe;.proc.addinitlist[(`initdatastripe;`)]];
 
 \d .ds
 


### PR DESCRIPTION
- TCS-116 Changed .ds.datastripe default value to 0b for both wdb and rdb as datastriping should only be turned on if tickerplant is configured for datastriping
- This introduced an issue that meant the initdatastripe functions in the datastripe.q scripts of the rdb/wdb were never be run as .ds.datastripe was set to 1b when subscribing which was after the check in each of these scripts.
- rdb/wdb now call initdatastripe after subscribing if .ds.datastripe is on 
