### PR TITLE
Tcs 147 start time of access on disk not updating

### DIFF
--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -18,7 +18,11 @@ modaccess:{[accesstab]};
     // remove periods of data from tables
     t:tables[`.] except .wdb.ignorelist;
     lasttime:nextp-.ds.periodstokeep*(nextp-currp);
-
+    
+    // call the savedown function
+    .ds.savealltablesoverperiod[.ds.td;nextp;lasttime];
+    .lg.o[`reload;"Kept ",string[.ds.periodstokeep]," period",$[.ds.periodstokeep>1;"s";""]," of data from : ",", " sv string[t]];
+    
     // update the access table in the wdb
     // on first save down we need to replace the null valued start time in the access table
     // using the first value in the saved data
@@ -26,10 +30,6 @@ modaccess:{[accesstab]};
     .ds.access:update start:.ds.getstarttime each table, end:?[(nextp>starttimes)&(starttimes<>0Np);nextp;0Np], stptime:data[][`p] from .ds.access;
     modaccess[.ds.access];
 
-    // call the savedown function
-    .ds.savealltablesoverperiod[.ds.td;nextp;lasttime];
-    .lg.o[`reload;"Kept ",string[.ds.periodstokeep]," period",$[.ds.periodstokeep>1;"s";""]," of data from : ",", " sv string[t]];
-    
     // update the access table on disk
     atab:get ` sv(.ds.td;.proc.procname;`access);
     atab,:() xkey .ds.access;

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -23,7 +23,7 @@ modaccess:{[accesstab]};
     // on first save down we need to replace the null valued start time in the access table
     // using the first value in the saved data
     starttimes:.ds.getstarttime each t;
-    .ds.access:update start:starttimes^start, end:?[(nextp>starttimes)&(starttimes<>0Np);nextp;0Np], stptime:data[][`p] from .ds.access;
+    .ds.access:update start:.ds.getstarttime each table, end:?[(nextp>starttimes)&(starttimes<>0Np);nextp;0Np], stptime:data[][`p] from .ds.access;
     modaccess[.ds.access];
 
     // call the savedown function


### PR DESCRIPTION
- Start time of access table never updating as a ^ join was being used which would only update if it was null. This meant that the very first entry into the start time would be repeated forever
-  Once this was fixed, I realised that the timing for the start time did not quite match what was in memory in the tailer
- this was because the savedown of tables was being called after the access was updated, so the access was displaying times for data that no longer existed in memory, this has been amended 