### PR TITLE
TCS-144 - Change enumeration in the Tailer and create symlink to HDB sym file

### DIFF
--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -572,5 +572,5 @@ if[.ds.datastripe;
   initdatastripe[]];
 
 /- create HDB sym file and taildir symlink
-if[.ds.datastripe & not `sym in key .wdb.hdbdir;
+if[.ds.datastripe;
   .ds.symlink[]];

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -570,3 +570,7 @@ upd:.wdb.upd
 if[.ds.datastripe;
   .lg.o[`dsinit;"datastripe on: initialising datastripe"];
   initdatastripe[]];
+
+/- create HDB sym file and taildir symlink
+if[.ds.datastripe;
+  .ds.symlink[]];

--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -572,5 +572,5 @@ if[.ds.datastripe;
   initdatastripe[]];
 
 /- create HDB sym file and taildir symlink
-if[.ds.datastripe;
+if[.ds.datastripe & not `sym in key .wdb.hdbdir;
   .ds.symlink[]];

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -59,6 +59,19 @@ initdatastripe:{
 
 \d .ds
 
+symlink:{
+    /- function to create HDB sym file and symlink to this sym file at start up
+    /- create HDB sym file
+    symdir:`$raze string .wdb.hdbdir,"/sym";
+    if[not `sym in key .wdb.hdbdir;symdir set `symbol$()];
+    .lg.o[`hdbsym;"creating HDB symfile"];
+
+    /- create symlink
+    basedir:` sv .ds.td,.proc.procname;
+    createsymlink[basedir;.wdb.hdbdir;`sym];
+    .lg.o[`symlink;"creating symlink"];
+    };
+
 createsymlink:{[tdpath;hdbpath;symfile]
     /- function to create symlink to HDB sym file in taildir
     tdsympath:1_raze string tdpath,"/",symfile;

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -61,7 +61,7 @@ initdatastripe:{
 
 createsymlink:{[tdpath;hdbpath;symfile]
     /- function to create symlink to HDB sym file in taildir
-    tdsympath:1_raze string tdpath,"/",.proc.procname,"/",symfile;
+    tdsympath:1_raze string tdpath,"/",symfile;
     hdbsympath:1_raze string hdbpath,"/",symfile;
 
     /- linux command to create symlink in specified dirs
@@ -95,7 +95,7 @@ upserttopartition:{[dir;tablename;keycol;enumdata;nextp]
     ];
 
     /- check if sym file exists in taildir, create sym link to HDB sym file if not
-    if[not `sym in key hsym basedir;createsymlink[.ds.td;.wdb.hdbdir;`sym]];
+    if[not `sym in key hsym basedir;createsymlink[basedir;.wdb.hdbdir;`sym]];
     };
 
 savetablesoverperiod:{[dir;tablename;nextp;lasttime]

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -62,14 +62,14 @@ initdatastripe:{
 symlink:{
     /- function to create HDB sym file and symlink to this sym file at start up
     /- create HDB sym file
-    symdir:`$raze string .wdb.hdbdir,"/sym";
-    if[not `sym in key .wdb.hdbdir;symdir set `symbol$()];
-    .lg.o[`hdbsym;"creating HDB symfile"];
+    sympath:` sv (.wdb.hdbdir;`sym);
+    .lg.o[`hdbsym;"creating HDB sym file"];
+    if[not `sym in key .wdb.hdbdir;sympath set `symbol$()];
 
     /- create symlink
     basedir:` sv .ds.td,.proc.procname;
-    if[not `sym in key basedir;createsymlink[basedir;.wdb.hdbdir;`sym]];
     .lg.o[`symlink;"creating symlink"];
+    if[not `sym in key basedir;createsymlink[basedir;.wdb.hdbdir;`sym]];
     };
 
 createsymlink:{[tdpath;hdbpath;symfile]

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -65,7 +65,11 @@ createsymlink:{[tdpath;hdbpath;symfile]
     hdbsympath:1_raze string hdbpath,"/",symfile;
 
     /- linux command to create symlink in specified dirs
-    system"ln -s ",hdbsympath," ",tdsympath;
+    symlink:{system"ln -s ",x," ",y};
+    .[symlink;
+        (hdbsympath;tdsympath);
+        {[e] .lg.e[`createsymlink;"Failed to create symlink : ",e];e}
+    ];
     };
 
 upserttopartition:{[dir;tablename;keycol;enumdata;nextp]
@@ -94,7 +98,7 @@ upserttopartition:{[dir;tablename;keycol;enumdata;nextp]
         {[e] .lg.e[`upserttopartition;"Failed to save table to disk : ",e];'e}
     ];
 
-    /- check if sym file exists in taildir, create sym link to HDB sym file if not
+    /- check if sym file exists in taildir, create symlink to HDB sym file if not
     if[not `sym in key hsym basedir;createsymlink[basedir;.wdb.hdbdir;`sym]];
     };
 

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -78,7 +78,7 @@ upserttopartition:{[dir;tablename;keycol;enumdata;nextp]
 
     /- get process specific taildir location
     basedir:` sv dir,.proc.procname;
-    dir:` sv dir,.proc.procname,`$ string .wdb.currentpartition;
+    dir:` sv basedir,`$ string .wdb.currentpartition;
 
     /- get symbol enumeration
     partitionint:`$string (where s=value [`.]keycol)0;

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -68,7 +68,7 @@ symlink:{
 
     /- create symlink
     basedir:` sv .ds.td,.proc.procname;
-    createsymlink[basedir;.wdb.hdbdir;`sym];
+    if[not `sym in key basedir;createsymlink[basedir;.wdb.hdbdir;`sym]];
     .lg.o[`symlink;"creating symlink"];
     };
 

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -123,7 +123,8 @@ savetablesoverperiod:{[dir;tablename;nextp;lasttime]
     partitionlist: ?[tablename;();();(distinct;keycol)];
 
     /- enumerate and then split by keycol
-    enumkeycol: .Q.en[.wdb.hdbdir;?[tablename;enlist (<;`time;nextp);0b;()]];
+    symdir:` sv dir,.proc.procname;
+    enumkeycol: .Q.en[symdir;?[tablename;enlist (<;`time;nextp);0b;()]];
     splitkeycol: {[enumkeycol;keycol;s] ?[enumkeycol;enlist (=;keycol;enlist s);0b;()]}[enumkeycol;keycol;] each partitionlist;
 
     /-upsert table to partition

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -106,8 +106,7 @@ savetablesoverperiod:{[dir;tablename;nextp;lasttime]
     partitionlist: ?[tablename;();();(distinct;keycol)];
 
     /- enumerate and then split by keycol
-    symdir:.wdb.hdbdir;
-    enumkeycol: .Q.en[symdir;?[tablename;enlist (<;`time;nextp);0b;()]];
+    enumkeycol: .Q.en[.wdb.hdbdir;?[tablename;enlist (<;`time;nextp);0b;()]];
     splitkeycol: {[enumkeycol;keycol;s] ?[enumkeycol;enlist (=;keycol;enlist s);0b;()]}[enumkeycol;keycol;] each partitionlist;
 
     /-upsert table to partition

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -74,8 +74,8 @@ symlink:{
 
 createsymlink:{[tdpath;hdbpath;symfile]
     /- function to create symlink to HDB sym file in taildir
-    tdsympath:1_raze string tdpath,"/",symfile;
-    hdbsympath:1_raze string hdbpath,"/",symfile;
+    tdsympath:1_string ` sv (tdpath;symfile);
+    hdbsympath:1_string ` sv (hdbpath;symfile);
 
     /- linux command to create symlink in specified dirs
     symlink:{system"ln -s ",x," ",y};


### PR DESCRIPTION
Change to enumeration in tailer to enumerate data against HDB symfile, rather than creating a sym file specific to each tailer.
Checks tailer directories for symlink to HDB sym file and creates this symlink if necessary.