### PR TITLE
Move access table to within date partition in taildir

### DIFF
--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -31,9 +31,9 @@ modaccess:{[accesstab]};
     .lg.o[`reload;"Kept ",string[.ds.periodstokeep]," period",$[.ds.periodstokeep>1;"s";""]," of data from : ",", " sv string[t]];
     
     // update the access table on disk
-    atab:get ` sv(.ds.td;.proc.procname;`access);
+    atab:get ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
     atab,:() xkey .ds.access;
-    (` sv(.ds.td;.proc.procname;`access)) set atab;
+    (` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)) set atab;
 
     // update the access table in the gateway
     handles:(.servers.getservers[`proctype;`gateway;()!();1b;1b])[`w];
@@ -50,10 +50,10 @@ initdatastripe:{
     t:tables[`.] except .wdb.ignorelist;
 
     // load the access table; fall back to generating table if load fails
-    .ds.access: @[get;(` sv(.ds.td;.proc.procname;`access));([] table:t ; start:0Np ; end:0Np ; stptime:0Np ; keycol:`sym^.wdb.tablekeycols[t])];
+    .ds.access: @[get;(` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access));([] table:t ; start:0Np ; end:0Np ; stptime:0Np ; keycol:`sym^.wdb.tablekeycols[t])];
     modaccess[.ds.access];
     .ds.checksegid[];
-    (` sv(.ds.td;.proc.procname;`access)) set .ds.access;       
+    (` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)) set .ds.access;       
     .ds.access:select by table from .ds.access where table in t;
     };
 

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -34,7 +34,7 @@ modaccess:{[accesstab]};
     accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
     atab:get accesspath;
     atab,:() xkey .ds.access;
-    (` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)) set atab;
+    accesspath set atab;
 
     // update the access table in the gateway
     handles:(.servers.getservers[`proctype;`gateway;()!();1b;1b])[`w];

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -49,6 +49,7 @@ initdatastripe:{
     // load in variables
     .wdb.tablekeycols:.ds.loadtablekeycols[];
     t:tables[`.] except .wdb.ignorelist;
+    accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
 
     // load the access table; fall back to generating table if load fails
     default:([]table:t; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols t);

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -31,7 +31,7 @@ modaccess:{[accesstab]};
     .lg.o[`reload;"Kept ",string[.ds.periodstokeep]," period",$[.ds.periodstokeep>1;"s";""]," of data from : ",", " sv string[t]];
     
     // update the access table on disk
-    accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)
+    accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
     atab:get accesspath;
     atab,:() xkey .ds.access;
     (` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)) set atab;

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -51,7 +51,7 @@ initdatastripe:{
     t:tables[`.] except .wdb.ignorelist;
 
     // load the access table; fall back to generating table if load fails
-    default:([]table:t; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols t)
+    default:([]table:t; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols t);
     .ds.access: @[get;accesspath;default];
     modaccess[.ds.access];
     .ds.checksegid[];

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -31,7 +31,8 @@ modaccess:{[accesstab]};
     .lg.o[`reload;"Kept ",string[.ds.periodstokeep]," period",$[.ds.periodstokeep>1;"s";""]," of data from : ",", " sv string[t]];
     
     // update the access table on disk
-    atab:get ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
+    accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)
+    atab:get accesspath;
     atab,:() xkey .ds.access;
     (` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)) set atab;
 

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -51,7 +51,8 @@ initdatastripe:{
     t:tables[`.] except .wdb.ignorelist;
 
     // load the access table; fall back to generating table if load fails
-    .ds.access: @[get;(` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access));([] table:t ; start:0Np ; end:0Np ; stptime:0Np ; keycol:`sym^.wdb.tablekeycols[t])];
+    default:([]table:t; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols t)
+    .ds.access: @[get;accesspath;default];
     modaccess[.ds.access];
     .ds.checksegid[];
     (` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)) set .ds.access;       

--- a/code/wdb/datastripe.q
+++ b/code/wdb/datastripe.q
@@ -55,7 +55,7 @@ initdatastripe:{
     .ds.access: @[get;accesspath;default];
     modaccess[.ds.access];
     .ds.checksegid[];
-    (` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access)) set .ds.access;       
+    accesspath set .ds.access;       
     .ds.access:select by table from .ds.access where table in t;
     };
 


### PR DESCRIPTION
- Access table used to be in taildir/wdb
- Now I have moved it so that it is in tailer/wdb1/2022.08.04
- This means when the tailreader then loads the access table from the current partition, it will just get info on that partition rather than one access table with a start time that is the time of first launch