### PR TITLE
Stop wdb saving to wdbhdb when using TorQ Cloud

### DIFF
--- a/code/processes/wdb.q
+++ b/code/processes/wdb.q
@@ -560,8 +560,8 @@ upd:.wdb.replayupd;
 .wdb.clearwdbdata[];
 /- initialise the wdb process
 .wdb.startup[];
-/ - start the timer
-if[.wdb.saveenabled;.wdb.starttimer[]];
+/ - start the timer if datastriping off
+$[.ds.datastripe;.lg.o[`data;"datastriping on - savedown to ",(string .wdb.savedir)," disabled"];.wdb.saveenabled;.wdb.starttimer[]];
 
 /- use the regular up after log replay
 upd:.wdb.upd


### PR DESCRIPTION
Data should only be saved to tail directory when using TorQ Cloud.
This change checks if datastriping is enabled. If so, the timer that runs standard TorQ wdb savedown will not be started, data will only be saved to tail directory at end of period.