### PR TITLE
Tcs 157 eod specific to tailer

### DIFF
--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -60,7 +60,7 @@ initdatastripe:{
     // update endofperiod function
     endofperiod::.wdb.datastripeendofperiod;
     
-	//update endofday function
+    //update endofday function
     endofday::.wdb.datastripeendofday;
 	
     // load in variables

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -143,7 +143,7 @@ savetables:{[dir;tablename]
 
     /- enumerate and then split by keycol
     symdir:` sv dir,.proc.procname;
-    enumkeycol: .Q.en[symdir;eval tablename];
+    enumkeycol: .Q.en[symdir;value tablename];
     splitkeycol: {[enumkeycol;keycol;s] ?[enumkeycol;enlist (=;keycol;enlist s);0b;()]}[enumkeycol;keycol;] each partitionlist;
 
     /-upsert table to partition

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -161,7 +161,7 @@ savealltablesoverperiod:{[dir;lasttime]
     /- saves each table up to given period to their respective partitions
     savetables[dir;]each .wdb.tablelist[];
 	
-	/- delete data from last period
+    /- delete data from last period
     .ds.deletetablebefore[;`time;lasttime]each .wdb.tablelist[];
 	
     /- trigger reload of access tables and intradayDBs in all tail reader processes

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -46,7 +46,7 @@ modaccess:{[accesstab]};
     //save all tables
     .ds.savetables[.ds.td;] each .wdb.tablelist[];
     //clear tables
-    @[`.wdb;`tabsizes;0#];
+    @[`.;;0#] each .wdb.tablelist[];
     //move to next partition
     .wdb.currentpartition:pt+1;
     //create accesspath

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -68,7 +68,7 @@ initdatastripe:{
     // load in variables
     .wdb.tablekeycols:.ds.loadtablekeycols[];
     t:tables[`.] except .wdb.ignorelist;
-accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
+        accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
 
     // load the access table; fall back to generating table if load fails
     default:([]table:t; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols t);

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -68,7 +68,7 @@ initdatastripe:{
     // load in variables
     .wdb.tablekeycols:.ds.loadtablekeycols[];
     t:tables[`.] except .wdb.ignorelist;
-	accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
+accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
 
     // load the access table; fall back to generating table if load fails
     default:([]table:t; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols t);

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -26,7 +26,7 @@ modaccess:{[accesstab]};
     modaccess[.ds.access];
 
     // call the savedown function
-    .ds.savealltablesoverperiod[.ds.td;lasttime];
+    .ds.savealltables[.ds.td];
     .lg.o[`reload;"Kept ",string[.ds.periodstokeep]," period",$[.ds.periodstokeep>1;"s";""]," of data from : ",", " sv string[.wdb.tablelist[]]];
     
     // update the access table on disk
@@ -43,14 +43,12 @@ modaccess:{[accesstab]};
 
 .wdb.datastripeendofday:{[pt;processdata]
     //save all tables
-    .ds.savetables[.ds.td;] each .wdb.tablelist[];
-    //clear tables
-    @[`.;;0#] each .wdb.tablelist[];
+    .ds.savealltables[.ds.td];
     //move to next partition
     .wdb.currentpartition:pt+1;
     //create accesspath
     accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
-    //make access for next partition
+    //define access for next partition
     .ds.access:([]table:.wdb.tablelist[]; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols .wdb.tablelist[]);
     modaccess[.ds.access];
     accesspath set .ds.access;
@@ -153,13 +151,13 @@ savetables:{[dir;tablename]
     .gc.run[];
     };
 
-savealltablesoverperiod:{[dir;lasttime]
+savealltables:{[dir]
     /- function takes the tailer hdb directory handle and a timestamp
     /- saves each table up to given period to their respective partitions
     savetables[dir;]each .wdb.tablelist[];
 	
-    /- delete data from last period
-    .ds.deletetablebefore[;`time;lasttime]each .wdb.tablelist[];
+    /- delete data that has been saved
+    @[`.;;0#] each .wdb.tablelist[];
 	
     /- trigger reload of access tables and intradayDBs in all tail reader processes
     .tailer.dotailreload[`]};

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -41,9 +41,28 @@ modaccess:{[accesstab]};
 
     };
 
+.wdb.datastripeendofday:{[pt;processdata]
+    //save all tables
+    .ds.savetables[.ds.td;]; each .wdb.tablelist[];
+    //clear tables
+    @[`.wdb;`tabsizes;0#];
+    //move to next partition
+    .wdb.currentpartition:pt+1;
+    //create accesspath
+    accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
+    //make access for next partition
+    t:tables[`.] except .wdb.ignorelist;
+    .ds.access:([]table:t; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols t);
+    modaccess[.ds.access];
+    accesspath set .ds.access;
+    };
+
 initdatastripe:{
     // update endofperiod function
     endofperiod::.wdb.datastripeendofperiod;
+    
+    //update endofday function
+    endofday::.wdb.datastripeendofday;
     
     // load in variables
     .wdb.tablekeycols:.ds.loadtablekeycols[];

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -164,8 +164,6 @@ savealltablesoverperiod:{[dir;lasttime]
     /- trigger reload of access tables and intradayDBs in all tail reader processes
     .tailer.dotailreload[`]};
 
-.timer.repeat[00:00+.z.d;0W;0D00:10:00;(`.ds.savealltablesoverperiod;.ds.td;.z.p);"Saving tables"]
-
 getaccess:{[] `location`table xkey update location:.proc.procname,proctype:.proc.proctype from .ds.access};
 
 // function to update the access table in the gateway. Takes the gateway handle as argument

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -68,7 +68,7 @@ initdatastripe:{
     // load in variables
     .wdb.tablekeycols:.ds.loadtablekeycols[];
     t:tables[`.] except .wdb.ignorelist;
-        accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
+    accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);
 
     // load the access table; fall back to generating table if load fails
     default:([]table:t; start:0Np; end:0Np; stptime:0Np; keycol:`sym^.wdb.tablekeycols t);


### PR DESCRIPTION
- Changes access table so that they are now saved under each partition in taildir, instead of the top level of taildir
- Update save functions and remove unecessary nextp, allowing an eod function to use the table saving functions that the eop is using
- Created eod to save all remaining data to disk and clear mem tables along with move access into new partition and clear it in mem
- Minor refactoring of the datastripe script