### PR TITLE
Tcs 122 refinement of segid usage

### DIFF
--- a/code/processes/tailreader.q
+++ b/code/processes/tailreader.q
@@ -4,8 +4,7 @@ gmttime:@[value;`gmttime;1b];                                              /-def
 getpartition:@[value;`getpartition;                                        /-function to determine the partition value
   getpartition:{(`date^partitiontype)$(.z.D,.z.d)gmttime}];
 currentpartition:@[value;`currentpartition;getpartition[]]
-segmentid: "J"$.proc.params[`segid]
-basedir:raze (getenv`KDBTAIL),"/tailer",(string .tr.segmentid),"/"         /-define associated tailer base directory
+basedir:raze (getenv`KDBTAIL),"/tailer",(string .ds.segmentid),"/"         /-define associated tailer base directory
 taildir:`$ basedir,string currentpartition;                                /-define tailDB direction
 
 \d .

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -47,22 +47,19 @@ filtermap:{[tabs;id] if[tabs~`;tabs:.stpps.t]; ((),tabs)!.stpps.segmentfilter\:[
 
 //grabs filters from the config files and for the "ignoretable" filter converts to "" to allow segmentedsudetails to run
 segmentfilter:{[tbl;segid]
-     id:`$string segid;
-     filter:first (flip .stpps.stripeconfig[id])[tbl];
+     filter:first (flip .stpps.stripeconfig[segid])[tbl];
      $[filter~"ignoretable";filter:"";filter]
      };
 
 //subscribe to a table using segmentID to determine filtering
 subsegment:{[tbl;segid];
-//casting segid to an symbol as json is restrictive
-     id:`$string segid;
-     if[not (id in (key .stpps.stripeconfig));
+     if[not (segid in (key .stpps.stripeconfig));
        .lg.e[`sub;m:"Segment ",string[segid]," is not defined in striping.json"];:()];
      ignoredtables:`$();
      //setting the default for non-configured tables
      default:.stpps.segmentfilter[`subscriptiondefault;segid];
      if[tbl~`;:.z.s[;segid] each .stpps.t];
-     stripedtables:.stpps.t inter key flip .stpps.stripeconfig[id];
+     stripedtables:.stpps.t inter key flip .stpps.stripeconfig[segid];
      //if the defualt is "all" tables not mentioned in striping.json will be subscribed unfiltered
      if[default~"all";suballtabs: .stpps.t except stripedtables;
        if[tbl in suballtabs;
@@ -73,7 +70,7 @@ subsegment:{[tbl;segid];
      if[default~"ignore"; ignoredtables: .stpps.t except stripedtables];
      filter:.stpps.segmentfilter[tbl;segid];
      //for case when filter is "ignoretable" adds that table to ignoredtables list
-     if[(first (flip .stpps.stripeconfig[id])[tbl])~"ignoretable";ignoredtables:ignoredtables,tbl];
+     if[(first (flip .stpps.stripeconfig[segid])[tbl])~"ignoretable";ignoredtables:ignoredtables,tbl];
      if[tbl in ignoredtables;
       .lg.o[`sub;m:"Table ",string[tbl]," is to be ignored for segment ",string[segid],""];
       :()];

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -1,7 +1,5 @@
 \d .ds
 
-segmentid: "J"$.proc.params[`segid]		// segmentid variable defined by applying key to dictionary of input values
-
 td:hsym `$getenv`KDBTAIL
 
 \d .


### PR DESCRIPTION
Used in tailreader but was previously redefined. Cleaned up and removed unnecessary casting and reassignment.