### PR TITLE
Add pubclear call for stpeoperiod and stpeod

### DIFF
--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -212,23 +212,14 @@ periodrollover:{[data]
   rolllog[multilog;dldir;rolltabs;data`p];
   }
 
-// endofday function defined in SCTP
-// passes on eod messages to subscribers and rolls logs
+// common eod for STP and SCTP to send out eod messages and roll logs
 endofday:{[date;data]
   .lg.o[`endofday;"flushing remaining data to subscribers and clearing tables"];
   .stpps.pubclear[.stplg.t];
+  .lg.o[`endofday;"executing end of day for ",.Q.s1 .eodtime.d];
   .stpps.end[date;data];  // sends endofday message to subscribers
   dayrollover[data];
   }
-
-// STP runs function to send out eod messages and roll logs
-stpeod:{[date;data]
-  .lg.o[`endofday;"flushing remaining data to subscribers and clearing tables"];
-  .stpps.pubclear[.stplg.t];
-  .lg.o[`stpeod;"executing end of day for ",.Q.s1 .eodtime.d];
-  .stpps.end[date;data];                                         // sends endofday message to subscribers
-  dayrollover[data];                 
- }
 
 // common eod log rolling logic for STP and SCTP
 dayrollover:{[data]
@@ -252,7 +243,7 @@ checkends:{
   // check for endofperiod
   if[nextperiod < x1:x+.eodtime.dailyadj; stpeoperiod[.stplg`currperiod;.stplg`nextperiod;.stplg.endofdaydata[],(enlist `p)!enlist x1;not .eodtime.nextroll < x]];
   // check for endofday
-  if[.eodtime.nextroll < x;if[.eodtime.d<("d"$x)-1;system"t 0";'"more than one day?"]; stpeod[.eodtime.d;.stplg.endofdaydata[],(enlist `p)!enlist x]];
+  if[.eodtime.nextroll < x;if[.eodtime.d<("d"$x)-1;system"t 0";'"more than one day?"]; endofday[.eodtime.d;.stplg.endofdaydata[],(enlist `p)!enlist x]];
  };
 
 init:{[dbname]

--- a/code/segmentedtickerplant/stplog.q
+++ b/code/segmentedtickerplant/stplog.q
@@ -194,6 +194,8 @@ endofperiod:{[currentpd;nextpd;data]
 // stp runs function to send out end of period messages and roll logs
 // eop log roll is stopped if eod is also going to be triggered (roll is not stopped in SCTP)
 stpeoperiod:{[currentpd;nextpd;data;rolllogs]
+  .lg.o[`endofperiod;"flushing remaining data to subscribers and clearing tables"];
+  .stpps.pubclear[.stplg.t];
   .lg.o[`stpeoperiod;"passing on endofperiod message to subscribers"];
   .stpps.endp[currentpd;nextpd;data];                      // sends endofperiod message to subscribers
   currperiod::nextperiod;                                  // increments current period
@@ -221,6 +223,8 @@ endofday:{[date;data]
 
 // STP runs function to send out eod messages and roll logs
 stpeod:{[date;data]
+  .lg.o[`endofday;"flushing remaining data to subscribers and clearing tables"];
+  .stpps.pubclear[.stplg.t];
   .lg.o[`stpeod;"executing end of day for ",.Q.s1 .eodtime.d];
   .stpps.end[date;data];                                         // sends endofday message to subscribers
   dayrollover[data];                 


### PR DESCRIPTION
- Noticed that data from the very end of previous day was getting saved in the next days partition
- Added call of pubclear within stpeoperiod and stpeod to flush remaining data to subscribers before the EOP/EOD message is sent
