### PR TITLE
TCS-160: Update .gw.access to populate on start-up with both RDB and Tailer metadata.

### DIFF
--- a/config/settings/gateway.q
+++ b/config/settings/gateway.q
@@ -17,11 +17,11 @@ loadprocesscode:1b              // whether to load the process specific code def
 
 // Server connection details
 \d .servers
-CONNECTIONS:`rdb`hdb`wdb	// list of connections to make at start up
+CONNECTIONS:`rdb`hdb`tailer_seg1`tailer_seg2    // list of connections to make at start up
 RETRY:0D00:01                   // period on which to retry dead connections.  If 0, no reconnection attempts
 
 \d .aqrest
 loadexecute:0b          // Whether to reset .aqrest.execute
 
 \d .ds
-subscribers:`rdb`wdb    // list of subscribers to retrieve access tables from. Can be list of proctypes or procnames
+subscribers:`rdb`tailer_seg1`tailer_seg2    // list of subscribers to retrieve access tables from. Can be list of proctypes or procnames


### PR DESCRIPTION
- Updated `.servers.CONNECTIONS` & `.ds.subscribers` parameters in `config/settings/gateway.q` to open connections to Tailer processes, and filter for them, in addition to RDB processes.
    - Uses explicit `proctype` values for Tailer processes in process .csv.