### PR TITLE
Change rdb proctype for different segments

### DIFF
--- a/code/gateway/datastripe.q
+++ b/code/gateway/datastripe.q
@@ -1,10 +1,28 @@
 \d .ds
 
+// function to add datastripe processes to the gateway connections
+addsegprocs:{
+    // Allows config file to be overwritten in process.csv
+    stripeconf:$[not""~x:first .proc.params[`.ds.stripeconfig];x;"striping.json"];
+    scpath:first .proc.getconfigfile[stripeconf];
+	// Check for successful json read in
+    stripeconfig:@[{.j.k read1 x}; scpath;{.lg.e[`configload;"Failed to load in striping.json file: ",x]}];
+    // get relevant proctypes from the json file
+	stripeprocs:{[stripeconfig;segments]
+	    stripeconfig[segments][1]
+		};
+	relevantprocs:`$raze exec RDBtypes,tailers,tailreaders from stripeprocs[stripeconfig;] each key stripeconfig;
+	// adds all relevant processes of all segments to server table
+	.servers.register[.servers.procstab;;0b] each relevantprocs;
+	.servers.CONNECTIONS,:relevantprocs;
+	.gw.addserversfromconnectiontable[.servers.CONNECTIONS]
+	};
+    
 // create a function which will retrieve the access tables from the subscribers
 getaccess:{[]
 
     // get handle(w) for each proctype given in list given by .server.getservers
-    handles:(.servers.getservers[`proctype;;()!();1b;1b] .ds.subscribers)[`w];
+    handles:(.servers.getservers[`proctype;;()!();1b;1b] .servers.CONNECTIONS)[`w];
 
     // get data from access tables in each subscriber and append to gateway access table, with trapping to default to empty table
     .gw.access: @[value;`.gw.access;([location:() ; table:()] start:() ; end:() ; stptime:() ; keycol:() ; proctype:() ; segment:())];
@@ -19,7 +37,11 @@ updateaccess:{[newtab]
     .gw.access,: newtab;
 
     };
-
+	
+initdatastripe:{
+     addsegprocs[];
+     getaccess[];
+     }
 \d .
 
-.proc.addinitlist[(`.ds.getaccess;`)];
+.proc.addinitlist[(`.ds.initdatastripe;`)];

--- a/code/gateway/datastripe.q
+++ b/code/gateway/datastripe.q
@@ -11,7 +11,7 @@ addsegprocs:{
 	stripeprocs:{[stripeconfig;segments]
 	    stripeconfig[segments][1]
 		};
-	relevantprocs:`$raze exec RDBtypes,tailers,tailreaders from stripeprocs[stripeconfig;] each key stripeconfig;
+	relevantprocs:`$raze exec rdbtypes,tailers,tailreaders from stripeprocs[stripeconfig;] each key stripeconfig;
 	// adds all relevant processes of all segments to server table
 	.servers.register[.servers.procstab;;0b] each relevantprocs;
 	.servers.CONNECTIONS,:relevantprocs;

--- a/code/processes/tailreader.q
+++ b/code/processes/tailreader.q
@@ -32,6 +32,16 @@ reload:{
   load hsym `$.tr.basedir,"sym"
   }
 
+.ds.getaccess:{[] `location`table xkey update location:.proc.procname,proctype:.proc.proctype from .ds.access};
+
+// function to update the access table in the gateway. Takes the gateway handle as argument
+.ds.updategw:{[h]
+
+    newtab:getaccess[];
+    neg[h](`.ds.updateaccess;newtab);
+
+    };
+	
 /- checks to see if the tailDB exists and if so loads in the accestable and tailDB on tailreader startup
 $[not ()~ key hsym .tr.taildir;reload[];.lg.o[`load;"No tailDB present for this date"]];
 /- logs as INF not ERR as it is expected on first time use that there is no data to load in

--- a/code/segmentedtickerplant/datastripe.q
+++ b/code/segmentedtickerplant/datastripe.q
@@ -11,11 +11,11 @@ configload:{[scpath]
 // Checks if each subscriptiondefault is set for each segment and errors if not defined
 jsonchecks:{[]
      // check defaults are ignore or all
-     defaults:value first each .stpps.stripeconfig[;`subscriptiondefault];
+     defaults:value (first each .stpps.stripeconfig)[;`subscriptiondefault];
      errors:1+ where not defaults in\:("ignore";"all");
      if[0<count errors;.lg.o[`jsonchecks;"subscriptiondefault not defined as \"ignore\" or \"all\" for segment(s) "," " sv string[errors]]];
      // check for valid tables
-     configtables: key(flip .stpps.stripeconfig[`segid]);
+     configtables: key(first .stpps.stripeconfig[`segid]);
      stripedtables: .stpps.t inter configtables;
      wrongtables:(configtables except `subscriptiondefault) except stripedtables;
      if[0<count wrongtables;.lg.o[`jsonchecks;"Table(s) ",(" " sv string[wrongtables])," not recognised"]];
@@ -50,7 +50,7 @@ filtermap:{[tabs;id] if[tabs~`;tabs:.stpps.t]; ((),tabs)!.stpps.segmentfilter\:[
 
 //grabs filters from the config files and for the "ignoretable" filter converts to "" to allow segmentedsudetails to run
 segmentfilter:{[tbl;segid]
-     filter:first (flip .stpps.stripeconfig[segid])[tbl];
+     filter:(first .stpps.stripeconfig[segid])[tbl];
      $[filter~"ignoretable";filter:"";filter]
      };
 
@@ -62,7 +62,7 @@ subsegment:{[tbl;segid];
      //setting the default for non-configured tables
      default:.stpps.segmentfilter[`subscriptiondefault;segid];
      if[tbl~`;:.z.s[;segid] each .stpps.t];
-     stripedtables:.stpps.t inter key flip .stpps.stripeconfig[segid];
+     stripedtables:.stpps.t inter key first .stpps.stripeconfig[segid];
      //if the defualt is "all" tables not mentioned in striping.json will be subscribed unfiltered
      if[default~"all";suballtabs: .stpps.t except stripedtables;
        if[tbl in suballtabs;
@@ -73,7 +73,7 @@ subsegment:{[tbl;segid];
      if[default~"ignore"; ignoredtables: .stpps.t except stripedtables];
      filter:.stpps.segmentfilter[tbl;segid];
      //for case when filter is "ignoretable" adds that table to ignoredtables list
-     if[(first (flip .stpps.stripeconfig[segid])[tbl])~"ignoretable";ignoredtables:ignoredtables,tbl];
+     if[(first (first .stpps.stripeconfig[segid])[tbl])~"ignoretable";ignoredtables:ignoredtables,tbl];
      if[tbl in ignoredtables;
       .lg.o[`sub;m:"Table ",string[tbl]," is to be ignored for segment ",string[segid],""];
       :()];


### PR DESCRIPTION
- Changed RDB proctypes within fsp
- Function in gateway to add processes specified in JSON to list of connections
- Add getaccess function to tailreader