### PR TITLE
adding conditional to file-loading to allow for user debugging

### DIFF
--- a/torq.q
+++ b/torq.q
@@ -477,7 +477,7 @@ loadf0:{[reload;x]
   if[not[reload]&x in loadedf;.lg.o[`fileload;"already loaded ",x];:()];
   .lg.o[`fileload;"loading ",x];
   // error trapped loading of file
-  @[system;"l ",x;{.lg.e[`fileload;"failed to load ",x," : ",y]}[x]];
+  $[.z.q;@[system;"l ",x;{.lg.e[`fileload;"failed to load ",x," : ",y]}[x]];system"l ",x];
   // if we got this far, file is loaded
   loadedf,:enlist x;
   .lg.o[`fileload;"successfully loaded ",x]

--- a/torq.q
+++ b/torq.q
@@ -477,7 +477,7 @@ loadf0:{[reload;x]
   if[not[reload]&x in loadedf;.lg.o[`fileload;"already loaded ",x];:()];
   .lg.o[`fileload;"loading ",x];
   // error trapped loading of file
-  $[.z.q;@[system;"l ",x;{.lg.e[`fileload;"failed to load ",x," : ",y]}[x]];system"l ",x];
+  $[`debug in key params;system"l ",x;@[system;"l ",x;{.lg.e[`fileload;"failed to load ",x," : ",y]}[x]]];
   // if we got this far, file is loaded
   loadedf,:enlist x;
   .lg.o[`fileload;"successfully loaded ",x]


### PR DESCRIPTION
In the [torq.q script](https://github.com/AquaQAnalytics/TorQ/blob/master/torq.q), an error trap will cause an exit when attempting to debug a file if the file cannot be loaded (Line 480).  A user has reported this issue and requested a change to prevent the exit and allow for debugging.
The solution here (suggested by the user) would allow for manual debugging while also maintaining the error trap for processes which are run in quiet mode (identified by .z.q), so that they can be exited on error.