### PR TITLE
TCS-179 tailer/access table related fixes

### DIFF
--- a/code/processes/tailer.q
+++ b/code/processes/tailer.q
@@ -20,7 +20,7 @@ upd:.wdb.upd;
 .tailer.replayupd:{[f;t;d]
   /- execute the supplied function
   f[t;d];
-  // check to see if data being replayed starts before most recent EOP
+  /- check to see if data being replayed starts before most recent EOP
   if[firstt:((first t `time) < .tailer.lasteop);
     /- if datastriping is on then filter before savedown to the tailDB, if not save down to wdbhdb
     /- if the table data count reaches row threshold or if last time in table greater than EOP then flush to disk
@@ -59,7 +59,7 @@ upd:.wdb.upd;
  };
 
 .tailer.stphandle: exec w from (.servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b]);
-.tailer.lasteop:((first .tailer.stphandle)".stplg.currperiod");
+.tailer.lasteop:((first .tailer.stphandle)".stplg.currperiod");                        /- variable defined in .tailer namespace so for latest EOP the STP only needs to be called once
 upd:.tailer.replayupd;                                                                 /-start up tailer process, with appropriate upd definition
 .tailer.cleartaildir[];
 .wdb.startup[];

--- a/code/processes/tailer.q
+++ b/code/processes/tailer.q
@@ -58,8 +58,8 @@ upd:.wdb.upd;
   .lg.o[`deletewdbdata;"finished removing taildb data prior to log replay"];
  };
 
-.tailer.stphandle: exec w from (.servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b]);
-.tailer.lasteop:((first .tailer.stphandle)".stplg.currperiod");                        /- variable defined in .tailer namespace so for latest EOP the STP only needs to be called once
+.tailer.stphandle: $[count u:exec w from (.servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b]);u;.lg.e[`tailerstp;"Failed to retrieve stp handle"]];
+.tailer.lasteop:@[(first .tailer.stphandle);".stplg.currperiod";{.lg.e[`lasteop;"Failed to call last end of period with error: ",x]}];                        /- variable defined in .tailer namespace so for latest EOP the STP only needs to be called once
 upd:.tailer.replayupd;                                                                 /-start up tailer process, with appropriate upd definition
 .tailer.cleartaildir[];
 .wdb.startup[];

--- a/code/processes/tailer.q
+++ b/code/processes/tailer.q
@@ -21,10 +21,10 @@ upd:.wdb.upd;
   /- execute the supplied function
   f[t;d];
   /- check to see if data being replayed starts before most recent EOP
-  if[firstt:((first t `time) < .tailer.lasteop);
+  if[(first t `time) < .tailer.lasteop;
     /- if datastriping is on then filter before savedown to the tailDB, if not save down to wdbhdb
     /- if the table data count reaches row threshold or if last time in table greater than EOP then flush to disk
-    if[((rpc:count[value t]) > lmt:.wdb.maxrows[t]) or (lastt:(last t `time) >= .tailer.lasteop);
+    if[(count[value t] > .wdb.maxrows[t]) or (last t `time) >= .tailer.lasteop;
       .lg.o[`replayupd;"first time not after EOP therefore can flush to disk"];
       .ds.applyfilters[enlist t;.sub.filterdict];
       .ds.savetables[.ds.td;t];
@@ -58,8 +58,8 @@ upd:.wdb.upd;
   .lg.o[`deletewdbdata;"finished removing taildb data prior to log replay"];
  };
 
-.tailer.stphandle: $[count u:exec w from (.servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b]);u;.lg.e[`tailerstp;"Failed to retrieve stp handle"]];
-.tailer.lasteop:@[(first .tailer.stphandle);".stplg.currperiod";{.lg.e[`lasteop;"Failed to call last end of period with error: ",x]}];                        /- variable defined in .tailer namespace so for latest EOP the STP only needs to be called once
+.tailer.stphandle:$[count u:exec w from .servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b];u;.lg.e[`tailerstp;"Failed to retrieve stp handle"]];
+.tailer.lasteop:@[first .tailer.stphandle;".stplg.currperiod";{.lg.e[`lasteop;"Failed to call last end of period with error: ",x]}];                        /- variable defined in .tailer namespace so for latest EOP the STP only needs to be called once
 upd:.tailer.replayupd;                                                                 /-start up tailer process, with appropriate upd definition
 .tailer.cleartaildir[];
 .wdb.startup[];

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -69,6 +69,15 @@ initdatastripe:{
     .ds.checksegid[];
     accesspath set .ds.access;      
     .ds.access:select by table from .ds.access where table in .wdb.tablelist[];
+
+    // Check carried out to see if access table is up to date relative to most recent EOP
+    stphandle:(.servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b])[`w];
+    .lg.o[`handlecheck;"stphandle found"];
+    currentperiod:(first stphandle)".stplg.currperiod";
+    .lg.o[`periodcheck;"current period found"];
+    lastcall:select last end where end<>0N from .ds.access;
+    $[(exec x from lastcall)~(enlist currentperiod);.lg.o[`accessupdate;"current period matches access table"];.lg.o[`accessupdate;"access table is out of date and needs updated"]]
+    
     // Fills tailDB if any tables are missing as a result of tables containing different keycol filters and therefore saving down to only some keycol partitions
     .Q.chk[` sv .ds.td,.proc.procname,`$ string .wdb.currentpartition];
     .tailer.dotailreload[`];

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -15,9 +15,6 @@ modaccess:{[accesstab]};
 
     .lg.o[`reload;"reload command has been called remotely"];
 
-    // remove periods of data from tables
-    /lasttime:nextp-.ds.periodstokeep*(nextp-currp);
-
     // update the access table in the wdb
     // on first save down we need to replace the null valued start time in the access table
     // using the first value in the saved data
@@ -27,7 +24,6 @@ modaccess:{[accesstab]};
 
     // call the savedown function
     .ds.savealltables[.ds.td];
-    /.lg.o[`reload;"Kept ",string[.ds.periodstokeep]," period",$[.ds.periodstokeep>1;"s";""]," of data from : ",", " sv string[.wdb.tablelist[]]];
     
     // update the access table on disk
     accesspath: ` sv(.ds.td;.proc.procname;`$ string .wdb.currentpartition;`access);

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -51,11 +51,11 @@ modaccess:{[accesstab]};
     };
 
 //Function to be called on startup if access table isn't up to date (i.e tailer down during normal EOP)
-accessreplay:{[currentperiod;lastcall]
+accessreplay:{[currpd;lastaccess]
     // defines data to be used for manual EOP call
     replaydata:`proctype`procname`tables`time`p!(.proc.proctype;.proc.procname;.stpps.t;.z.P;.z.p+.eodtime.dailyadj);
-    .lg.o[`accessreplay;"doing endofperiod replay"];
-    endofperiod[(max lastcall`x);.z.p;replaydata];
+    .lg.o[`accessreplay;"doing manual endofperiod replay..."];
+    endofperiod[(first(exec x from lastaccess));.z.p;replaydata];
     .lg.o[`accessreplay;"replay was a success"];
     };
 
@@ -80,9 +80,9 @@ initdatastripe:{
     currentperiod:(first stphandle)".stplg.currperiod";
     nextperiod:(first stphandle)".stplg.nextperiod";
 
-    // Check carried out to see if access table is up to date relative to most recent EOP, if not then EOP is called manually to get the data up to date
+    // Check carried out to see if access table is up to date relative to most recent EOP, if not then EOP is called manually to get the access table data up to date
     lastcall:select last end where end<>0N from .ds.access;
-    $[first(((enlist nextperiod)>=(exec x from lastcall))&((exec x from lastcall)>=(enlist currentperiod)));.lg.o[`accessupdate;"current period matches access table"];accessreplay[currentperiod;lastcall]];
+    $[first(((enlist nextperiod)>=(exec x from lastcall))&((exec x from lastcall)>=(enlist currentperiod)));.lg.o[`accessreplay;"Most recent time on access table is up to date"];accessreplay[currentperiod;lastcall]];
 
     // Fills tailDB if any tables are missing as a result of tables containing different keycol filters and therefore saving down to only some keycol partitions
     .Q.chk[` sv .ds.td,.proc.procname,`$ string .wdb.currentpartition];

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -76,9 +76,9 @@ initdatastripe:{
     .ds.access:select by table from .ds.access where table in .wdb.tablelist[];
 
     // Variables set up for lastcall check
-    stphandle:(.servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b])[`w];
-    currentperiod:(first stphandle)".stplg.currperiod";
-    nextperiod:(first stphandle)".stplg.nextperiod";
+    stphandle:$[count u:(.servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b])[`w];u;.lg.e[`stphandle;"Failed to retrieve handle of stp"]];
+    currentperiod:@[(first stphandle);".stplg.currperiod";{.lg.e[`currentP;"Couldn't retrieve current period from stp with error:",x]}];
+    nextperiod:@[(first stphandle);".stplg.nextperiod";{.lg.e[`nextP;"Couldn't retrieve next period from stp with error:",x]}];
 
     // Check carried out to see if access table is up to date relative to most recent EOP, if not then EOP is called manually to get the access table data up to date
     lastcall:select last end where end<>0N from .ds.access;

--- a/code/tailer/datastripe.q
+++ b/code/tailer/datastripe.q
@@ -55,7 +55,7 @@ accessreplay:{[currpd;lastaccess]
     // defines data to be used for manual EOP call
     replaydata:`proctype`procname`tables`time`p!(.proc.proctype;.proc.procname;.stpps.t;.z.P;.z.p+.eodtime.dailyadj);
     .lg.o[`accessreplay;"doing manual endofperiod replay..."];
-    endofperiod[(first(exec x from lastaccess));.z.p;replaydata];
+    endofperiod[first exec x from lastaccess;.z.p;replaydata];
     .lg.o[`accessreplay;"replay was a success"];
     };
 
@@ -77,12 +77,12 @@ initdatastripe:{
 
     // Variables set up for lastcall check
     stphandle:$[count u:(.servers.getservers[`proctype;`segmentedtickerplant;()!();1b;1b])[`w];u;.lg.e[`stphandle;"Failed to retrieve handle of stp"]];
-    currentperiod:@[(first stphandle);".stplg.currperiod";{.lg.e[`currentP;"Couldn't retrieve current period from stp with error:",x]}];
-    nextperiod:@[(first stphandle);".stplg.nextperiod";{.lg.e[`nextP;"Couldn't retrieve next period from stp with error:",x]}];
+    currentperiod:@[first stphandle;".stplg.currperiod";{.lg.e[`currentP;"Couldn't retrieve current period from stp with error:",x]}];
+    nextperiod:@[first stphandle;".stplg.nextperiod";{.lg.e[`nextP;"Couldn't retrieve next period from stp with error:",x]}];
 
     // Check carried out to see if access table is up to date relative to most recent EOP, if not then EOP is called manually to get the access table data up to date
     lastcall:select last end where end<>0N from .ds.access;
-    $[first(((enlist nextperiod)>=(exec x from lastcall))&((exec x from lastcall)>=(enlist currentperiod)));.lg.o[`accessreplay;"Most recent time on access table is up to date"];accessreplay[currentperiod;lastcall]];
+    $[first ((enlist nextperiod)>=exec x from lastcall)&(exec x from lastcall)>=enlist currentperiod;.lg.o[`accessreplay;"Most recent time on access table is up to date"];accessreplay[currentperiod;lastcall]];
 
     // Fills tailDB if any tables are missing as a result of tables containing different keycol filters and therefore saving down to only some keycol partitions
     .Q.chk[` sv .ds.td,.proc.procname,`$ string .wdb.currentpartition];


### PR DESCRIPTION
PR has three fixes as addressed in Jira tickets TCS-179 and TCS-181:

- Fixed access table being defaulted by a tailer restart
- Addressed edge case issue where if tailer is down during an EOP then access table is out of sync
- Addressed issue where if tailer is restarted data was being misplaced between tailer mem and taildb due to saving down based off row count