### PR TITLE
adding conditional on .proc.try func to allow for manual debugging of initialisation function running

### DIFF
--- a/torq.q
+++ b/torq.q
@@ -640,7 +640,7 @@ if[@[value;`.servers.STARTUP;0b]; .servers.startup[]]
 // function to execute functions in .proc.initlist
 .proc.try:{[id;a]
   .lg.o[id;"attempting to run: ",.Q.s1 a];
-  success:@[{value x;1b};a;{[id;a;x].lg.e[id;x," error - failed to run: ",.Q.s1 a];0b}[id;a]];
+  success:$[`debug in key .proc.params;{value x;1b}a;@[{value x;1b};a;{[id;a;x].lg.e[id;x," error - failed to run: ",.Q.s1 a];0b}[id;a]]];
   if[not success;:()];
   .proc.initexecuted,:a;
   .lg.o[id;"run successful: ",.Q.s1 a];


### PR DESCRIPTION
Similarly to PR #543, if an error occurs in the .proc.try function (Line 641 of [torq.q](https://github.com/AquaQAnalytics/TorQ/blob/master/torq.q)) the process will exit with an error log created due to error trapping.  This change adds a conditional to detect if the process is started in debug and, if so, will allow a user to manually debug should an error occur here.  If debug mode is not utilised, the process will exit with an error log created as before.

(.proc.try is used by initialisation functions such as the `init` function in the [segmented tickerplant's process script](https://github.com/AquaQAnalytics/TorQ/blob/master/code/processes/segmentedtickerplant.q).)