### PR TITLE
Adding fix so rdb replays when datastriping turned off

### DIFF
--- a/code/common/subscriptions.q
+++ b/code/common/subscriptions.q
@@ -80,6 +80,10 @@ replay0:{[proc;tabs;realsubs;schemalist;logfilelist;filters]
     //run replay and filtering of logs
     {[logfile;filters;logmetatab] .[.ds.filterreplayed;(logfile;filters;logmetatab);{.lg.e[`subscribe;"could not replay the log file: ", x]}]}[;filters;logmetatab] each logfilelist; 
   ];
+  // replays like the function above but when vanilla TorQ is enabled (datastriping turned off)
+  if[not .ds.datastripe;
+    {[lf] .lg.o[`vanillasubscribe;"replaying log file ",.Q.s1 lf]; -11!lf} each logfilelist;
+    ]
   // reset the upd function back to original upd
   @[`.;`upd;:;origupd];
   .lg.o[`subscribe;"finished log file replay"];


### PR DESCRIPTION
Small change to subscriptions.q to ensure the RDB always replays when in vanilla Torq