### PR TITLE
Fix port retrieval in torq.sh summary

### DIFF
--- a/torq.sh
+++ b/torq.sh
@@ -55,7 +55,7 @@ parameter() {
 
 findproc() {
   procno=$(awk '/,'$1',/{print NR}' "$CSVPATH")                                                     # get line number for file
-  pgrep -f "\-stackid ${KDBBASEPORT} \-proctype $(getfield "$procno" proctype) \-procname $1"       # get pid of process
+  pgrep -f "\-stackid ${KDBBASEPORT} \-proctype $(getfield "$procno" proctype) \-procname $1 "      # get pid of process
  }
 
 startline() {
@@ -132,7 +132,7 @@ summary() {
         printf "%s | %s | down |" "$(date '+%H:%M:%S')" "$1"                                        # summary table row for down process
     else
         pid=$((findproc "$1")|awk 'END{print}')
-        port=$(echo $(netstat -nlp 2>/dev/null | grep -w "$pid" | awk '{ print $4 }' | awk -F: '{ print $2 }'))  # get port process is running on
+        port=$(echo $(netstat -nlp 2>/dev/null | grep " $pid/" | awk '{ print $4 }' | awk -F: '{ print $2 }'))  # get port process is running on
         printf "%s | %s | up | %s | %s" "$(date '+%H:%M:%S')" "$1" "$pid" "$port"                   # summary table row for running process
     fi
   fi


### PR DESCRIPTION
This PR fixes two bugs in retrieving the ports for summary in torq.sh:

* Multiple processes that begin the same can collide e.g. `rdb1` & `rdb11`, when we grep for `rdb1` we can match either - if we match wrong one, we display wrong PID & port in summary
* When getting port, we grep for PID, but this could also match the listening port of another process & we can end up with multiple ports being displayed

# Colliding names

Before change, rdb11 details displayed for rdb1:

```
(base) jmcmurray@homer ~/deploy/TorQ $ ./torq.sh summary
TIME      |  PROCESS       |  STATUS  |  PID    |  PORT
10:45:25  |  discovery1    |  up      |  8879   |  11201
10:45:25  |  tickerplant1  |  up      |  9054   |  11200
10:45:25  |  rdb1          |  up      |  12121  |  11204
10:45:26  |  rdb10         |  up      |  12014  |  11203  12014
10:45:26  |  rdb11         |  up      |  12121  |  11204
```

Change is just to add a space after process name when grepping to prevent collisions. After:

```
(base) jmcmurray@homer ~/deploy/TorQ $ ./torq.sh summary
TIME      |  PROCESS       |  STATUS  |  PID    |  PORT
10:45:36  |  discovery1    |  up      |  8879   |  11201
10:45:36  |  tickerplant1  |  up      |  9054   |  11200
10:45:37  |  rdb1          |  up      |  9259   |  11202
10:45:37  |  rdb10         |  up      |  12014  |  11203  12014
10:45:37  |  rdb11         |  up      |  12121  |  11204
```

# Multiple ports

Before, displaying multiple ports for rdb10:

```
(base) jmcmurray@homer ~/deploy/TorQ $ ./torq.sh summary
TIME      |  PROCESS       |  STATUS  |  PID    |  PORT
10:48:03  |  discovery1    |  up      |  8879   |  11201
10:48:03  |  tickerplant1  |  up      |  9054   |  11200
10:48:03  |  rdb1          |  up      |  9259   |  11202
10:48:04  |  rdb10         |  up      |  12014  |  11203  12014
10:48:04  |  rdb11         |  up      |  12121  |  11204
```

Reason is that grepping netstat can find processing listening on port that matches PID:

```
(base) jmcmurray@homer ~/deploy/TorQ $ netstat -nlp 2>/dev/null | grep -w 12014
459:tcp        0      0 0.0.0.0:11203           0.0.0.0:*               LISTEN      12014/q
770:tcp        0      0 0.0.0.0:12014           0.0.0.0:*               LISTEN      -
2025:unix  2      [ ACC ]     STREAM     LISTENING     1240913805 -                    @/tmp/kx.12014
2027:unix  2      [ ACC ]     STREAM     LISTENING     4094038095 12014/q              @/tmp/kx.11203
```

PID in netstat output will always be preceeded by space & followed by /, so can include those in the grep:

```
(base) jmcmurray@homer ~/deploy/TorQ $ netstat -nlp 2>/dev/null | grep " 12014/"
458:tcp        0      0 0.0.0.0:11203           0.0.0.0:*               LISTEN      12014/q
2026:unix  2      [ ACC ]     STREAM     LISTENING     4094038095 12014/q              @/tmp/kx.11203
```

After making change:

```
(base) jmcmurray@homer ~/deploy/TorQ $ ./torq.sh summary
TIME      |  PROCESS       |  STATUS  |  PID    |  PORT
10:48:36  |  discovery1    |  up      |  8879   |  11201
10:48:36  |  tickerplant1  |  up      |  9054   |  11200
10:48:37  |  rdb1          |  up      |  9259   |  11202
10:48:37  |  rdb10         |  up      |  12014  |  11203
10:48:37  |  rdb11         |  up      |  12121  |  11204
```