### PR TITLE
hdb attribute retrieval bug fix/adding ignorelist to hdb

### DIFF
--- a/code/hdb/hdbstandard.q
+++ b/code/hdb/hdbstandard.q
@@ -20,7 +20,7 @@ reload:{
 				enlist each(?),/:(enlist each(=;-0W),/:mtcols),'(enlist(+;-1;($;ets;`.z.d))),/:enlist each($;ets:enlist`timestamp),/:mtcols:enlist each max,/:tcols];
 		dict[dcols]:`date$dict dcols;
 		enlist[`timecolumns]!enlist dict
-		}each t:tables[`.];
+		}each t:tables[`.] except .hdb.ignorelist;
 	/ update date attribute for .gw.partdict and .gw.attributesrouting
 	default[`date]:asc default[`date]union first[d]+til 1+(-) . d:exec(max;min)@\:distinct`date$raze[value each timecolumns][;1]from timecolumns;
 	default[`dataaccess]:`segid`tablename!(.ds.segmentid 0;t!select instrumentsfilter:{""}'[i],timecolumns from timecolumns);

--- a/config/settings/hdb.q
+++ b/config/settings/hdb.q
@@ -1,4 +1,6 @@
 // Bespoke HDB config
+\d .hdb
+ignorelist:`packets             // list of tables to ignore retrieving attributes from to send to gateways
 
 \d .proc
 loadprocesscode:1b              // whether to load the process specific code defined at ${KDBCODE}/{process type}


### PR DESCRIPTION
A bug was found preventing the `.proc.getattributes` function from running in the hdb as intended, believed due to the absence of the `packets` table on disk.  To remedy this we've added an `ignorelist` variable defined in the config/settings/hdb.q file to create a list of tables which we don't want to retrieve attributes from.  This list is config driven and therefore can be altered by users to suit their requirement.