### PR TITLE
#561 Added 'err signal to exit out of infinite if loop during unit test

### DIFF
--- a/code/handlers/trackservers.q
+++ b/code/handlers/trackservers.q
@@ -349,6 +349,7 @@ startupdepcyclestypename:{[requiredprocs;typeornamefunc;timeintv;cycles]
     if[n>cycles;
       b:((),requiredprocs)except(),exec proctype from .servers.SERVERS where .dotz.liveh w;
       .lg.e[`connectionreport;string[.proc.procname]," cannot connect to ",","sv string'[b]];                           //after "cycles" times output error and exit process.
+      'err;                                                                                                             //signal to error out if running after initialisation
      ];
     .os.sleep[timeintv];
     n+:1;


### PR DESCRIPTION
Added one line at line 352 to trackservers.q to error signal out of the loop during unit testing.
Confirmed that it worked using a unit test and checked that syms were ticking as usual.