### PR TITLE
Make DQE/DQC use .servers.CONNECTIONS from config if present

### DIFF
--- a/code/processes/dqc.q
+++ b/code/processes/dqc.q
@@ -7,7 +7,7 @@ detailcsv:@[value;`.dqe.detailcsv;first .proc.getconfigfile["dqedetail.csv"]];  
 utctime:@[value;`utctime;1b];                                                   // define whether the process is on UTC time or not
 partitiontype:@[value;`partitiontype;`date];                                    // set type of partition (defaults to `date)
 writedownperiod:@[value;`writedownperiod;0D01:00:00];                           // dqc periodically writes down to dqcdb, writedownperiod determines the period between writedowns
-.servers.CONNECTIONS:`tickerplant`rdb`hdb`dqe`dqedb`dqcdb                       // set to only the processes it needs
+.servers.CONNECTIONS:distinct .servers.CONNECTIONS,`tickerplant`rdb`hdb`dqe`dqedb`dqcdb   // set to only the processes it needs
 getpartition:@[value;`getpartition;                                             // determines the partition value
   {{@[value;`.dqe.currentpartition;
     (`date^partitiontype)$(.z.D,.z.d).dqe.utctime]}}];

--- a/code/processes/dqe.q
+++ b/code/processes/dqe.q
@@ -122,7 +122,7 @@ writedownadvanced:{
 .dqe.currentpartition:.dqe.getpartition[];  /- initialize current partition
 
 
-.servers.CONNECTIONS:`tickerplant`rdb`hdb`dqedb`dqcdb /- open connections to required procs, need dqedb as some checks rely on info from both dqe and dqedb
+.servers.CONNECTIONS:distinct .servers.CONNECTIONS,`tickerplant`rdb`hdb`dqedb`dqcdb /- open connections to required procs, need dqedb as some checks rely on info from both dqe and dqedb
 
 /- setting up .u.end for dqe
 .u.end:{[pt]


### PR DESCRIPTION
Currently, .servers.CONNECTIONS is hardcoded in DQE & DQC. This means that adding checks for different processes requires editing the main scripts for these processes. This change ensures that existing connections are always opened, while also using any additional proctypes set in config.