### PR TITLE
Updated .Q.lim to give the key-values for just limit values

### DIFF
--- a/config/settings/default.q
+++ b/config/settings/default.q
@@ -59,7 +59,7 @@ enabled:0b			// prevent write access to clients if enabled
 \d .servers
 enabled:1b																	// whether server tracking is enabled
 CONNECTIONS:()																// list of connections to make at start up
-DISCOVERYCONNECT:$[`lim in key`.Q;$[0W=.Q.lim[][`conns];1b;0b];1b]          // check for limit on process connections (relevant for KDB-X community edition)
+DISCOVERYCONNECT:$[`lim in key`.Q;$[0W=.Q.lim[][`conns][`lim];1b;0b];1b]          // check for limit on process connections (relevant for KDB-X community edition)
 DISCOVERYREGISTER:DISCOVERYCONNECT											// whether to register with the discovery service
 CONNECTIONSFROMDISCOVERY:DISCOVERYREGISTER									// whether to get connection details from the discovery service (as opposed to the static file).
 TRACKNONTORQPROCESS:1b          											// whether to track and register non torQ processes

--- a/config/settings/segmentedchainedtickerplant.q
+++ b/config/settings/segmentedchainedtickerplant.q
@@ -37,4 +37,4 @@ enabled:1b                                        // switch on subscribercutoff
 
 \d .servers
 CONNECTIONS,:`segmentedtickerplant
-CONNECTIONSFROMDISCOVERY:$[`lim in key`.Q;$[0W=.Q.lim[][`conns];1b;0b];1b] // check for limit on process connections (relevant for KDB-X community edition)
+CONNECTIONSFROMDISCOVERY:$[`lim in key`.Q;$[0W=.Q.lim[][`conns][`lim];1b;0b];1b] // check for limit on process connections (relevant for KDB-X community edition)


### PR DESCRIPTION
**Issue**
In the latest KDB-X release, KDB-X 5.0.20260410, `.Q.lim[]` returns a dictionary with the current and limit values - this will cause a type error.

**Suggested Fix**
Change check for limit on process connections
```$[`lim in key`.Q;$[0W=.Q.lim[][`conns][`lim];1b;0b];1b] ```