### PR TITLE
Fix .Q.lim[] dict access for KDB-X Community edition connection limit…

### DIFF
--- a/config/settings/default.q
+++ b/config/settings/default.q
@@ -59,7 +59,7 @@ enabled:0b			// prevent write access to clients if enabled
 \d .servers
 enabled:1b																	// whether server tracking is enabled
 CONNECTIONS:()																// list of connections to make at start up
-DISCOVERYCONNECT:$[`lim in key`.Q;$[0W=.Q.lim[][`conns];1b;0b];1b]          // check for limit on process connections (relevant for KDB-X community edition)
+DISCOVERYCONNECT:$[`lim in key`.Q;@[{$[0W=x[`conns][`lim];1b;0b]};.Q.lim[];1b];1b]  // check for limit on process connections (relevant for KDB-X community edition; error-trapped for Community edition where .Q.lim[] may not return expected dict)
 DISCOVERYREGISTER:DISCOVERYCONNECT											// whether to register with the discovery service
 CONNECTIONSFROMDISCOVERY:DISCOVERYREGISTER									// whether to get connection details from the discovery service (as opposed to the static file).
 TRACKNONTORQPROCESS:1b          											// whether to track and register non torQ processes

--- a/config/settings/segmentedchainedtickerplant.q
+++ b/config/settings/segmentedchainedtickerplant.q
@@ -37,4 +37,4 @@ enabled:1b                                        // switch on subscribercutoff
 
 \d .servers
 CONNECTIONS,:`segmentedtickerplant
-CONNECTIONSFROMDISCOVERY:$[`lim in key`.Q;$[0W=.Q.lim[][`conns];1b;0b];1b] // check for limit on process connections (relevant for KDB-X community edition)
+CONNECTIONSFROMDISCOVERY:$[`lim in key`.Q;@[{$[0W=x[`conns];1b;0b]};.Q.lim[];1b];1b] // check for limit on process connections (relevant for KDB-X community edition; error-trapped for Community edition where .Q.lim[] may not return expected dict)


### PR DESCRIPTION


.Q.lim[] returns a dict `cur`lim!N N in KDB-X, not a scalar. The condition `0W=.Q.lim[][`conns]` compared 0W against the whole dict, which always evaluates false causing discovery to be enabled even under connection limits.

q).Q.lim[]
       | cur lim  
-----  | ---------
cores  | 10  0W   
threads| 0   4    
mem    | 64  16384
conns  | 1   8  

q).Q.lim[][`conns][`lim]
8
q)0W=.Q.lim[][`conns][`lim]
0b

Fix: use `x[`conns][`lim]` to extract the scalar limit value so the
comparison works correctly. With lim=8: `0W=8` → 0b → discovery disabled.

Affects:
- config/settings/default.q (DISCOVERYCONNECT)
- config/settings/segmentedchainedtickerplant.q (CONNECTIONSFROMDISCOVERY)