### PR TITLE
Fix for kdb-x community issue with lim

### DIFF
--- a/config/settings/segmentedchainedtickerplant.q
+++ b/config/settings/segmentedchainedtickerplant.q
@@ -37,4 +37,4 @@ enabled:1b                                        // switch on subscribercutoff
 
 \d .servers
 CONNECTIONS,:`segmentedtickerplant
-CONNECTIONSFROMDISCOVERY:$[`lim in key`.Q;@[{$[0W=x[`conns];1b;0b]};.Q.lim[];1b];1b] // check for limit on process connections (relevant for KDB-X community edition; error-trapped for Community edition where .Q.lim[] may not return expected dict)
+CONNECTIONSFROMDISCOVERY:$[`lim in key`.Q;@[{$[0W=x[`conns][`lim];1b;0b]};.Q.lim[];1b];1b] // check for limit on process connections (relevant for KDB-X community edition; error-trapped for Community edition where .Q.lim[] may not return expected dict)


### PR DESCRIPTION
.Q.lim[] returns a different dictionary in KDB-X community edition than the full edition.

KDB-X:
q).Q.lim[]
cores | 0W
threads| 0W
mem | 0W
conns | 0W

KDB-X Community:
q).Q.lim[]
| cur lim
----- | ---------
cores | 14 0W
threads| 0 4
mem | 64 16384
conns | 0 16

Update to previous MR that missed `lim and therefore always set variable to 1b with error trapping. 